### PR TITLE
feat: stajyer hesap onay durumu (PENDING/APPROVED/REJECTED)

### DIFF
--- a/prisma/migrations/20260614061742_add_account_status/migration.sql
+++ b/prisma/migrations/20260614061742_add_account_status/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "AccountStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "accountStatus" "AccountStatus" NOT NULL DEFAULT 'APPROVED';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,7 @@ model User {
   password      String
   phone         String?
   role          Role      @default(STUDENT)
+  accountStatus AccountStatus @default(APPROVED)
   emailVerified DateTime?
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt
@@ -173,6 +174,14 @@ enum Role {
   ADMIN
   MENTOR
   STUDENT
+}
+
+// Stajyer hesap onay durumu. Yeni signup'lar PENDING; admin APPROVED/REJECTED yapar.
+// DB default APPROVED → mevcut kullanıcılar ve admin/mentor migration sonrası kilitlenmez.
+enum AccountStatus {
+  PENDING
+  APPROVED
+  REJECTED
 }
 
 enum AssignmentStatus {

--- a/src/app/(auth)/signup/actions.ts
+++ b/src/app/(auth)/signup/actions.ts
@@ -64,6 +64,8 @@ export async function signupAction(
         password: hashedPassword,
         phone: parsed.data.phone ?? null,
         role: "STUDENT",
+        // Yeni stajyer hesabı admin onayına kadar PENDING — aktif değildir.
+        accountStatus: "PENDING",
       },
     })
   } catch (err) {

--- a/src/app/(student)/student-dashboard/page.tsx
+++ b/src/app/(student)/student-dashboard/page.tsx
@@ -17,6 +17,37 @@ export default async function StudentDashboardPage() {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) return <p>Oturum açmanız gerekiyor.</p>;
 
+  // #38: Onaylanmamış stajyer (PENDING/REJECTED) panele erişemez.
+  // (#39 bu bloğu tam ekran pending/rejected tasarımlarıyla değiştirecek.)
+  const accountStatus = session.user.accountStatus;
+  if (accountStatus && accountStatus !== "APPROVED") {
+    const rejected = accountStatus === "REJECTED";
+    return (
+      <div className="min-h-[80vh] flex flex-col items-center justify-center p-6 text-center relative">
+        <div className="absolute top-4 right-4">
+          <LogoutButton />
+        </div>
+        <div className="bg-white border border-slate-200 shadow-sm rounded-2xl p-10 max-w-lg w-full space-y-4">
+          <div
+            className={`w-16 h-16 rounded-full flex items-center justify-center mx-auto ${
+              rejected ? "bg-red-50" : "bg-amber-50"
+            }`}
+          >
+            <Clock className={`w-8 h-8 ${rejected ? "text-red-600" : "text-amber-600"}`} />
+          </div>
+          <h1 className="text-2xl font-bold text-slate-900">
+            {rejected ? "Başvurunuz reddedildi" : "Hesabınız onay bekliyor"}
+          </h1>
+          <p className="text-slate-600 leading-relaxed">
+            {rejected
+              ? "Hesabınız bir yönetici tarafından reddedildi. Sorunuz varsa lütfen ekiple iletişime geçin."
+              : "Kaydınız alındı. Bir yönetici hesabınızı onayladıktan sonra panele erişebilirsiniz."}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   const profile = await prisma.studentProfile.findUnique({
     where: { userId: session.user.id },
     include: {

--- a/src/lib/auth/guard.ts
+++ b/src/lib/auth/guard.ts
@@ -35,6 +35,22 @@ export async function requireAuth(requiredRole?: Role | Role[]) {
     }
   }
 
+  // Onaylanmamış stajyer hesabı (PENDING/REJECTED) hiçbir student işlemi yapamaz.
+  // Admin/mentor bu kontrolden etkilenmez (yalnızca STUDENT rolüne uygulanır).
+  if (
+    session.user.role === "STUDENT" &&
+    session.user.accountStatus &&
+    session.user.accountStatus !== "APPROVED"
+  ) {
+    return {
+      authorized: false as const,
+      response: NextResponse.json(
+        { error: "Hesabınız henüz onaylanmadı." },
+        { status: 403 }
+      ),
+    };
+  }
+
   return {
     authorized: true as const,
     session,

--- a/src/lib/auth/nextauth.ts
+++ b/src/lib/auth/nextauth.ts
@@ -114,6 +114,7 @@ callbacks: {
         token.id = user.id
         token.email = user.email
         token.role = user.role
+        token.accountStatus = (user as { accountStatus?: string }).accountStatus
       }
       return token
     },
@@ -127,7 +128,7 @@ callbacks: {
         id: token.id as string | undefined,
         email: token.email?? "",
         role: typeof token.role === "string" ? token.role : undefined,
-        
+        accountStatus: typeof token.accountStatus === "string" ? token.accountStatus : undefined,
       }
       return session
     },

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -12,6 +12,7 @@ declare module "next-auth" {
       name?: string
       email?: string
       role?: string
+      accountStatus?: string
     }
   }
 
@@ -19,10 +20,12 @@ declare module "next-auth" {
     id?: string
     sessionToken?: string
     role?: string
+    accountStatus?: string
   }
 
   interface User {
     id?: string
     role?: string
+    accountStatus?: string
   }
 }


### PR DESCRIPTION
## Summary
Yeni kayıt olan stajyerler şu ana kadar doğrudan aktif `STUDENT` olarak oluşuyordu. Bu PR, hesap onay durumu kavramını ekler: yeni stajyer **PENDING** oluşur ve admin onaylayana kadar (APPROVED) platforma erişemez; reddedilen (REJECTED) hesap da işlem yapamaz.

## Changes
- **Schema + migration:** `AccountStatus` enum (PENDING/APPROVED/REJECTED) + `User.accountStatus`. DB default **APPROVED** → mevcut kullanıcılar ve admin/mentor migration sonrası kilitlenmez.
- **Signup:** yeni stajyer `accountStatus: PENDING` ile oluşturulur.
- **Session:** `accountStatus` JWT token + session'a taşınır (`types/next-auth.d.ts` augmentasyonu).
- **API gate (`requireAuth`):** onaylanmamış `STUDENT` tüm student API'lerinde `403` alır. Admin/mentor etkilenmez.
- **Dashboard gate:** onaylanmamış stajyere panel yerine durum mesajı gösterilir.

## Out of Scope (sonraki issue'lar)
- Tam ekran pending/rejected tasarımları → #39
- Admin onay/red kontrolleri (UI + endpoint) → #40

## Test
- `npm run lint` 0 error · `npm run build` ✓ (migration uygulandı, Prisma client üretildi)
- Migration SQL: `accountStatus ... NOT NULL DEFAULT 'APPROVED'` → mevcut satırlar APPROVED (lockout yok)
- Manuel doğrulama adımları (reviewer için): yeni signup → giriş → "onay bekliyor" ekranı; mevcut seed öğrencisi → panele erişebiliyor.

## Reviewer Notes
- Default'u APPROVED seçtim ki migration mevcut/admin/mentor hesaplarını kilitlemesin; "yeni stajyer PENDING" davranışı signup'ta explicit set ile sağlanıyor.
- Enforcement iki katmanlı: API (requireAuth 403) + dashboard sayfası. #39 bunu tam ekran UX'e taşıyacak.

Closes #38
