### PR TITLE
feat: admin stajyer onay/red kontrolleri

### DIFF
--- a/src/app/(admin)/admin-dashboard/page.tsx
+++ b/src/app/(admin)/admin-dashboard/page.tsx
@@ -13,7 +13,11 @@ import {
   Loader2,
   FolderKanban,
   MessageSquare,
+  CheckCircle2,
+  XCircle,
+  Clock,
 } from "lucide-react";
+import { toast } from "sonner";
 import LogoutButton from "@/components/LogoutButton";
 import { UnreadBadge } from "@/features/messaging/ui/UnreadBadge";
 
@@ -23,6 +27,7 @@ type User = {
   name: string | null;
   lastName: string | null;
   role: "ADMIN" | "MENTOR" | "STUDENT";
+  accountStatus: "PENDING" | "APPROVED" | "REJECTED";
   studentProfile?: {
     id: string;
     mentorId?: string | null;
@@ -40,6 +45,12 @@ const roleConfig: Record<User["role"], { label: string; color: string }> = {
   ADMIN: { label: "Yönetici", color: "bg-purple-50 text-purple-700 border-purple-200" },
   MENTOR: { label: "Mentor", color: "bg-blue-50 text-blue-700 border-blue-200" },
   STUDENT: { label: "Öğrenci", color: "bg-emerald-50 text-emerald-700 border-emerald-200" },
+};
+
+const statusConfig: Record<User["accountStatus"], { label: string; color: string }> = {
+  PENDING: { label: "Onay Bekliyor", color: "bg-amber-50 text-amber-700 border-amber-200" },
+  APPROVED: { label: "Onaylı", color: "bg-emerald-50 text-emerald-700 border-emerald-200" },
+  REJECTED: { label: "Reddedildi", color: "bg-red-50 text-red-700 border-red-200" },
 };
 
 export default function AdminDashboard() {
@@ -121,6 +132,38 @@ export default function AdminDashboard() {
     }
   }
 
+  async function handleAccountStatus(userId: string, accountStatus: User["accountStatus"]) {
+    setUpdating(userId);
+    try {
+      const response = await fetch("/api/admin/users/approval", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId, accountStatus }),
+      });
+      if (response.ok) {
+        setUsers((prev) =>
+          prev.map((u) => (u.id === userId ? { ...u, accountStatus } : u)),
+        );
+        toast.success(
+          accountStatus === "APPROVED"
+            ? "Stajyer onaylandı."
+            : accountStatus === "REJECTED"
+              ? "Stajyer reddedildi."
+              : "Durum güncellendi.",
+        );
+      } else {
+        const data = await response.json().catch(() => null);
+        const msg =
+          data && typeof data.error === "string" ? data.error : "Durum güncellenemedi.";
+        toast.error(msg);
+      }
+    } catch {
+      toast.error("Bağlantı hatası. Lütfen tekrar deneyin.");
+    } finally {
+      setUpdating(null);
+    }
+  }
+
   const filteredUsers = useMemo(() => {
     const q = search.trim().toLowerCase();
     return users.filter((u) => {
@@ -142,7 +185,10 @@ export default function AdminDashboard() {
     const studentsWithoutMentor = users.filter(
       (u) => u.role === "STUDENT" && u.studentProfile && !u.studentProfile.mentorId,
     ).length;
-    return { total, studentCount, mentorCount, adminCount, studentsWithProfile, studentsWithoutMentor };
+    const pendingCount = users.filter(
+      (u) => u.role === "STUDENT" && u.accountStatus === "PENDING",
+    ).length;
+    return { total, studentCount, mentorCount, adminCount, studentsWithProfile, studentsWithoutMentor, pendingCount };
   }, [users]);
 
   const getDisplayName = (u: { name: string | null; lastName: string | null; email: string }) => {
@@ -219,6 +265,21 @@ export default function AdminDashboard() {
           ))}
         </div>
 
+        {/* Onay bekleyen stajyerler */}
+        {stats.pendingCount > 0 && (
+          <div className="mb-6 flex items-start gap-3 rounded-2xl bg-blue-50 border border-blue-200 px-5 py-4">
+            <Clock className="w-5 h-5 text-blue-600 mt-0.5 shrink-0" />
+            <div className="text-sm">
+              <p className="font-semibold text-blue-900">
+                {stats.pendingCount} stajyer onay bekliyor
+              </p>
+              <p className="text-blue-700 mt-0.5">
+                Aşağıdaki listeden onay bekleyen stajyerleri onaylayabilir veya reddedebilirsin.
+              </p>
+            </div>
+          </div>
+        )}
+
         {/* Uyarı banner — mentor atanmamış öğrenciler */}
         {stats.studentsWithoutMentor > 0 && (
           <div className="mb-6 flex items-start gap-3 rounded-2xl bg-amber-50 border border-amber-200 px-5 py-4">
@@ -282,7 +343,7 @@ export default function AdminDashboard() {
               <div className="hidden md:grid grid-cols-12 gap-4 px-6 py-3 bg-slate-50/60 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
                 <div className="col-span-4">Kullanıcı</div>
                 <div className="col-span-3">Rol</div>
-                <div className="col-span-5">Mentor Ataması</div>
+                <div className="col-span-5">Onay / Mentor</div>
               </div>
 
               {filteredUsers.map((user) => {
@@ -303,6 +364,13 @@ export default function AdminDashboard() {
                           {getDisplayName(user)}
                         </p>
                         <p className="text-xs text-slate-500 truncate">{user.email}</p>
+                        {user.role === "STUDENT" && (
+                          <span
+                            className={`mt-1 inline-flex w-fit items-center px-1.5 py-0.5 text-[10px] font-semibold rounded border ${statusConfig[user.accountStatus].color}`}
+                          >
+                            {statusConfig[user.accountStatus].label}
+                          </span>
+                        )}
                       </div>
                       <span
                         className={`md:hidden shrink-0 px-2 py-1 text-[10px] font-semibold rounded-lg border ${role.color}`}
@@ -328,10 +396,30 @@ export default function AdminDashboard() {
                       {isUpdating && <Loader2 className="animate-spin w-3.5 h-3.5 text-blue-600" />}
                     </div>
 
-                    {/* Mentor Atama */}
+                    {/* Onay / Mentor Atama */}
                     <div className="md:col-span-5 flex items-center">
                       {user.role === "STUDENT" ? (
-                        user.studentProfile ? (
+                        user.accountStatus !== "APPROVED" ? (
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <button
+                              onClick={() => handleAccountStatus(user.id, "APPROVED")}
+                              disabled={isUpdating}
+                              className="inline-flex items-center gap-1.5 px-3 py-2 rounded-xl bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-semibold transition-colors disabled:opacity-60"
+                            >
+                              <CheckCircle2 className="w-3.5 h-3.5" /> Onayla
+                            </button>
+                            {user.accountStatus === "PENDING" && (
+                              <button
+                                onClick={() => handleAccountStatus(user.id, "REJECTED")}
+                                disabled={isUpdating}
+                                className="inline-flex items-center gap-1.5 px-3 py-2 rounded-xl bg-red-50 hover:bg-red-100 text-red-700 text-xs font-semibold transition-colors disabled:opacity-60"
+                              >
+                                <XCircle className="w-3.5 h-3.5" /> Reddet
+                              </button>
+                            )}
+                            {isUpdating && <Loader2 className="animate-spin w-3.5 h-3.5 text-blue-600" />}
+                          </div>
+                        ) : user.studentProfile ? (
                           <div className="flex items-center gap-2 w-full">
                             <select
                               value={user.studentProfile.mentorId || ""}

--- a/src/app/api/admin/users/approval/route.ts
+++ b/src/app/api/admin/users/approval/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { updateAccountStatus } from "@/features/admin/server/user";
+import { requireAuth } from "@/lib/auth/guard";
+import { updateAccountStatusSchema } from "@/lib/validations/api";
+
+/**
+ * POST /api/admin/users/approval
+ * Admin: bir stajyer hesabını APPROVED / REJECTED / PENDING yapar.
+ * Body: { userId: string, accountStatus: "PENDING" | "APPROVED" | "REJECTED" }
+ */
+export async function POST(req: Request) {
+  const auth = await requireAuth("ADMIN");
+  if (!auth.authorized) return auth.response;
+
+  const body = await req.json();
+  const parsed = updateAccountStatusSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten().fieldErrors },
+      { status: 400 }
+    );
+  }
+
+  // Admin kendi hesabının durumunu değiştiremez (yanlışlıkla kendini pasifleştirmesin)
+  if (parsed.data.userId === auth.session.user.id) {
+    return NextResponse.json(
+      { error: "Kendi hesabınızın durumunu değiştiremezsiniz." },
+      { status: 403 }
+    );
+  }
+
+  const updated = await updateAccountStatus(parsed.data.userId, parsed.data.accountStatus);
+  return NextResponse.json(updated);
+}

--- a/src/features/admin/server/user.ts
+++ b/src/features/admin/server/user.ts
@@ -7,6 +7,7 @@ export type UserWithProfile = {
   name: string | null;
   lastName: string | null;
   role: "ADMIN" | "MENTOR" | "STUDENT";
+  accountStatus: "PENDING" | "APPROVED" | "REJECTED";
   studentProfile?: {
     id: string;
     experienceLevel?: string | null;
@@ -27,6 +28,7 @@ export async function getAllUsers(): Promise<UserWithProfile[]> {
       name: true,
       lastName: true,
       role: true,
+      accountStatus: true,
       studentProfile: {
         select: {
           id: true,
@@ -57,6 +59,19 @@ export async function updateUserRole(userId: string, role: "ADMIN" | "MENTOR" | 
     where: { id: userId },
     data: { role },
     select: { id: true, email: true, name: true, lastName: true, role: true },
+  });
+}
+
+// ------------------------------------
+// Stajyer hesap onay durumunu güncelle (approve/reject)
+export async function updateAccountStatus(
+  userId: string,
+  accountStatus: "PENDING" | "APPROVED" | "REJECTED",
+) {
+  return prisma.user.update({
+    where: { id: userId },
+    data: { accountStatus },
+    select: { id: true, email: true, name: true, lastName: true, role: true, accountStatus: true },
   });
 }
 

--- a/src/lib/validations/api.ts
+++ b/src/lib/validations/api.ts
@@ -14,6 +14,14 @@ export const assignMentorSchema = z.object({
   mentorId: z.string().nullable(),
 });
 
+// Admin: Stajyer hesap onay durumu güncelleme (approve/reject)
+export const updateAccountStatusSchema = z.object({
+  userId: z.string().min(1, "Kullanıcı ID gerekli"),
+  accountStatus: z.enum(["PENDING", "APPROVED", "REJECTED"], {
+    error: "Geçersiz durum. PENDING, APPROVED veya REJECTED olmalı.",
+  }),
+});
+
 // Admin: Proje şablonu oluşturma
 export const createTemplateSchema = z.object({
   title: z.string().min(1, "Başlık gerekli"),


### PR DESCRIPTION
## Summary
Admin panelinde kayıt olan stajyerleri onaylama/reddetme akışı ekler. Admin pending stajyerleri ayırt edebilir, approve/reject yapabilir ve sonucu UI'da net görür. #38 ile gelen `accountStatus` üzerine kurulur.

## Changes
- **API:** `POST /api/admin/users/approval` — admin-only; `accountStatus`'u günceller. Admin **kendi hesabının** durumunu değiştiremez (403).
- **Backend:** `updateAccountStatus()` + `updateAccountStatusSchema` (Zod). `getAllUsers` select'ine `accountStatus` eklendi (password hâlâ dışarıda).
- **UI (admin panel):** durum badge'i (Onay Bekliyor / Onaylı / Reddedildi), "X stajyer onay bekliyor" banner'ı, **Onayla / Reddet** butonları (onaylanmamış stajyerde mentor select yerine), sonner toast ile başarı/hata geri bildirimi.

## Acceptance Criteria
- [x] Admin pending kullanıcıları ayırt edebilir (badge + banner)
- [x] Admin kullanıcıyı approved yapabilir
- [x] Admin kullanıcıyı rejected yapabilir
- [x] Admin kendi hesabını pasifleştiremez (endpoint 403)
- [x] API yalnızca admin rolüyle kullanılabilir (`requireAuth("ADMIN")`)

## Test
- `npm run build` ✓ (29/29) · lint temiz
- Data-layer (gerçek DB): `getAllUsers` → accountStatus döner, **password dönmez**; `updateAccountStatus(REJECTED)` çalışır, password dönmez, geri APPROVED'a alındı ✓
- Manuel (reviewer): admin panel → pending stajyerde Onayla/Reddet → badge ve buton durumu güncellenir, toast çıkar.

## Reviewer Notes
- `getAllUsers` select'ine `accountStatus` eklenmesi #41 (PR #64) ile çakışmadı; #41 merge sonrası develop tabanından temiz uygulandı.
- Onaylanmamış stajyerin mentor ataması gizli (önce onay, sonra mentor mantığı).

Closes #40
