### PR TITLE
feat: proje şablonlarına GitHub repository URL alanı ekle

### DIFF
--- a/prisma/migrations/20260703174206_add_github_repo_url/migration.sql
+++ b/prisma/migrations/20260703174206_add_github_repo_url/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "ProjectTemplate" ADD COLUMN     "githubRepoUrl" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,13 +59,15 @@ model StudentProfile {
 }
 
 model ProjectTemplate {
-  id          String   @id @default(cuid())
-  title       String
-  description String
-  track       String[]
-  difficulty  Difficulty
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  id            String   @id @default(cuid())
+  title         String
+  description   String
+  track         String[]
+  difficulty    Difficulty
+  // #49: Projenin GitHub repository URL'i (opsiyonel, public repo).
+  githubRepoUrl String?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 
   assignedProjects AssignedProject[]
 }

--- a/src/app/(admin)/admin-dashboard/projects/page.tsx
+++ b/src/app/(admin)/admin-dashboard/projects/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { Plus, Pencil, Trash2, X, ArrowLeft, FolderKanban } from "lucide-react";
+import { Plus, Pencil, Trash2, X, ArrowLeft, FolderKanban, Github } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
 
@@ -11,6 +11,7 @@ type ProjectTemplate = {
   description: string;
   difficulty: "EASY" | "MEDIUM" | "HARD";
   track: string[];
+  githubRepoUrl?: string | null;
 };
 
 type FormData = {
@@ -18,6 +19,7 @@ type FormData = {
   description: string;
   difficulty: "EASY" | "MEDIUM" | "HARD";
   track: string;
+  githubRepoUrl: string;
 };
 
 const difficultyColors = {
@@ -35,6 +37,7 @@ export default function ProjectsPage() {
     description: "",
     difficulty: "EASY",
     track: "",
+    githubRepoUrl: "",
   });
   const [loading, setLoading] = useState(false);
   const [pageLoading, setPageLoading] = useState(true); // Sayfa yükleniyor durumu
@@ -63,7 +66,7 @@ export default function ProjectsPage() {
   }, [loadTemplates]);
 
   function resetForm() {
-    setForm({ title: "", description: "", difficulty: "EASY", track: "" });
+    setForm({ title: "", description: "", difficulty: "EASY", track: "", githubRepoUrl: "" });
     setIsFormOpen(false);
     setEditingId(null);
   }
@@ -74,6 +77,7 @@ export default function ProjectsPage() {
       description: template.description,
       difficulty: template.difficulty,
       track: template.track.join(", "),
+      githubRepoUrl: template.githubRepoUrl ?? "",
     });
     setEditingId(template.id);
     setIsFormOpen(true);
@@ -87,6 +91,8 @@ export default function ProjectsPage() {
       const payload = {
         ...form,
         track: form.track.split(",").map(t => t.trim()).filter(Boolean),
+        // #49: Boş input -> null (repo linki opsiyonel; boş string geçersiz URL sayılmasın).
+        githubRepoUrl: form.githubRepoUrl.trim() === "" ? null : form.githubRepoUrl.trim(),
       };
 
       let res;
@@ -104,12 +110,26 @@ export default function ProjectsPage() {
         });
       }
 
-      if (!res.ok) throw new Error("Failed to save template");
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        const fieldErrors = data?.error;
+        let message = "Şablon kaydedilemedi.";
+        if (fieldErrors && typeof fieldErrors === "object") {
+          const firstMessage = Object.values(fieldErrors).flat()[0];
+          if (firstMessage) message = String(firstMessage);
+        } else if (typeof fieldErrors === "string") {
+          message = fieldErrors;
+        }
+        toast.error(message);
+        return;
+      }
 
       await loadTemplates();
       resetForm();
+      toast.success(editingId ? "Şablon güncellendi." : "Şablon oluşturuldu.");
     } catch (error) {
       console.error("Failed to save template:", error);
+      toast.error("Bağlantı hatası. Lütfen tekrar deneyin.");
     } finally {
       setLoading(false);
     }
@@ -250,6 +270,19 @@ export default function ProjectsPage() {
                 </div>
               </div>
 
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-2">
+                  GitHub Repository URL (opsiyonel)
+                </label>
+                <input
+                  type="text"
+                  value={form.githubRepoUrl}
+                  onChange={e => setForm(f => ({ ...f, githubRepoUrl: e.target.value }))}
+                  className="w-full px-3 py-2 border border-slate-200 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="https://github.com/kullanici/repo"
+                />
+              </div>
+
               <div className="flex justify-end gap-3 pt-4 border-t">
                 <button
                   type="button"
@@ -324,6 +357,18 @@ export default function ProjectsPage() {
                         </span>
                       )}
                     </div>
+
+                    {template.githubRepoUrl && (
+                      <a
+                        href={template.githubRepoUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1.5 text-xs text-slate-600 hover:text-slate-900 mb-4 transition-colors"
+                      >
+                        <Github className="w-3.5 h-3.5" />
+                        {template.githubRepoUrl.replace(/^https:\/\/github\.com\//, "")}
+                      </a>
+                    )}
 
                     <div className="flex justify-between items-center">
                       <span className="text-xs text-slate-500">

--- a/src/app/(mentor)/mentor-dashboard/[studentId]/page.tsx
+++ b/src/app/(mentor)/mentor-dashboard/[studentId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
-import { ArrowLeft, User, Calendar, Target, Clock, BookOpen, Plus, CheckCircle, AlertCircle, Trash2, Sparkles, Map } from "lucide-react"; // Map ikonu eklendi
+import { ArrowLeft, User, Calendar, Target, Clock, BookOpen, Plus, CheckCircle, AlertCircle, Trash2, Sparkles, Map, Github } from "lucide-react"; // Map ikonu eklendi
 import Link from "next/link";
 import { toast } from "sonner";
 import { experienceLevelLabel } from "@/lib/experience-level";
@@ -13,6 +13,7 @@ type ProjectTemplate = {
   description: string;
   difficulty: "EASY" | "MEDIUM" | "HARD";
   track: string[];
+  githubRepoUrl?: string | null;
 };
 
 type AIRecommendation = {
@@ -446,7 +447,19 @@ export default function StudentDetailPage() {
                         <p className="text-gray-600 text-sm mb-4 line-clamp-2">
                           {project.projectTemplate.description}
                         </p>
-                        
+
+                        {project.projectTemplate.githubRepoUrl && (
+                          <a
+                            href={project.projectTemplate.githubRepoUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1.5 text-xs text-gray-600 hover:text-gray-900 mb-3 transition-colors"
+                          >
+                            <Github className="w-3.5 h-3.5" />
+                            {project.projectTemplate.githubRepoUrl.replace(/^https:\/\/github\.com\//, "")}
+                          </a>
+                        )}
+
                         <div className="flex items-center justify-between mb-4">
                           <div className="flex flex-wrap gap-1">
                             {project.projectTemplate.track.slice(0, 3).map((tag, index) => (

--- a/src/app/(student)/student-dashboard/page.tsx
+++ b/src/app/(student)/student-dashboard/page.tsx
@@ -5,7 +5,7 @@ import { RoadmapSteps } from "@/features/student/ui/RoadmapSteps";
 import { prisma } from "@/lib/db";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth/nextauth";
-import { Clock, Briefcase, Target, MessageSquare } from "lucide-react";
+import { Clock, Briefcase, Target, MessageSquare, Github } from "lucide-react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { Progress } from "@/components/ui/progress";
@@ -190,6 +190,17 @@ export default async function StudentDashboardPage() {
                         <p className="text-slate-600 mt-2 text-sm max-w-3xl leading-relaxed">
                           {project.projectTemplate.description}
                         </p>
+                        {project.projectTemplate.githubRepoUrl && (
+                          <a
+                            href={project.projectTemplate.githubRepoUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center gap-1.5 text-xs text-slate-600 hover:text-slate-900 mt-2 transition-colors"
+                          >
+                            <Github className="w-3.5 h-3.5" />
+                            {project.projectTemplate.githubRepoUrl.replace(/^https:\/\/github\.com\//, "")}
+                          </a>
+                        )}
                       </div>
                     </div>
 

--- a/src/app/api/admin/project-templates/route.test.ts
+++ b/src/app/api/admin/project-templates/route.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, prismaMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  prismaMock: { projectTemplate: { create: vi.fn() } },
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+
+import { POST } from "./route";
+
+function authAdmin() {
+  requireAuthMock.mockResolvedValue({
+    authorized: true,
+    session: { user: { id: "admin-1", role: "ADMIN" } },
+  });
+}
+function postReq(body: unknown) {
+  return new Request("http://test/api/admin/project-templates", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  title: "Proje",
+  description: "Açıklama",
+  difficulty: "EASY",
+  track: ["React"],
+};
+
+describe("POST /api/admin/project-templates — githubRepoUrl (#49)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.projectTemplate.create.mockResolvedValue({ id: "pt-1" });
+  });
+
+  it("geçerli github.com URL'i ile 201 döner", async () => {
+    authAdmin();
+
+    const res = await POST(
+      postReq({ ...validBody, githubRepoUrl: "https://github.com/kullanici/repo" }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.projectTemplate.create).toHaveBeenCalledOnce();
+    const arg = prismaMock.projectTemplate.create.mock.calls[0][0];
+    expect(arg.data.githubRepoUrl).toBe("https://github.com/kullanici/repo");
+  });
+
+  it("geçersiz URL ile 400 döner, create çağrılmaz", async () => {
+    authAdmin();
+
+    const res = await POST(postReq({ ...validBody, githubRepoUrl: "not-a-url" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error.githubRepoUrl).toBeTruthy();
+    expect(prismaMock.projectTemplate.create).not.toHaveBeenCalled();
+  });
+
+  it("githubRepoUrl belirtilmeden 201 döner (opsiyonel)", async () => {
+    authAdmin();
+
+    const res = await POST(postReq(validBody));
+
+    expect(res.status).toBe(201);
+  });
+});

--- a/src/features/projects/server/templates.ts
+++ b/src/features/projects/server/templates.ts
@@ -6,6 +6,7 @@ export type CreateTemplateData = {
   description: string;
   difficulty: "EASY" | "MEDIUM" | "HARD";
   track: string[];
+  githubRepoUrl?: string | null;
 };
 
 export type UpdateTemplateData = Partial<CreateTemplateData>;
@@ -31,6 +32,7 @@ export async function createTemplate(data: CreateTemplateData) {
         description: data.description,
         difficulty: data.difficulty,
         track: data.track,
+        githubRepoUrl: data.githubRepoUrl ?? null,
       },
     });
   } catch (error) {

--- a/src/lib/validations/api.test.ts
+++ b/src/lib/validations/api.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { createTemplateSchema, updateTemplateSchema } from "./api";
+
+const validBase = {
+  title: "Proje",
+  description: "Açıklama",
+  difficulty: "EASY" as const,
+};
+
+describe("createTemplateSchema — githubRepoUrl (#49)", () => {
+  it("geçerli github.com URL'ini kabul eder", () => {
+    const result = createTemplateSchema.safeParse({
+      ...validBase,
+      githubRepoUrl: "https://github.com/kullanici/repo",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("github.com olmayan domaini reddeder", () => {
+    const result = createTemplateSchema.safeParse({
+      ...validBase,
+      githubRepoUrl: "https://gitlab.com/kullanici/repo",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("bozuk URL'i reddeder", () => {
+    const result = createTemplateSchema.safeParse({
+      ...validBase,
+      githubRepoUrl: "not-a-url",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("sadece domain (repo yolu yok) reddedilir", () => {
+    const result = createTemplateSchema.safeParse({
+      ...validBase,
+      githubRepoUrl: "https://github.com",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("http (https değil) reddedilir", () => {
+    const result = createTemplateSchema.safeParse({
+      ...validBase,
+      githubRepoUrl: "http://github.com/kullanici/repo",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("null / undefined / alan yok — opsiyonel olduğu için geçerli", () => {
+    expect(createTemplateSchema.safeParse({ ...validBase, githubRepoUrl: null }).success).toBe(true);
+    expect(createTemplateSchema.safeParse({ ...validBase, githubRepoUrl: undefined }).success).toBe(true);
+    expect(createTemplateSchema.safeParse(validBase).success).toBe(true);
+  });
+});
+
+describe("updateTemplateSchema — githubRepoUrl (#49)", () => {
+  it("yalnızca githubRepoUrl güncellemesi (diğer alanlar opsiyonel) geçerli", () => {
+    const result = updateTemplateSchema.safeParse({
+      githubRepoUrl: "https://github.com/kullanici/repo",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("geçersiz URL güncellemede de reddedilir", () => {
+    const result = updateTemplateSchema.safeParse({ githubRepoUrl: "ftp://github.com/a/b" });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/lib/validations/api.ts
+++ b/src/lib/validations/api.ts
@@ -54,6 +54,24 @@ export const updateAccountStatusSchema = z.object({
   }),
 });
 
+// #49: Public GitHub repository URL — yalnızca github.com üzerinde
+// https://github.com/<owner>/<repo>(...) formatı kabul edilir.
+const githubRepoUrlSchema = z
+  .string()
+  .trim()
+  .refine((val) => {
+    try {
+      const url = new URL(val);
+      if (url.protocol !== "https:" || url.hostname !== "github.com") return false;
+      const segments = url.pathname.split("/").filter(Boolean);
+      return segments.length >= 2;
+    } catch {
+      return false;
+    }
+  }, "Geçerli bir GitHub repository URL'i girin (ör: https://github.com/kullanici/repo)")
+  .nullable()
+  .optional();
+
 // Admin: Proje şablonu oluşturma
 export const createTemplateSchema = z.object({
   title: z.string().min(1, "Başlık gerekli"),
@@ -62,6 +80,7 @@ export const createTemplateSchema = z.object({
     error: "Geçersiz zorluk seviyesi. EASY, MEDIUM veya HARD olmalı.",
   }),
   track: z.array(z.string()).default([]),
+  githubRepoUrl: githubRepoUrlSchema,
 });
 
 // Admin: Proje şablonu güncelleme
@@ -70,6 +89,7 @@ export const updateTemplateSchema = z.object({
   description: z.string().min(1).optional(),
   difficulty: z.enum(["EASY", "MEDIUM", "HARD"]).optional(),
   track: z.array(z.string()).optional(),
+  githubRepoUrl: githubRepoUrlSchema,
 });
 
 // Mentor: Proje atama


### PR DESCRIPTION
## Özet
Issue #49: Admin proje şablonu oluştururken/düzenlerken **GitHub repo URL'i** girebilir; mentor ve öğrenci proje detayında bu linki görebilir. (#50'nin roadmap adımlarına issue linki eklemesi için zemin — bu PR sadece repo URL alanı.)

## Değişiklikler
- **`prisma/schema.prisma` + migration** — `ProjectTemplate.githubRepoUrl` (opsiyonel, nullable `TEXT`). Basit `ADD COLUMN`, geri uyumluluk sorunu yok.
- **`lib/validations/api.ts`** — `githubRepoUrlSchema`: yalnızca **`https://github.com/<owner>/<repo>`** formatı kabul edilir (`URL` constructor + `hostname === "github.com"` + en az 2 path segmenti). `createTemplateSchema`/`updateTemplateSchema`'ya eklendi.
- **`features/projects/server/templates.ts`** — `createTemplate` alan eşlemesine `githubRepoUrl` eklendi (`updateTemplate` zaten `data`'yı direkt Prisma'ya geçiriyordu, otomatik aktı).
- **Admin `projects/page.tsx`** — form input'u (boş string → `null` dönüşümü), submit başarı/hata **toast**'ı (önceden hata sessizce yutuluyordu — bu PR'la validation hataları admin'e görünür oldu), liste kartında repo linki.
- **Mentor `[studentId]`** ve **`student-dashboard`** — proje kartında repo linki. `mentor-dashboard`'ın genel listesi (aggregate, açıklama bile göstermiyor) kapsam dışı bırakıldı — gerçek "detay" görünümü olan `[studentId]` sayfası güncellendi.

## Test
- `src/lib/validations/api.test.ts` — URL validasyonu: geçerli github.com, yanlış domain, bozuk URL, path yok, http (https değil), null/undefined/opsiyonel (8 test).
- `src/app/api/admin/project-templates/route.test.ts` — POST uçtan uca: geçerli URL → 201, geçersiz URL → 400 (create çağrılmaz), URL'siz → 201 (opsiyonel) (3 test).
- `npm test` (67/67 yeşil) · `npm run lint` (0 hata) · `npm run build` ✓

## Acceptance Criteria
- [x] Proje şablonu GitHub repo URL saklayabilir
- [x] Admin repo URL ekleyebilir ve düzenleyebilir
- [x] Geçersiz URL için validation hatası döner (400 + admin'de toast)
- [x] Mentor ve öğrenci proje detayında repo linkini görebilir

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)