### PR TITLE
fix: stajyer taslak roadmap adımlarında yorum/dosya etkileşimini engelle

### DIFF
--- a/src/app/api/steps/[stepId]/comments/route.ts
+++ b/src/app/api/steps/[stepId]/comments/route.ts
@@ -87,6 +87,16 @@ export async function POST(
       );
     }
 
+    // #52: Öğrenci yalnızca PUBLISHED roadmap adımına yorum ekleyebilir.
+    // Mentor, taslağı (DRAFT) düzenleme/inceleme için yorum yapabilir.
+    const isStudent = step.roadmap.assignedProject.studentProfile.userId === userId;
+    if (isStudent && step.roadmap.status !== "PUBLISHED") {
+      return NextResponse.json(
+        { error: "Bu yol haritası henüz yayınlanmadı. Yayınlandığında etkileşim kurabilirsiniz." },
+        { status: 403 }
+      );
+    }
+
     const body = await req.json();
     const parsed = createStepCommentSchema.safeParse(body);
     if (!parsed.success) {

--- a/src/app/api/steps/[stepId]/files/route.ts
+++ b/src/app/api/steps/[stepId]/files/route.ts
@@ -122,6 +122,16 @@ export async function POST(
       );
     }
 
+    // #52: Öğrenci yalnızca PUBLISHED roadmap adımına dosya yükleyebilir.
+    // Mentor, taslağı (DRAFT) inceleme/düzenleme için yükleyebilir.
+    const isStudent = step.roadmap.assignedProject.studentProfile.userId === userId;
+    if (isStudent && step.roadmap.status !== "PUBLISHED") {
+      return NextResponse.json(
+        { error: "Bu yol haritası henüz yayınlanmadı. Yayınlandığında etkileşim kurabilirsiniz." },
+        { status: 403 }
+      );
+    }
+
     // Bu adıma ait dosya sayısını kontrol et (max 10)
     const fileCount = await prisma.stepFile.count({ where: { stepId } });
     if (fileCount >= 10) {

--- a/src/features/files/ui/StepFiles.tsx
+++ b/src/features/files/ui/StepFiles.tsx
@@ -34,9 +34,12 @@ type Props = {
   stepId: string;
   currentUserId: string;
   currentUserRole: string;
+  isDraft?: boolean;
 };
 
-export function StepFiles({ stepId, currentUserId, currentUserRole }: Props) {
+export function StepFiles({ stepId, currentUserId, currentUserRole, isDraft }: Props) {
+  // #52: Taslak roadmap'te öğrenci dosya yükleyemez (mentor inceleme için yükleyebilir).
+  const interactionLocked = isDraft && currentUserRole === "STUDENT";
   const [files, setFiles] = useState<StepFile[]>([]);
   const [loading, setLoading] = useState(false);
   const [uploading, setUploading] = useState(false);
@@ -178,46 +181,52 @@ export function StepFiles({ stepId, currentUserId, currentUserRole }: Props) {
       {/* Dosya Paneli */}
       {isOpen && (
         <div className="mt-3 space-y-3 animate-in fade-in slide-in-from-top-1 duration-200">
-          {/* Upload Alanı */}
-          <div
-            className={`relative border-2 border-dashed rounded-lg p-4 text-center transition-colors cursor-pointer
-              ${dragOver
-                ? "border-blue-400 bg-blue-50"
-                : "border-slate-200 hover:border-slate-300 bg-slate-50/50"
-              }
-              ${uploading ? "pointer-events-none opacity-60" : ""}`}
-            onDragOver={(e) => {
-              e.preventDefault();
-              setDragOver(true);
-            }}
-            onDragLeave={() => setDragOver(false)}
-            onDrop={onDrop}
-            onClick={() => fileInputRef.current?.click()}
-          >
-            <input
-              ref={fileInputRef}
-              type="file"
-              className="hidden"
-              onChange={onFileChange}
-              accept=".png,.jpg,.jpeg,.gif,.webp,.pdf,.txt,.md,.csv,.json,.zip,.js,.ts,.tsx,.jsx,.css,.py,.java,.go,.rs,.c,.cpp,.h,.sql"
-            />
-            {uploading ? (
-              <div className="flex items-center justify-center gap-2 py-1">
-                <Loader2 className="w-4 h-4 animate-spin text-blue-500" />
-                <span className="text-xs text-slate-500">Yükleniyor...</span>
-              </div>
-            ) : (
-              <div className="flex flex-col items-center gap-1 py-1">
-                <Upload className="w-5 h-5 text-slate-400" />
-                <span className="text-xs text-slate-500">
-                  Dosyayı sürükleyin veya tıklayıp seçin
-                </span>
-                <span className="text-[10px] text-slate-400">
-                  Maks. 10 MB &middot; Resim, PDF, Kod, ZIP
-                </span>
-              </div>
-            )}
-          </div>
+          {/* Upload Alanı — taslak roadmap'te öğrenci yükleyemez (#52) */}
+          {interactionLocked ? (
+            <p className="text-[11px] text-slate-400 text-center border-2 border-dashed border-slate-200 rounded-lg p-4">
+              Bu yol haritası taslak aşamasında. Mentörünüz yayınladığında dosya yükleyebilirsiniz.
+            </p>
+          ) : (
+            <div
+              className={`relative border-2 border-dashed rounded-lg p-4 text-center transition-colors cursor-pointer
+                ${dragOver
+                  ? "border-blue-400 bg-blue-50"
+                  : "border-slate-200 hover:border-slate-300 bg-slate-50/50"
+                }
+                ${uploading ? "pointer-events-none opacity-60" : ""}`}
+              onDragOver={(e) => {
+                e.preventDefault();
+                setDragOver(true);
+              }}
+              onDragLeave={() => setDragOver(false)}
+              onDrop={onDrop}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <input
+                ref={fileInputRef}
+                type="file"
+                className="hidden"
+                onChange={onFileChange}
+                accept=".png,.jpg,.jpeg,.gif,.webp,.pdf,.txt,.md,.csv,.json,.zip,.js,.ts,.tsx,.jsx,.css,.py,.java,.go,.rs,.c,.cpp,.h,.sql"
+              />
+              {uploading ? (
+                <div className="flex items-center justify-center gap-2 py-1">
+                  <Loader2 className="w-4 h-4 animate-spin text-blue-500" />
+                  <span className="text-xs text-slate-500">Yükleniyor...</span>
+                </div>
+              ) : (
+                <div className="flex flex-col items-center gap-1 py-1">
+                  <Upload className="w-5 h-5 text-slate-400" />
+                  <span className="text-xs text-slate-500">
+                    Dosyayı sürükleyin veya tıklayıp seçin
+                  </span>
+                  <span className="text-[10px] text-slate-400">
+                    Maks. 10 MB &middot; Resim, PDF, Kod, ZIP
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Hata Mesajı */}
           {error && (

--- a/src/features/messaging/ui/StepComments.tsx
+++ b/src/features/messaging/ui/StepComments.tsx
@@ -22,9 +22,12 @@ type Props = {
   stepId: string;
   currentUserId: string;
   currentUserRole: string;
+  isDraft?: boolean;
 };
 
-export function StepComments({ stepId, currentUserId, currentUserRole }: Props) {
+export function StepComments({ stepId, currentUserId, currentUserRole, isDraft }: Props) {
+  // #52: Taslak roadmap'te öğrenci yorum ekleyemez (mentor inceleme için ekleyebilir).
+  const interactionLocked = isDraft && currentUserRole === "STUDENT";
   const [comments, setComments] = useState<Comment[]>([]);
   const [newComment, setNewComment] = useState("");
   const [loading, setLoading] = useState(false);
@@ -253,29 +256,35 @@ export function StepComments({ stepId, currentUserId, currentUserRole }: Props) 
             </div>
           )}
 
-          {/* Yorum Gönder */}
-          <form onSubmit={handleSend} className="flex gap-2 items-end pt-2 border-t border-slate-200">
-            <textarea
-              ref={inputRef}
-              value={newComment}
-              onChange={(e) => setNewComment(e.target.value)}
-              placeholder="Yorumunuzu yazın..."
-              maxLength={1000}
-              rows={2}
-              className="flex-1 text-xs px-3 py-2 bg-white border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
-            />
-            <button
-              type="submit"
-              disabled={!newComment.trim() || sending}
-              className="w-8 h-8 flex items-center justify-center bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors disabled:opacity-50"
-            >
-              {sending ? (
-                <Loader2 className="w-3.5 h-3.5 animate-spin" />
-              ) : (
-                <Send className="w-3.5 h-3.5" />
-              )}
-            </button>
-          </form>
+          {/* Yorum Gönder — taslak roadmap'te öğrenci etkileşim kuramaz (#52) */}
+          {interactionLocked ? (
+            <p className="text-[11px] text-slate-400 text-center pt-2 border-t border-slate-200">
+              Bu yol haritası taslak aşamasında. Mentörünüz yayınladığında yorum ekleyebilirsiniz.
+            </p>
+          ) : (
+            <form onSubmit={handleSend} className="flex gap-2 items-end pt-2 border-t border-slate-200">
+              <textarea
+                ref={inputRef}
+                value={newComment}
+                onChange={(e) => setNewComment(e.target.value)}
+                placeholder="Yorumunuzu yazın..."
+                maxLength={1000}
+                rows={2}
+                className="flex-1 text-xs px-3 py-2 bg-white border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+              />
+              <button
+                type="submit"
+                disabled={!newComment.trim() || sending}
+                className="w-8 h-8 flex items-center justify-center bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors disabled:opacity-50"
+              >
+                {sending ? (
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                ) : (
+                  <Send className="w-3.5 h-3.5" />
+                )}
+              </button>
+            </form>
+          )}
         </div>
       )}
     </div>

--- a/src/features/student/ui/RoadmapSteps.tsx
+++ b/src/features/student/ui/RoadmapSteps.tsx
@@ -212,6 +212,7 @@ export function RoadmapSteps({ steps, isDraft, currentUserId, currentUserRole }:
                     stepId={step.id}
                     currentUserId={currentUserId}
                     currentUserRole={currentUserRole}
+                    isDraft={isDraft}
                   />
                 )}
 
@@ -221,6 +222,7 @@ export function RoadmapSteps({ steps, isDraft, currentUserId, currentUserRole }:
                     stepId={step.id}
                     currentUserId={currentUserId}
                     currentUserRole={currentUserRole}
+                    isDraft={isDraft}
                   />
                 )}
               </div>


### PR DESCRIPTION
## Summary
Öğrenci UI'da DRAFT roadmap için progress butonları kapalıydı, fakat yorum/dosya API'leri roadmap status kontrolü yapmadığından öğrenci taslak adımlarda yorum ekleyip dosya yükleyebiliyordu. Bu PR hem API hem UI tarafında taslak etkileşimini öğrenci için engeller; mentörün taslağı inceleme/düzenleme yetkisi korunur.

## Changes
- **API (`/api/steps/[stepId]/comments` POST, `/api/steps/[stepId]/files` POST):** İstek sahibi roadmap'in öğrencisiyse ve roadmap `PUBLISHED` değilse `403`. `getStepWithAccess` zaten roadmap'i getiriyordu; ekstra sorgu yok.
- **UI (`StepComments`, `StepFiles`):** `isDraft` prop'u eklendi; öğrenci + taslak durumunda yorum/dosya **girişi** yerine bilgilendirme notu gösterilir. Mevcut yorum/dosyalar görüntülenebilir. `RoadmapSteps` `isDraft`'ı iletir.

## Acceptance Criteria
- [x] Öğrenci draft roadmap step'ine yorum ekleyemez (API 403 + UI kapalı)
- [x] Öğrenci draft roadmap step'ine dosya yükleyemez (API 403 + UI kapalı)
- [x] Published roadmap için mevcut yorum/dosya akışı çalışır
- [x] Mentor yetkili olduğu roadmap'i (taslak dahil) incelemeye devam edebilir

## Test
- `npm run lint` 0 error · `npm run build` ✓
- Mantık: `isStudent = roadmap.assignedProject.studentProfile.userId === userId`; `isStudent && status !== "PUBLISHED" → 403`. Mentor (mentorId === userId) etkilenmez.
- Manuel (reviewer): mentor taslak roadmap oluştursun → öğrenci o adımda yorum/dosya alanı yerine "yayınlanınca..." notu görür; mentor roadmap'i PUBLISHED yapınca öğrenci yorum/dosya ekleyebilir.

## Reviewer Notes
- Güvenlik sınırı API'de; UI gating yalnızca UX. Mentor draft'ta etkileşim kurabilir (preview/düzenleme korunur).

Closes #52
