### PR TITLE
feat: Posilog'u yönlendirici (guidance-only) yap

### DIFF
--- a/src/app/api/student/ai-chat/route.ts
+++ b/src/app/api/student/ai-chat/route.ts
@@ -9,21 +9,23 @@ const limiter = createRateLimiter("ai-chat", {
   windowSeconds: 60,
 });
 
-const SYSTEM_PROMPT = `Sen AISigner platformundaki bir yapay zeka eğitim asistanısın. Adın "Posilog"dur.
+const SYSTEM_PROMPT = `Sen AISigner platformundaki bir yapay zeka öğrenme rehberisin. Adın "Posilog"dur.
+
+Rolün REHBERLİK etmek — öğrencinin YERİNE işi YAPMAMAK. Amacın, öğrencinin kendi başına ilerlemeyi öğrenmesidir.
 
 Görevin:
-- Öğrencilere yazılım geliştirme, programlama ve teknoloji konularında yardımcı olmak
-- Proje adımlarında takıldıkları noktaları açıklamak
-- Kavramları basit ve anlaşılır bir dille Türkçe açıklamak
-- Kod örnekleri ile desteklemek
-- Motivasyon vermek ve öğrenme sürecini desteklemek
+- Öğrenciyi yönlendir: nereden başlayacağını, hangi roadmap adımına / issue'ya odaklanacağını, nasıl plan yapacağını ve nasıl branch açıp ilerleyeceğini anlat.
+- Takıldığı noktada problemi küçük adımlara böl, doğru soruları sormasına yardım et, ilgili kavramı veya kaynağı işaret et.
+- Gerektiğinde KISA, açıklayıcı kod parçacıkları (snippet) ver — ama tam çözümü/ödevi baştan sona yazma.
+- Motivasyon ver, öğrenme sürecini destekle.
 
 Kurallar:
-- Türkçe yanıt ver (teknik terimler hariç)
-- Kısa ve öz ol, gereksiz uzatma
-- Konu dışı sorularda kibar bir şekilde yönlendir
-- Asla zararlı, yanıltıcı veya uygunsuz içerik üretme
-- Öğrencinin seviyesine uygun açıklamalar yap`;
+- Öğrencinin yerine tam çözüm, komple dosya veya uzun hazır kod ÜRETME. Bunun yerine yaklaşımı, adımları ve ipuçlarını ver.
+- Öğrenci "kodu sen yaz / ödevi çöz" derse kibarca yönlendir: "Hadi birlikte adım adım ilerleyelim" de ve ilk adımı sor.
+- Mümkünse öğrencinin aktif projesi, roadmap adımı ve hedeflerini kullanarak somut yönlendir.
+- Türkçe yanıt ver (teknik terimler hariç), kısa ve öz ol.
+- Konu dışı sorularda kibarca öğrenme hedefine yönlendir.
+- Asla zararlı, yanıltıcı veya uygunsuz içerik üretme.`;
 
 /**
  * POST /api/student/ai-chat
@@ -141,7 +143,7 @@ export async function POST(req: Request) {
           role: "model",
           parts: [
             {
-              text: "Anladım! Ben Posilog. Yazılım ve teknoloji konularında sorularınıza yardımcı olmaya hazırım. Nasıl yardımcı olabilirim?",
+              text: "Selam! Ben Posilog 👋 Senin yerine ödevini yapmam ama nereden başlayacağını, hangi adıma odaklanacağını ve nasıl ilerleyeceğini birlikte planlarız. Hangi konuda takıldın?",
             },
           ],
         },
@@ -151,14 +153,15 @@ export async function POST(req: Request) {
 
     const result = await chat.sendMessage(message.trim());
     const response = result.response;
-    const text = response.candidates?.[0]?.content?.parts?.[0]?.text || "Üzgünüm, bir cevap üretemiyorum. Lütfen tekrar deneyin.";
+    const text = response.candidates?.[0]?.content?.parts?.[0]?.text || "Bunu tam çözemedim. Sorunu biraz daha somutlaştırır mısın — hangi adımda, tam olarak nerede takıldın?";
 
     return NextResponse.json({ reply: text });
   } catch (error) {
     console.error("POST /api/student/ai-chat error:", error);
-    return NextResponse.json(
-      { error: "AI yanıt üretirken hata oluştu. Lütfen tekrar deneyin." },
-      { status: 500 }
-    );
+    // #51: AI servisine ulaşılamazsa hata ekranı yerine dostça bir rehber fallback döndür.
+    return NextResponse.json({
+      reply:
+        "Şu an sana bağlanırken bir aksaklık oldu 🙏 Bu sırada şöyle ilerleyebilirsin: roadmap'inde şu anki adıma odaklan, takıldığın yeri küçük parçalara böl ve adımdaki kaynakları incele. Birazdan tekrar yazarsan kaldığımız yerden devam ederiz.",
+    });
   }
 }


### PR DESCRIPTION
## Summary
Posilog chatbot genel eğitim asistanı gibi davranıp öğrencinin yerine iş yapabiliyordu. Ürün tanımına göre Posilog **rehberlik** etmeli: nereden başlanacağını, hangi roadmap adımına/issue'ya odaklanılacağını, nasıl branch açılıp plan yapılacağını anlatmalı; komple çözüm üretmemeli.

## Changes
- `src/app/api/student/ai-chat/route.ts`
  - **SYSTEM_PROMPT** guidance-only olarak yeniden yazıldı: öğrencinin yerine tam çözüm / uzun hazır kod üretmez; yaklaşımı, adımları ve kısa snippet'lerle yönlendirir. "Kodu sen yaz" denince kibarca adım adım ilerlemeye yönlendirir. Aktif proje/roadmap/hedef bağlamını kullanır.
  - Intro mesajı guidance tonuna güncellendi.
  - **AI servis hatasında** artık `500` yerine kullanıcı dostu **rehber fallback** mesajı döner (chat'te hata yerine yol gösteren bir yanıt görünür).

## Acceptance Criteria
- [x] Prompt açıkça öğrencinin yerine işi yapmamayı söyler
- [x] Posilog plan, başlangıç noktası ve adım/issue yönlendirmesi verir
- [x] Uzun hazır çözüm/kod yerine öğrenmeyi destekleyen cevap verir
- [x] AI servis hatasında kullanıcı dostu fallback mesajı döner

## Test
- `npm run lint` 0 error · `npm run build` ✓
- Mevcut bağlam (profil + aktif proje + roadmap adımları) zaten prompt'a ekleniyordu; korundu.
- Manuel (reviewer): öğrenci olarak Posilog'a "tüm kodu sen yaz / ödevimi çöz" deyince → komple çözüm dökmek yerine adım adım yönlendirir.

## Reviewer Notes
- Prompt-injection korumaları (history filtreleme, uzunluk limitleri) ve graceful degradation (AI hata → mock/fallback) korundu.

Closes #51
