### PR TITLE
feat: detaylı AI profil analizini admin ve mentor'a göster

### DIFF
--- a/prisma/migrations/20260702233306_add_profile_analysis/migration.sql
+++ b/prisma/migrations/20260702233306_add_profile_analysis/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "ProfileAnalysis" (
+    "id" TEXT NOT NULL,
+    "studentProfileId" TEXT NOT NULL,
+    "level" TEXT NOT NULL,
+    "summary" VARCHAR(2000) NOT NULL,
+    "strengths" TEXT[],
+    "developmentAreas" TEXT[],
+    "technicalTracks" TEXT[],
+    "recommendedPath" VARCHAR(2000) NOT NULL,
+    "recommendations" TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProfileAnalysis_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProfileAnalysis_studentProfileId_key" ON "ProfileAnalysis"("studentProfileId");
+
+-- AddForeignKey
+ALTER TABLE "ProfileAnalysis" ADD CONSTRAINT "ProfileAnalysis_studentProfileId_fkey" FOREIGN KEY ("studentProfileId") REFERENCES "StudentProfile"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,6 +56,7 @@ model StudentProfile {
   mentor           User?             @relation("StudentProfile_mentorIdToUser", fields: [mentorId], references: [id])
   assignedProjects AssignedProject[]
   surveyAnswers    SurveyAnswer[]
+  profileAnalysis  ProfileAnalysis?
 }
 
 model ProjectTemplate {
@@ -186,6 +187,24 @@ model SurveyQuestion {
   updatedAt DateTime @updatedAt
 
   answers SurveyAnswer[]
+}
+
+// #47: AI profil analizinin kalıcı sonucu — öğrenci profiliyle 1-1.
+// Profil tamamlandığında/güncellendiğinde üretilip upsert edilir (tek satır).
+model ProfileAnalysis {
+  id               String   @id @default(cuid())
+  studentProfileId String   @unique
+  level            String
+  summary          String   @db.VarChar(2000)
+  strengths        String[]
+  developmentAreas String[]
+  technicalTracks  String[]
+  recommendedPath  String   @db.VarChar(2000)
+  recommendations  String[]
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  studentProfile StudentProfile @relation(fields: [studentProfileId], references: [id], onDelete: Cascade)
 }
 
 // #45: Öğrencinin bir ankete verdiği cevap — profile ile ilişkili.

--- a/src/app/(admin)/admin-dashboard/page.tsx
+++ b/src/app/(admin)/admin-dashboard/page.tsx
@@ -16,10 +16,13 @@ import {
   CheckCircle2,
   XCircle,
   Clock,
+  Sparkles,
+  X,
 } from "lucide-react";
 import { toast } from "sonner";
 import LogoutButton from "@/components/LogoutButton";
 import { UnreadBadge } from "@/features/messaging/ui/UnreadBadge";
+import { ProfileAnalysisCard, type ProfileAnalysisData } from "@/features/ai/ui/ProfileAnalysisCard";
 
 type User = {
   id: string;
@@ -60,6 +63,39 @@ export default function AdminDashboard() {
   const [updating, setUpdating] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [roleFilter, setRoleFilter] = useState<"ALL" | User["role"]>("ALL");
+
+  // #48: Analiz modal'ı — hangi öğrenci için açık, veri/loading/error durumu (lazy fetch).
+  const [analysisModalUser, setAnalysisModalUser] = useState<User | null>(null);
+  const [analysisData, setAnalysisData] = useState<ProfileAnalysisData | null>(null);
+  const [analysisLoading, setAnalysisLoading] = useState(false);
+  const [analysisError, setAnalysisError] = useState<string | null>(null);
+
+  async function openAnalysisModal(user: User) {
+    setAnalysisModalUser(user);
+    setAnalysisData(null);
+    setAnalysisError(null);
+    setAnalysisLoading(true);
+    try {
+      const res = await fetch(`/api/admin/students/${user.id}/profile-analysis`);
+      if (res.ok) {
+        const data = await res.json();
+        setAnalysisData(data.analysis);
+      } else {
+        const data = await res.json().catch(() => null);
+        setAnalysisError(
+          (data && typeof data.error === "string" && data.error) || "Analiz yüklenemedi.",
+        );
+      }
+    } catch {
+      setAnalysisError("Bağlantı hatası. Lütfen tekrar deneyin.");
+    } finally {
+      setAnalysisLoading(false);
+    }
+  }
+
+  function closeAnalysisModal() {
+    setAnalysisModalUser(null);
+  }
 
   useEffect(() => {
     async function loadData() {
@@ -373,11 +409,21 @@ export default function AdminDashboard() {
                         </p>
                         <p className="text-xs text-slate-500 truncate">{user.email}</p>
                         {user.role === "STUDENT" && (
-                          <span
-                            className={`mt-1 inline-flex w-fit items-center px-1.5 py-0.5 text-[10px] font-semibold rounded border ${statusConfig[user.accountStatus].color}`}
-                          >
-                            {statusConfig[user.accountStatus].label}
-                          </span>
+                          <div className="flex items-center gap-1.5 mt-1 flex-wrap">
+                            <span
+                              className={`inline-flex w-fit items-center px-1.5 py-0.5 text-[10px] font-semibold rounded border ${statusConfig[user.accountStatus].color}`}
+                            >
+                              {statusConfig[user.accountStatus].label}
+                            </span>
+                            {user.studentProfile && (
+                              <button
+                                onClick={() => openAnalysisModal(user)}
+                                className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px] font-semibold rounded border bg-indigo-50 text-indigo-700 border-indigo-200 hover:bg-indigo-100 transition-colors"
+                              >
+                                <Sparkles className="w-2.5 h-2.5" /> Analizi Gör
+                              </button>
+                            )}
+                          </div>
                         )}
                       </div>
                       <span
@@ -461,6 +507,35 @@ export default function AdminDashboard() {
           )}
         </div>
       </div>
+
+      {/* #48: Admin — Detaylı AI Profil Analizi Modal'ı (lazy fetch) */}
+      {analysisModalUser && (
+        <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-2xl shadow-xl max-w-2xl w-full max-h-[85vh] overflow-y-auto">
+            <div className="flex items-center justify-between px-6 py-4 border-b border-slate-100 sticky top-0 bg-white rounded-t-2xl">
+              <div>
+                <h2 className="text-lg font-semibold text-slate-900">AI Profil Analizi</h2>
+                <p className="text-sm text-slate-500">
+                  {getDisplayName(analysisModalUser)} ({analysisModalUser.email})
+                </p>
+              </div>
+              <button
+                onClick={closeAnalysisModal}
+                className="p-2 rounded-lg hover:bg-slate-100 text-slate-500 transition-colors"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            <div className="p-6">
+              <ProfileAnalysisCard
+                analysis={analysisData}
+                loading={analysisLoading}
+                error={analysisError}
+              />
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/(mentor)/mentor-dashboard/[studentId]/page.tsx
+++ b/src/app/(mentor)/mentor-dashboard/[studentId]/page.tsx
@@ -6,6 +6,7 @@ import { ArrowLeft, User, Calendar, Target, Clock, BookOpen, Plus, CheckCircle, 
 import Link from "next/link";
 import { toast } from "sonner";
 import { experienceLevelLabel } from "@/lib/experience-level";
+import { ProfileAnalysisCard, type ProfileAnalysisData } from "@/features/ai/ui/ProfileAnalysisCard";
 
 type ProjectTemplate = {
   id: string;
@@ -55,6 +56,8 @@ type StudentDetail = {
       createdAt: string;
       roadmap?: Roadmap | null; // 🚀 SPRINT 3: Roadmap eklendi
     }[];
+    // #48: Detaylı AI profil analizi (yoksa null — henüz üretilmemiş).
+    profileAnalysis: ProfileAnalysisData | null;
   } | null;
 };
 
@@ -510,6 +513,13 @@ export default function StudentDetailPage() {
               )}
             </div>
           </div>
+        </div>
+      )}
+
+      {/* #48: Detaylı AI Profil Analizi (profil varsa) */}
+      {student.studentProfile && (
+        <div className="mt-6">
+          <ProfileAnalysisCard analysis={student.studentProfile.profileAnalysis} />
         </div>
       )}
 

--- a/src/app/api/admin/students/[studentId]/profile-analysis/route.test.ts
+++ b/src/app/api/admin/students/[studentId]/profile-analysis/route.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, prismaMock, getStoredMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  prismaMock: { studentProfile: { findUnique: vi.fn() } },
+  getStoredMock: vi.fn(),
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+vi.mock("@/features/ai/server/profile-analysis-store", () => ({
+  getStoredProfileAnalysis: getStoredMock,
+}));
+
+import { GET } from "./route";
+
+function authAdmin() {
+  requireAuthMock.mockResolvedValue({
+    authorized: true,
+    session: { user: { id: "admin-1", role: "ADMIN" } },
+  });
+}
+function unauthorized() {
+  requireAuthMock.mockResolvedValue({
+    authorized: false,
+    response: new Response(JSON.stringify({ error: "yetkisiz" }), { status: 403 }),
+  });
+}
+const ctx = { params: Promise.resolve({ studentId: "student-1" }) };
+
+describe("GET /api/admin/students/[studentId]/profile-analysis (#48)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("admin değilse guard yanıtını döner (403)", async () => {
+    unauthorized();
+    const res = await GET(new Request("http://test"), ctx);
+    expect(res.status).toBe(403);
+    expect(prismaMock.studentProfile.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("öğrenci profili yoksa 404 döner", async () => {
+    authAdmin();
+    prismaMock.studentProfile.findUnique.mockResolvedValue(null);
+
+    const res = await GET(new Request("http://test"), ctx);
+
+    expect(res.status).toBe(404);
+    expect(getStoredMock).not.toHaveBeenCalled();
+  });
+
+  it("profil var ama analiz yoksa 200 + analysis:null (empty state)", async () => {
+    authAdmin();
+    prismaMock.studentProfile.findUnique.mockResolvedValue({ id: "sp-1" });
+    getStoredMock.mockResolvedValue(null);
+
+    const res = await GET(new Request("http://test"), ctx);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.analysis).toBeNull();
+  });
+
+  it("analiz varsa 200 + analiz verisini döner", async () => {
+    authAdmin();
+    prismaMock.studentProfile.findUnique.mockResolvedValue({ id: "sp-1" });
+    getStoredMock.mockResolvedValue({ id: "pa-1", level: "Orta", summary: "özet" });
+
+    const res = await GET(new Request("http://test"), ctx);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.analysis).toEqual({ id: "pa-1", level: "Orta", summary: "özet" });
+    expect(getStoredMock).toHaveBeenCalledWith("sp-1");
+  });
+});

--- a/src/app/api/admin/students/[studentId]/profile-analysis/route.ts
+++ b/src/app/api/admin/students/[studentId]/profile-analysis/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { requireAuth } from "@/lib/auth/guard";
+import { getStoredProfileAnalysis } from "@/features/ai/server/profile-analysis-store";
+
+/**
+ * GET /api/admin/students/[studentId]/profile-analysis
+ * #48: Admin'in tek bir öğrencinin detaylı AI analizini isteğe bağlı (lazy) çekmesi için.
+ * Profil yoksa 404; profil var ama analiz henüz üretilmemişse 200 + analysis:null (empty state).
+ */
+export async function GET(
+  _: Request,
+  { params }: { params: Promise<{ studentId: string }> },
+) {
+  const auth = await requireAuth("ADMIN");
+  if (!auth.authorized) return auth.response;
+
+  try {
+    const { studentId } = await params;
+
+    const studentProfile = await prisma.studentProfile.findUnique({
+      where: { userId: studentId },
+      select: { id: true },
+    });
+
+    if (!studentProfile) {
+      return NextResponse.json(
+        { error: "Öğrenci profili bulunamadı. Öğrenci henüz onboarding'i tamamlamamış olabilir." },
+        { status: 404 },
+      );
+    }
+
+    const analysis = await getStoredProfileAnalysis(studentProfile.id);
+    return NextResponse.json({ analysis });
+  } catch (error) {
+    console.error("GET /api/admin/students/[studentId]/profile-analysis error:", error);
+    return NextResponse.json(
+      { error: "Analiz yüklenirken hata oluştu." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/features/ai/server/profile-analysis-store.test.ts
+++ b/src/features/ai/server/profile-analysis-store.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { prismaMock, analyzeMock } = vi.hoisted(() => ({
+  prismaMock: {
+    profileAnalysis: { upsert: vi.fn(), findUnique: vi.fn() },
+  },
+  analyzeMock: vi.fn(),
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+vi.mock("./profile-analysis", () => ({ analyzeStudentProfile: analyzeMock }));
+
+import {
+  generateAndPersistProfileAnalysis,
+  getStoredProfileAnalysis,
+} from "./profile-analysis-store";
+
+const analysisResult = {
+  level: "Orta",
+  tracks: ["Frontend", "Backend"],
+  summary: "özet",
+  strengths: ["hızlı öğrenir"],
+  developmentAreas: ["test yazımı"],
+  recommendedPath: "önce temel sonra proje",
+  recommendations: ["oku", "yaz"],
+};
+
+describe("profile-analysis-store (#47)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    analyzeMock.mockResolvedValue(analysisResult);
+    prismaMock.profileAnalysis.upsert.mockResolvedValue({ id: "pa-1" });
+  });
+
+  it("analiz üretilip upsert edilir; tracks → technicalTracks eşlenir", async () => {
+    const res = await generateAndPersistProfileAnalysis("sp-1", {
+      experienceLevel: "INTERMEDIATE",
+      interests: ["Web"],
+    });
+
+    expect(res).toBe(analysisResult);
+    expect(prismaMock.profileAnalysis.upsert).toHaveBeenCalledOnce();
+    const arg = prismaMock.profileAnalysis.upsert.mock.calls[0][0];
+    expect(arg.where).toEqual({ studentProfileId: "sp-1" });
+    expect(arg.create.technicalTracks).toEqual(["Frontend", "Backend"]);
+    expect(arg.create.strengths).toEqual(["hızlı öğrenir"]);
+    expect(arg.update.recommendedPath).toBe("önce temel sonra proje");
+  });
+
+  it("getStoredProfileAnalysis findUnique ile okur", async () => {
+    prismaMock.profileAnalysis.findUnique.mockResolvedValue({ id: "pa-1" });
+
+    const res = await getStoredProfileAnalysis("sp-1");
+
+    expect(prismaMock.profileAnalysis.findUnique).toHaveBeenCalledWith({
+      where: { studentProfileId: "sp-1" },
+    });
+    expect(res).toEqual({ id: "pa-1" });
+  });
+});

--- a/src/features/ai/server/profile-analysis-store.ts
+++ b/src/features/ai/server/profile-analysis-store.ts
@@ -1,0 +1,54 @@
+import { prisma } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import {
+  analyzeStudentProfile,
+  type ProfileAnalysisInput,
+  type ProfileAnalysisResult,
+} from "./profile-analysis";
+
+// #47: AI profil analizini üretip öğrenci profiline bağlı kalıcı olarak saklar.
+
+/** Kayıtlı analizi okur (yoksa null). #48 gösterimi bunu kullanır. */
+export async function getStoredProfileAnalysis(studentProfileId: string) {
+  return prisma.profileAnalysis.findUnique({
+    where: { studentProfileId },
+  });
+}
+
+/**
+ * Analizi üretir ve tek satır olarak upsert eder (profil başına 1 kayıt).
+ * `analyzeStudentProfile` AI hatasında güvenli fallback döndürür (asla throw etmez),
+ * bu yüzden hata durumunda bile tutarlı bir analiz saklanır (AC3).
+ */
+export async function generateAndPersistProfileAnalysis(
+  studentProfileId: string,
+  input: ProfileAnalysisInput,
+): Promise<ProfileAnalysisResult> {
+  const result = await analyzeStudentProfile(input);
+
+  await prisma.profileAnalysis.upsert({
+    where: { studentProfileId },
+    update: {
+      level: result.level,
+      summary: result.summary,
+      strengths: result.strengths,
+      developmentAreas: result.developmentAreas,
+      technicalTracks: result.tracks,
+      recommendedPath: result.recommendedPath,
+      recommendations: result.recommendations,
+    },
+    create: {
+      studentProfileId,
+      level: result.level,
+      summary: result.summary,
+      strengths: result.strengths,
+      developmentAreas: result.developmentAreas,
+      technicalTracks: result.tracks,
+      recommendedPath: result.recommendedPath,
+      recommendations: result.recommendations,
+    },
+  });
+
+  logger.info("Profil analizi kaydedildi", { studentProfileId, level: result.level });
+  return result;
+}

--- a/src/features/ai/server/profile-analysis.test.ts
+++ b/src/features/ai/server/profile-analysis.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { getModelMock } = vi.hoisted(() => ({ getModelMock: vi.fn() }));
+vi.mock("@/lib/ai/gemini-client", () => ({ getModel: getModelMock }));
+
+import { analyzeStudentProfile } from "./profile-analysis";
+
+const input = {
+  experienceLevel: "BEGINNER",
+  interests: ["Web Development", "AI"],
+  goals: "Full-stack olmak",
+};
+
+function modelReturning(json: unknown) {
+  return {
+    generateContent: vi.fn().mockResolvedValue({
+      response: { candidates: [{ content: { parts: [{ text: JSON.stringify(json) }] } }] },
+    }),
+  };
+}
+
+describe("analyzeStudentProfile — genişletilmiş sonuç (#47)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("AI hata verirse fallback tüm yeni alanları içerir", async () => {
+    getModelMock.mockImplementation(() => {
+      throw new Error("AI down");
+    });
+
+    const res = await analyzeStudentProfile(input);
+
+    expect(res.level).toBeTruthy();
+    expect(Array.isArray(res.tracks)).toBe(true);
+    expect(res.strengths.length).toBeGreaterThan(0);
+    expect(res.developmentAreas.length).toBeGreaterThan(0);
+    expect(typeof res.recommendedPath).toBe("string");
+    expect(res.recommendedPath.length).toBeGreaterThan(0);
+    expect(res.recommendations.length).toBeGreaterThan(0);
+  });
+
+  it("tam JSON dönerse tüm alanlar korunur", async () => {
+    getModelMock.mockReturnValue(
+      modelReturning({
+        level: "İleri",
+        tracks: ["Backend"],
+        summary: "özet",
+        strengths: ["algoritma"],
+        developmentAreas: ["test yazımı"],
+        recommendedPath: "önce X sonra Y",
+        recommendations: ["oku", "yaz"],
+      }),
+    );
+
+    const res = await analyzeStudentProfile(input);
+
+    expect(res.level).toBe("İleri");
+    expect(res.strengths).toEqual(["algoritma"]);
+    expect(res.developmentAreas).toEqual(["test yazımı"]);
+    expect(res.recommendedPath).toBe("önce X sonra Y");
+  });
+
+  it("model yeni alanları üretmezse güvenli varsayılanlar atanır", async () => {
+    getModelMock.mockReturnValue(
+      modelReturning({
+        level: "Orta",
+        tracks: ["Frontend"],
+        summary: "özet",
+        recommendations: ["oku"],
+        // strengths / developmentAreas / recommendedPath yok
+      }),
+    );
+
+    const res = await analyzeStudentProfile(input);
+
+    expect(res.strengths).toEqual([]);
+    expect(res.developmentAreas).toEqual([]);
+    expect(res.recommendedPath).toBe("");
+    expect(res.level).toBe("Orta");
+  });
+});

--- a/src/features/ai/server/profile-analysis.ts
+++ b/src/features/ai/server/profile-analysis.ts
@@ -11,8 +11,11 @@ export type ProfileAnalysisInput = {
 
 export type ProfileAnalysisResult = {
   level: 'Başlangıç' | 'Orta' | 'İleri';
-  tracks: string[];
+  tracks: string[];           // teknik eğilimler / uygun alanlar
   summary: string;
+  strengths: string[];        // #47: güçlü yönler
+  developmentAreas: string[]; // #47: gelişim alanları
+  recommendedPath: string;    // #47: önerilen yol
   recommendations: string[];
 };
 
@@ -30,8 +33,11 @@ Hedefler: ${input.goals || 'Belirtilmemiş'}
 Lütfen aşağıdaki formatta SADECE JSON yanıtı ver (başka metin ekleme):
 {
   "level": "Başlangıç" veya "Orta" veya "İleri" (bunlardan biri olmalı),
-  "tracks": ["Frontend Development", "Backend", vb. - öğrenciye uygun 2-4 teknoloji alanı],
+  "tracks": ["Frontend Development", "Backend", vb. - öğrenciye uygun 2-4 teknoloji alanı (teknik eğilimler)],
   "summary": "2-3 cümlelik profesyonel değerlendirme (Türkçe, pozitif ve motive edici)",
+  "strengths": ["öğrencinin 2-4 güçlü yönü (Türkçe)"],
+  "developmentAreas": ["gelişime açık 2-4 alan (Türkçe, yapıcı)"],
+  "recommendedPath": "öğrenciye önerilen öğrenme/gelişim yolu (2-3 cümle, Türkçe)",
   "recommendations": ["öğrenciye özel 3-4 pratik tavsiye (Türkçe)"]
 }
 
@@ -39,8 +45,10 @@ Lütfen aşağıdaki formatta SADECE JSON yanıtı ver (başka metin ekleme):
 1. "level" sadece şu 3 değerden biri olabilir: "Başlangıç", "Orta", "İleri"
 2. "tracks" dizisinde 2-4 alan öner
 3. "summary" pozitif ve motive edici olsun
-4. "recommendations" pratik ve uygulanabilir olsun
-5. Sadece JSON döndür, başka metin ekleme`;
+4. "strengths" ve "developmentAreas" dizilerinde 2-4 madde olsun; developmentAreas yapıcı bir dille yazılsın
+5. "recommendedPath" somut ve uygulanabilir bir yol tarifi olsun
+6. "recommendations" pratik ve uygulanabilir olsun
+7. Sadece JSON döndür, başka metin ekleme`;
 
   try {
     const model = getModel();
@@ -74,6 +82,14 @@ Lütfen aşağıdaki formatta SADECE JSON yanıtı ver (başka metin ekleme):
       parsedResult.level = 'Orta';
     }
 
+    // #47: Yeni alanlar model tarafından üretilmemişse güvenli varsayılanlar ata
+    // (şekil her zaman tam olsun; downstream persist/gösterim bozulmasın).
+    parsedResult.tracks = Array.isArray(parsedResult.tracks) ? parsedResult.tracks : [];
+    parsedResult.strengths = Array.isArray(parsedResult.strengths) ? parsedResult.strengths : [];
+    parsedResult.developmentAreas = Array.isArray(parsedResult.developmentAreas) ? parsedResult.developmentAreas : [];
+    parsedResult.recommendedPath = typeof parsedResult.recommendedPath === 'string' ? parsedResult.recommendedPath : '';
+    parsedResult.recommendations = Array.isArray(parsedResult.recommendations) ? parsedResult.recommendations : [];
+
     return parsedResult;
 
   } catch (error) {
@@ -83,6 +99,16 @@ Lütfen aşağıdaki formatta SADECE JSON yanıtı ver (başka metin ekleme):
       level: 'Orta',
       tracks: input.interests.slice(0, 3),
       summary: `${experienceLevelLabel(input.experienceLevel)} seviyesinde bir öğrenci. ${input.interests.join(', ')} alanlarında ilgi gösteriyor.`,
+      strengths: [
+        'Öğrenmeye açık ve istekli',
+        `${input.interests[0] ?? 'Yazılım'} alanına ilgi duyuyor`,
+      ],
+      developmentAreas: [
+        'Temel kavramların pekiştirilmesi',
+        'Proje deneyiminin artırılması',
+      ],
+      recommendedPath:
+        'Önce temel kavramları pekiştir, ardından küçük projelerle pratik yaparak ilerle. Düzenli olarak kaynakları takip et.',
       recommendations: [
         'Temel kavramları pekiştirmeye devam edin',
         'Küçük projelerle pratik yapın',

--- a/src/features/ai/ui/ProfileAnalysisCard.tsx
+++ b/src/features/ai/ui/ProfileAnalysisCard.tsx
@@ -1,0 +1,150 @@
+// features/ai/ui/ProfileAnalysisCard.tsx
+// #48: Mentor detay sayfası ve admin modal'ı tarafından paylaşılan, #47'de
+// saklanan detaylı AI analizini gösteren kart.
+
+import { Award, TrendingUp, Compass, Lightbulb, Layers, Loader2, AlertCircle, Sparkles } from "lucide-react";
+
+export type ProfileAnalysisData = {
+  level: string;
+  summary: string;
+  strengths: string[];
+  developmentAreas: string[];
+  technicalTracks: string[];
+  recommendedPath: string;
+  recommendations: string[];
+};
+
+type Props = {
+  analysis: ProfileAnalysisData | null | undefined;
+  loading?: boolean;
+  error?: string | null;
+};
+
+export function ProfileAnalysisCard({ analysis, loading, error }: Props) {
+  if (loading) {
+    return (
+      <div className="bg-white rounded-xl border border-slate-200 p-8 flex items-center justify-center gap-3 text-slate-500">
+        <Loader2 className="w-5 h-5 animate-spin" />
+        <span className="text-sm">Analiz yükleniyor...</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white rounded-xl border border-red-200 p-8 flex flex-col items-center justify-center gap-2 text-center">
+        <AlertCircle className="w-6 h-6 text-red-500" />
+        <p className="text-sm text-red-600">{error}</p>
+      </div>
+    );
+  }
+
+  if (!analysis) {
+    return (
+      <div className="bg-white rounded-xl border border-slate-200 p-8 flex flex-col items-center justify-center gap-2 text-center">
+        <Sparkles className="w-6 h-6 text-slate-300" />
+        <p className="text-sm text-slate-500">
+          Bu öğrenci için henüz bir AI analizi oluşturulmamış.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-gradient-to-br from-blue-50 to-indigo-50 rounded-xl shadow-sm p-6 space-y-4 border border-blue-100">
+      <div className="flex items-center gap-2">
+        <div className="p-2 bg-blue-600 rounded-lg">
+          <Sparkles className="w-5 h-5 text-white" />
+        </div>
+        <h2 className="text-lg font-semibold text-gray-900">Detaylı AI Profil Analizi</h2>
+        <span className="ml-auto px-3 py-1 bg-blue-100 text-blue-800 rounded-full text-sm font-semibold">
+          {analysis.level}
+        </span>
+      </div>
+
+      <div className="bg-white rounded-lg p-4 text-sm text-gray-700 leading-relaxed">
+        {analysis.summary}
+      </div>
+
+      {analysis.technicalTracks.length > 0 && (
+        <div className="bg-white rounded-lg p-4">
+          <h3 className="font-semibold text-gray-900 mb-3 flex items-center gap-2 text-sm">
+            <Layers className="w-4 h-4 text-blue-600" />
+            Teknik Eğilimler
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            {analysis.technicalTracks.map((track, i) => (
+              <span
+                key={i}
+                className="px-3 py-1 bg-blue-50 text-blue-800 rounded-lg text-xs font-medium border border-blue-200"
+              >
+                {track}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {analysis.strengths.length > 0 && (
+        <div className="bg-white rounded-lg p-4">
+          <h3 className="font-semibold text-gray-900 mb-3 flex items-center gap-2 text-sm">
+            <Award className="w-4 h-4 text-emerald-600" />
+            Güçlü Yönler
+          </h3>
+          <ul className="space-y-1.5">
+            {analysis.strengths.map((s, i) => (
+              <li key={i} className="flex items-start gap-2 text-sm text-gray-700">
+                <span className="text-emerald-500 mt-1">•</span>
+                <span>{s}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {analysis.developmentAreas.length > 0 && (
+        <div className="bg-white rounded-lg p-4">
+          <h3 className="font-semibold text-gray-900 mb-3 flex items-center gap-2 text-sm">
+            <TrendingUp className="w-4 h-4 text-amber-600" />
+            Gelişim Alanları
+          </h3>
+          <ul className="space-y-1.5">
+            {analysis.developmentAreas.map((d, i) => (
+              <li key={i} className="flex items-start gap-2 text-sm text-gray-700">
+                <span className="text-amber-500 mt-1">•</span>
+                <span>{d}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {analysis.recommendedPath && (
+        <div className="bg-white rounded-lg p-4">
+          <h3 className="font-semibold text-gray-900 mb-2 flex items-center gap-2 text-sm">
+            <Compass className="w-4 h-4 text-indigo-600" />
+            Önerilen Yol
+          </h3>
+          <p className="text-sm text-gray-700 leading-relaxed">{analysis.recommendedPath}</p>
+        </div>
+      )}
+
+      {analysis.recommendations.length > 0 && (
+        <div className="bg-white rounded-lg p-4">
+          <h3 className="font-semibold text-gray-900 mb-3 flex items-center gap-2 text-sm">
+            <Lightbulb className="w-4 h-4 text-yellow-500" />
+            Öneriler
+          </h3>
+          <ul className="space-y-1.5">
+            {analysis.recommendations.map((r, i) => (
+              <li key={i} className="flex items-start gap-2 text-sm text-gray-700">
+                <span className="text-yellow-500 mt-1">•</span>
+                <span>{r}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/mentors/server/actions.ts
+++ b/src/features/mentors/server/actions.ts
@@ -111,6 +111,8 @@ export async function getStudentDetail(studentId: string, mentorId: string) {
                 createdAt: "desc",
               },
             },
+            // #48: Detaylı AI profil analizi (varsa) — mentor kendi öğrencisininkini görür.
+            profileAnalysis: true,
           },
         },
       },

--- a/src/features/student/server/onboarding.ts
+++ b/src/features/student/server/onboarding.ts
@@ -7,6 +7,8 @@ import { prisma } from "@/lib/auth/prisma"
 import { getServerSession } from "next-auth"
 import { authOptions } from "@/lib/auth/nextauth"
 import { normalizeExperienceLevel } from "@/lib/experience-level"
+import { generateAndPersistProfileAnalysis } from "@/features/ai/server/profile-analysis-store"
+import { logger } from "@/lib/logger"
 
 // Tek birleşik şema
 const onboardingSchema = z.object({
@@ -35,7 +37,7 @@ export async function saveOnboarding(rawData: unknown) {
   const experienceLevel = normalizeExperienceLevel(data.experience.level)
 
   // 3. User + StudentProfile'ı atomik güncelle (firstName/lastName/phone User'da, profil alanları StudentProfile'da)
-  await prisma.$transaction([
+  const [, studentProfile] = await prisma.$transaction([
     prisma.user.update({
       where: { id: session.user.id },
       data: {
@@ -64,7 +66,21 @@ export async function saveOnboarding(rawData: unknown) {
     }),
   ])
 
-  // 4. Profil değişti → AI özet cache'ini invalidate et
+  // 4. #47: Detaylı AI analizini üret + kalıcı sakla. Best-effort — hata olursa
+  // onboarding akışı kırılmaz (analyzeStudentProfile zaten fallback döndürür;
+  // yalnızca DB persist hatasına karşı try/catch).
+  try {
+    await generateAndPersistProfileAnalysis(studentProfile.id, {
+      experienceLevel,
+      interests: data.experience.interest,
+      goals: data.goals.goal,
+      availability: data.goals.availability,
+    })
+  } catch (error) {
+    logger.error("Onboarding: profil analizi kaydedilemedi", error)
+  }
+
+  // 5. Profil değişti → AI özet cache'ini invalidate et
   revalidateTag(`profile-summary-${session.user.id}`)
 
   // Client component zaten window.location.href ile yönlendiriyor,


### PR DESCRIPTION
## Özet
Issue #48: #47'de saklanan `ProfileAnalysis` kaydını (güçlü yönler, gelişim alanları, teknik eğilimler, önerilen yol, öneriler) mentor öğrenci detay sayfasında ve admin panelinde gösteren **paylaşılan bir kart** eklendi.

## Değişiklikler
- **`features/ai/ui/ProfileAnalysisCard.tsx`** (yeni, paylaşılan) — `loading`/`error`/`analysis:null` (empty state: "henüz analiz yok") destekler. Hem mentor hem admin aynı kartı kullanır.
- **Mentor** — `getStudentDetail` sorgusuna `profileAnalysis: true` eklendi (sorgu zaten `studentProfile.mentorId` ile filtreli, ekstra yetki kontrolü gerekmedi). `[studentId]` sayfasında kart, profil+proje grid'inin altında tam genişlikte gösteriliyor.
- **Admin** — `GET /api/admin/students/[studentId]/profile-analysis` (ADMIN guard, **lazy fetch**). Kullanıcı tablosunda öğrenci satırına "Analizi Gör" butonu; tıklanınca modal açılıp aynı kart `loading`→veri/hata state'iyle render ediliyor.

## Neden lazy (admin tarafı)?
`getAllUsers` her admin paneli açılışında **tüm** öğrencileri hafif bir profille çekiyor. Analizi oraya gömersek her açılışta gereksiz veri taşınır — çoğu zaman admin sadece birkaç öğrenciye bakacak. Modal zaten isteğe bağlı olduğu için, analiz **yalnızca modal açılınca** ayrı bir istekle çekiliyor.

## Endpoint davranışı (empty state ayrımı)
- Öğrencinin `StudentProfile`'ı yok (onboarding tamamlanmamış) → **404**
- Profil var ama analiz henüz üretilmemiş → **200 + `analysis: null`** (empty state, hata değil)
- Analiz var → **200 + analiz verisi**

## Test
`src/app/api/admin/students/[studentId]/profile-analysis/route.test.ts` — guard/404/empty/dolu analiz (4 test).
`npm test` (65/65 yeşil) · `npm run lint` (0 hata) · `npm run build` ✓

> ⚠️ **Not:** Yerel Postgres/Docker olmadığı için tam tarayıcı akışını (login → panel → modal) uçtan uca deneyemedim. Build ve testler kodun doğruluğunu kanıtlıyor; aşağıdaki adımlarla manuel doğrulama önerilir.

### Manuel test adımları
1. Bir öğrenci onboarding'i tamamlasın (#47 sayesinde analiz otomatik üretilip kaydedilir).
2. **Mentor** olarak o öğrencinin `[studentId]` detay sayfasına gir → profil/proje bölümünün altında "Detaylı AI Profil Analizi" kartı görünmeli.
3. **Admin** olarak panelde o öğrencinin satırında "Analizi Gör" butonuna tıkla → modal açılır, kısa bir loading'in ardından aynı kart görünür.
4. Onboarding tamamlamamış bir öğrenci için admin tarafında "Analizi Gör" butonu **görünmemeli** (profil yok).
5. Profili olan ama (hipotetik olarak) analiz kaydı olmayan bir öğrenci için modal "henüz analiz yok" empty state'i göstermeli.

## Acceptance Criteria
- [x] Mentor kendi öğrencisinin detaylı AI analizini görebilir
- [x] Admin profilini tamamlayan öğrencinin analizini görebilir
- [x] Analiz yoksa anlamlı empty state görünür
- [x] Yetkisiz kullanıcı analiz verisine erişemez (mentor: sorgu filtresi; admin: `requireAuth("ADMIN")`)

> ℹ️ **Stacked:** [#47](https://github.com/Posinowa/AISigner/pull/79) üzerine kurulu (ProfileAnalysis modeline bağımlı); #47 merge olunca diff sadeleşir.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)