### PR TITLE
fix: rol/hesap durumu değişikliğini aktif session'a yansıt

### DIFF
--- a/src/lib/auth/nextauth.ts
+++ b/src/lib/auth/nextauth.ts
@@ -111,10 +111,36 @@ export const authOptions : AuthOptions = {
 callbacks: {
     async jwt({ token, user }) {
       if (user) {
+        // İlk giriş — bilgileri token'a yaz
         token.id = user.id
         token.email = user.email
         token.role = user.role
         token.accountStatus = (user as { accountStatus?: string }).accountStatus
+        return token
+      }
+
+      // #44: Sonraki isteklerde rol + hesap durumunu DB'den tazele.
+      // Admin bir kullanıcının rolünü düşürürse (veya hesabını reddederse),
+      // değişiklik aktif session'a bir sonraki istekte yansır — stale role
+      // ile korumalı API kullanma penceresi kapanır.
+      // Not: JWT yapısına uygun en basit çözüm; getServerSession başına 1 sorgu.
+      if (token.id) {
+        try {
+          const dbUser = await prisma.user.findUnique({
+            where: { id: token.id as string },
+            select: { role: true, accountStatus: true },
+          })
+          if (dbUser) {
+            token.role = dbUser.role
+            token.accountStatus = dbUser.accountStatus
+          } else {
+            // Kullanıcı silinmiş → yetkiyi kaldır
+            token.role = undefined
+            token.accountStatus = undefined
+          }
+        } catch {
+          // DB geçici hatası → mevcut token değerlerini koru (oturumu bozma)
+        }
       }
       return token
     },


### PR DESCRIPTION
## Summary
Kullanıcı rolü admin tarafından değiştirildiğinde, mevcut JWT'deki eski rol token süresince geçerli kalıyordu → yetkisi düşürülen kullanıcı eski yetkilerini kullanmaya devam edebiliyordu. Bu PR, JWT yapısına uygun en basit çözümü uygular: `jwt` callback ilk giriş sonrası her istekte rol + `accountStatus`'u DB'den tazeler.

## Changes
- `src/lib/auth/nextauth.ts` — `jwt` callback:
  - İlk giriş: bilgileri token'a yazar (önceki davranış, ekstra sorgu yok).
  - Sonraki istekler: `role` + `accountStatus` DB'den yeniden okunur → değişiklik bir sonraki istekte aktif session'a yansır.
  - DB hatasında mevcut token korunur (oturum bozulmaz); kullanıcı silinmişse yetki kaldırılır.

## Test (uçtan uca, gerçek DB + oturum)
- Test STUDENT oluşturuldu → giriş → oturum rolü `STUDENT`.
- Baseline: student cookie ile `GET /api/admin/users` → **403** ✓
- DB'de rol `ADMIN` yapıldı (admin değişikliği simülasyonu).
- **Aynı cookie** ile `GET /api/admin/users` → **200** ✓ + `/api/auth/session` rolü `ADMIN` (token tazelendi).
- Test kullanıcı silindi (cleanup).
- `npm run lint` 0 error · `npm run build` ✓

## Reviewer Notes
- Güvenlik sınırı API guard'ı (`requireAuth` → `getServerSession` → `jwt` callback) tazelenmiş rolü kullanır. Bu, accountStatus değişikliklerinin (approve/reject) de aktif session'a yansımasını sağlar (bonus).
- Maliyet: `getServerSession` başına 1 ek hafif sorgu (`select: role, accountStatus`). Küçük uygulama için kabul edilebilir; issue "en basit çözüm" tradeoff'unu onaylıyor.

Closes #44
