### PR TITLE
fix: admin users API'sinde password hash sızıntısını engelle

### DIFF
--- a/src/features/admin/server/user.ts
+++ b/src/features/admin/server/user.ts
@@ -17,9 +17,25 @@ export type UserWithProfile = {
 
 // ------------------------------------
 // Tüm kullanıcıları getir
+// NOT: Explicit select kullanılır — password hash gibi hassas alanlar
+// hiçbir zaman API response'una sızmamalı (include tüm scalar alanları döndürürdü).
 export async function getAllUsers(): Promise<UserWithProfile[]> {
   return prisma.user.findMany({
-    include: { studentProfile: true },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      lastName: true,
+      role: true,
+      studentProfile: {
+        select: {
+          id: true,
+          experienceLevel: true,
+          interests: true,
+          mentorId: true,
+        },
+      },
+    },
     orderBy: { createdAt: "desc" },
   });
 }
@@ -36,9 +52,11 @@ export async function getMentors(): Promise<{id: string; name: string | null; la
 // ------------------------------------
 // Kullanıcı rolünü güncelle
 export async function updateUserRole(userId: string, role: "ADMIN" | "MENTOR" | "STUDENT") {
+  // Güvenli response shape — password hash döndürülmez.
   return prisma.user.update({
     where: { id: userId },
     data: { role },
+    select: { id: true, email: true, name: true, lastName: true, role: true },
   });
 }
 


### PR DESCRIPTION
## Summary
`getAllUsers()` Prisma user kaydını `select` olmadan döndürüyordu → `password` hash dahil tüm scalar alanlar `GET /api/admin/users` response'una sızabiliyordu. `updateUserRole()` da güncellenen user'ı password ile döndürüyordu. Bu PR her ikisine de explicit `select` ekler.

## Changes
- `src/features/admin/server/user.ts`
  - `getAllUsers()` → explicit `select`: `id, email, name, lastName, role` + `studentProfile { id, experienceLevel, interests, mentorId }`. Password asla seçilmiyor.
  - `updateUserRole()` → güvenli `select` (password yok).

## Test
- `getAllUsers()` gerçek DB'ye karşı çalıştırıldı: Prisma'nın ürettiği SQL `password` kolonunu **hiç çekmiyor**; dönen alanlar yalnızca `id, email, name, lastName, role, studentProfile`. ✅
- 8 kullanıcının hiçbirinde `password` alanı yok.
- `npm run lint` 0 error · `npm run build` ✓

## Reviewer Notes
- Admin paneli UI'ı yalnızca `id, email, name, lastName, role, studentProfile.{id,mentorId}` kullanıyor; select bunları kapsıyor, işlevde kayıp yok.
- `select` allowlist mantığıyla çalıştığı için ileride şemaya hassas alan eklense bile otomatik dışarıda kalır.

Closes #41
