### PR TITLE
feat: roadmap adımlarına GitHub issue linki ekle

### DIFF
--- a/prisma/migrations/20260703214845_add_step_github_issue_url/migration.sql
+++ b/prisma/migrations/20260703214845_add_step_github_issue_url/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "RoadmapStep" ADD COLUMN     "githubIssueUrl" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,6 +107,8 @@ model RoadmapStep {
   resources      String[]
   estimatedHours Int?
   status         StepStatus @default(TODO)
+  // #50: Bu adımın bağlı olduğu GitHub issue linki (opsiyonel).
+  githubIssueUrl String?
   createdAt      DateTime   @default(now())
   updatedAt      DateTime   @updatedAt
 

--- a/src/app/(mentor)/mentor-dashboard/roadmap/[roadmapId]/page.tsx
+++ b/src/app/(mentor)/mentor-dashboard/roadmap/[roadmapId]/page.tsx
@@ -20,6 +20,7 @@ import {
   Send,
   ChevronDown,
   ChevronUp,
+  Github,
 } from "lucide-react";
 import { StepComments } from "@/features/messaging/ui/StepComments";
 import { StepFiles } from "@/features/files/ui/StepFiles";
@@ -33,6 +34,7 @@ type RoadmapStep = {
   estimatedHours: number | null;
   resources: string[];
   status: string;
+  githubIssueUrl?: string | null;
 };
 
 type Roadmap = {
@@ -69,6 +71,25 @@ const stepStatusConfig: Record<string, { label: string; color: string; icon: typ
   COMPLETED: { label: "Tamamlandı", color: "bg-green-100 text-green-700", icon: CheckCircle },
 };
 
+// #50: Boş input -> null (issue linki opsiyonel; boş string geçersiz URL sayılmasın).
+function toNullableUrl(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+// #50: Zod fieldErrors ({ alan: [mesaj] }) şeklindeki hatayı okunabilir tek mesaja indirger.
+async function extractErrorMessage(res: Response, fallback: string): Promise<string> {
+  const data = await res.json().catch(() => null);
+  const fieldErrors = data?.error;
+  if (fieldErrors && typeof fieldErrors === "object") {
+    const first = Object.values(fieldErrors).flat()[0];
+    if (first) return String(first);
+  } else if (typeof fieldErrors === "string") {
+    return fieldErrors;
+  }
+  return fallback;
+}
+
 /* ─── Sayfa ─── */
 export default function RoadmapReviewPage() {
   const params = useParams();
@@ -88,6 +109,7 @@ export default function RoadmapReviewPage() {
     description: "",
     estimatedHours: 0,
     resources: [""],
+    githubIssueUrl: "",
   });
 
   // Yeni adım ekleme
@@ -97,6 +119,7 @@ export default function RoadmapReviewPage() {
     description: "",
     estimatedHours: 2,
     resources: [""],
+    githubIssueUrl: "",
   });
 
   // Hangi adım açık (accordion)
@@ -174,13 +197,14 @@ export default function RoadmapReviewPage() {
       description: step.description,
       estimatedHours: step.estimatedHours ?? 0,
       resources: step.resources.length > 0 ? [...step.resources] : [""],
+      githubIssueUrl: step.githubIssueUrl ?? "",
     });
     setExpandedStepId(step.id);
   }
 
   function cancelEditStep() {
     setEditingStepId(null);
-    setEditForm({ title: "", description: "", estimatedHours: 0, resources: [""] });
+    setEditForm({ title: "", description: "", estimatedHours: 0, resources: [""], githubIssueUrl: "" });
   }
 
   async function handleSaveStep() {
@@ -197,15 +221,19 @@ export default function RoadmapReviewPage() {
             description: editForm.description,
             estimatedHours: editForm.estimatedHours || null,
             resources: editForm.resources.filter((r) => r.trim() !== ""),
+            githubIssueUrl: toNullableUrl(editForm.githubIssueUrl),
           }),
         }
       );
       if (res.ok) {
         await loadRoadmap();
         cancelEditStep();
+      } else {
+        toast.error(await extractErrorMessage(res, "Adım güncellenemedi."));
       }
     } catch (error) {
       console.error(error);
+      toast.error("Bağlantı hatası. Lütfen tekrar deneyin.");
     } finally {
       setSaving(false);
     }
@@ -244,15 +272,19 @@ export default function RoadmapReviewPage() {
           description: newStepForm.description,
           estimatedHours: newStepForm.estimatedHours || null,
           resources: newStepForm.resources.filter((r) => r.trim() !== ""),
+          githubIssueUrl: toNullableUrl(newStepForm.githubIssueUrl),
         }),
       });
       if (res.ok) {
         await loadRoadmap();
         setShowAddForm(false);
-        setNewStepForm({ title: "", description: "", estimatedHours: 2, resources: [""] });
+        setNewStepForm({ title: "", description: "", estimatedHours: 2, resources: [""], githubIssueUrl: "" });
+      } else {
+        toast.error(await extractErrorMessage(res, "Adım eklenemedi."));
       }
     } catch (error) {
       console.error(error);
+      toast.error("Bağlantı hatası. Lütfen tekrar deneyin.");
     } finally {
       setSaving(false);
     }
@@ -534,6 +566,16 @@ export default function RoadmapReviewPage() {
                         />
                       </div>
                       <div>
+                        <label className="block text-sm font-medium text-gray-700 mb-1">GitHub Issue Linki (opsiyonel)</label>
+                        <input
+                          type="text"
+                          value={editForm.githubIssueUrl}
+                          onChange={(e) => setEditForm({ ...editForm, githubIssueUrl: e.target.value })}
+                          placeholder="https://github.com/kullanici/repo/issues/12"
+                          className="w-full border rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-purple-300 focus:border-purple-400 outline-none"
+                        />
+                      </div>
+                      <div>
                         <label className="block text-sm font-medium text-gray-700 mb-1">Kaynaklar</label>
                         <div className="space-y-2">
                           {editForm.resources.map((res, i) => (
@@ -612,6 +654,18 @@ export default function RoadmapReviewPage() {
                           <Clock className="w-3 h-3" />
                           Tahmini: {step.estimatedHours} saat
                         </div>
+                      )}
+
+                      {step.githubIssueUrl && (
+                        <a
+                          href={step.githubIssueUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="mt-3 inline-flex items-center gap-1.5 text-xs font-medium text-gray-600 hover:text-gray-900 transition-colors"
+                        >
+                          <Github className="w-3.5 h-3.5" />
+                          {step.githubIssueUrl.replace(/^https:\/\/github\.com\//, "")}
+                        </a>
                       )}
 
                       <div className="flex items-center gap-2 mt-4 pt-3 border-t border-gray-100">
@@ -695,6 +749,16 @@ export default function RoadmapReviewPage() {
                 />
               </div>
               <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">GitHub Issue Linki (opsiyonel)</label>
+                <input
+                  type="text"
+                  value={newStepForm.githubIssueUrl}
+                  onChange={(e) => setNewStepForm({ ...newStepForm, githubIssueUrl: e.target.value })}
+                  placeholder="https://github.com/kullanici/repo/issues/12"
+                  className="w-full border rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-purple-300 focus:border-purple-400 outline-none"
+                />
+              </div>
+              <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">Kaynaklar</label>
                 <div className="space-y-2">
                   {newStepForm.resources.map((res, i) => (
@@ -734,7 +798,7 @@ export default function RoadmapReviewPage() {
                 <button
                   onClick={() => {
                     setShowAddForm(false);
-                    setNewStepForm({ title: "", description: "", estimatedHours: 2, resources: [""] });
+                    setNewStepForm({ title: "", description: "", estimatedHours: 2, resources: [""], githubIssueUrl: "" });
                   }}
                   className="px-4 py-2 text-sm text-gray-600 hover:text-gray-900 font-medium"
                 >

--- a/src/app/api/mentor/roadmap/[roadmapId]/steps/route.test.ts
+++ b/src/app/api/mentor/roadmap/[roadmapId]/steps/route.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, prismaMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  prismaMock: {
+    roadmap: { findUnique: vi.fn() },
+    roadmapStep: { findFirst: vi.fn(), create: vi.fn() },
+  },
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+
+import { POST } from "./route";
+
+function authMentor() {
+  requireAuthMock.mockResolvedValue({
+    authorized: true,
+    session: { user: { id: "mentor-1", role: "MENTOR" } },
+  });
+}
+function postReq(body: unknown) {
+  return new Request("http://test/api/mentor/roadmap/rm-1/steps", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+const ctx = { params: Promise.resolve({ roadmapId: "rm-1" }) };
+const validBody = { title: "Adım", description: "Açıklama" };
+
+describe("POST /api/mentor/roadmap/[roadmapId]/steps — githubIssueUrl (#50)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.roadmap.findUnique.mockResolvedValue({
+      id: "rm-1",
+      assignedProject: { studentProfile: { mentorId: "mentor-1" } },
+    });
+    prismaMock.roadmapStep.findFirst.mockResolvedValue(null);
+    prismaMock.roadmapStep.create.mockResolvedValue({ id: "step-1" });
+  });
+
+  it("geçerli github.com issue URL'i ile 201 döner", async () => {
+    authMentor();
+
+    const res = await POST(
+      postReq({ ...validBody, githubIssueUrl: "https://github.com/kullanici/repo/issues/12" }),
+      ctx,
+    );
+
+    expect(res.status).toBe(201);
+    const arg = prismaMock.roadmapStep.create.mock.calls[0][0];
+    expect(arg.data.githubIssueUrl).toBe("https://github.com/kullanici/repo/issues/12");
+  });
+
+  it("geçersiz URL ile 400 döner, create çağrılmaz", async () => {
+    authMentor();
+
+    const res = await POST(postReq({ ...validBody, githubIssueUrl: "not-a-url" }), ctx);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error.githubIssueUrl).toBeTruthy();
+    expect(prismaMock.roadmapStep.create).not.toHaveBeenCalled();
+  });
+
+  it("githubIssueUrl belirtilmeden 201 döner (opsiyonel)", async () => {
+    authMentor();
+
+    const res = await POST(postReq(validBody), ctx);
+
+    expect(res.status).toBe(201);
+  });
+
+  it("başka mentor'un roadmap'ine adım eklemeye çalışırsa 403", async () => {
+    authMentor();
+    prismaMock.roadmap.findUnique.mockResolvedValue({
+      id: "rm-1",
+      assignedProject: { studentProfile: { mentorId: "baska-mentor" } },
+    });
+
+    const res = await POST(postReq(validBody), ctx);
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/app/api/mentor/roadmap/[roadmapId]/steps/route.ts
+++ b/src/app/api/mentor/roadmap/[roadmapId]/steps/route.ts
@@ -60,6 +60,7 @@ export async function POST(
         description: parsed.data.description,
         estimatedHours: parsed.data.estimatedHours || null,
         resources: parsed.data.resources || [],
+        githubIssueUrl: parsed.data.githubIssueUrl || null,
         status: "TODO",
       },
     });

--- a/src/features/student/ui/RoadmapSteps.tsx
+++ b/src/features/student/ui/RoadmapSteps.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { CheckCircle2, PlayCircle, Lock, ExternalLink, Loader2 } from "lucide-react";
+import { CheckCircle2, PlayCircle, Lock, ExternalLink, Loader2, Github } from "lucide-react";
 import { StepComments } from "@/features/messaging/ui/StepComments";
 import { StepFiles } from "@/features/files/ui/StepFiles";
 import { toast } from "sonner";
@@ -15,6 +15,7 @@ type Step = {
   status: string;
   estimatedHours: number | null;
   resources: string[];
+  githubIssueUrl?: string | null;
 };
 
 type Props = {
@@ -144,6 +145,19 @@ export function RoadmapSteps({ steps, isDraft, currentUserId, currentUserRole }:
                   <p className="text-xs text-slate-400 mt-2">
                     Tahmini süre: ~{step.estimatedHours} saat
                   </p>
+                )}
+
+                {/* GitHub Issue Linki */}
+                {!isLocked && step.githubIssueUrl && (
+                  <a
+                    href={step.githubIssueUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center text-xs font-medium text-slate-600 hover:text-blue-600 transition-colors mt-2"
+                  >
+                    <Github className="w-3.5 h-3.5 mr-1.5" />
+                    GitHub Issue&apos;yu Görüntüle
+                  </a>
                 )}
 
                 {/* Kilitli mesajı */}

--- a/src/lib/validations/api.test.ts
+++ b/src/lib/validations/api.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { createStepSchema, updateStepSchema } from "./api";
+
+const validBase = {
+  title: "Adım",
+  description: "Açıklama",
+};
+
+describe("createStepSchema — githubIssueUrl (#50)", () => {
+  it("geçerli github.com issue URL'ini kabul eder", () => {
+    const result = createStepSchema.safeParse({
+      ...validBase,
+      githubIssueUrl: "https://github.com/kullanici/repo/issues/12",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("issue numarası olmayan repo URL'ini reddeder", () => {
+    const result = createStepSchema.safeParse({
+      ...validBase,
+      githubIssueUrl: "https://github.com/kullanici/repo",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("sayısal olmayan issue numarasını reddeder", () => {
+    const result = createStepSchema.safeParse({
+      ...validBase,
+      githubIssueUrl: "https://github.com/kullanici/repo/issues/abc",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("github.com olmayan domaini reddeder", () => {
+    const result = createStepSchema.safeParse({
+      ...validBase,
+      githubIssueUrl: "https://gitlab.com/kullanici/repo/issues/12",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("pull request linkini reddeder (issues değil)", () => {
+    const result = createStepSchema.safeParse({
+      ...validBase,
+      githubIssueUrl: "https://github.com/kullanici/repo/pull/12",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("bozuk URL'i reddeder", () => {
+    const result = createStepSchema.safeParse({ ...validBase, githubIssueUrl: "not-a-url" });
+    expect(result.success).toBe(false);
+  });
+
+  it("null / undefined / alan yok — opsiyonel olduğu için geçerli", () => {
+    expect(createStepSchema.safeParse({ ...validBase, githubIssueUrl: null }).success).toBe(true);
+    expect(createStepSchema.safeParse({ ...validBase, githubIssueUrl: undefined }).success).toBe(true);
+    expect(createStepSchema.safeParse(validBase).success).toBe(true);
+  });
+});
+
+describe("updateStepSchema — githubIssueUrl (#50)", () => {
+  it("yalnızca githubIssueUrl güncellemesi geçerli", () => {
+    const result = updateStepSchema.safeParse({
+      githubIssueUrl: "https://github.com/kullanici/repo/issues/1",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("geçersiz URL güncellemede de reddedilir", () => {
+    const result = updateStepSchema.safeParse({ githubIssueUrl: "ftp://github.com/a/b/issues/1" });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/lib/validations/api.ts
+++ b/src/lib/validations/api.ts
@@ -94,12 +94,30 @@ export const updateRoadmapSchema = z.object({
   status: z.enum(["DRAFT", "PUBLISHED"]).optional(),
 });
 
+// #50: GitHub issue URL — https://github.com/<owner>/<repo>/issues/<number> formatı zorunlu.
+const githubIssueUrlSchema = z
+  .string()
+  .trim()
+  .refine((val) => {
+    try {
+      const url = new URL(val);
+      if (url.protocol !== "https:" || url.hostname !== "github.com") return false;
+      const segments = url.pathname.split("/").filter(Boolean);
+      return segments.length === 4 && segments[2] === "issues" && /^\d+$/.test(segments[3]);
+    } catch {
+      return false;
+    }
+  }, "Geçerli bir GitHub issue URL'i girin (ör: https://github.com/kullanici/repo/issues/12)")
+  .nullable()
+  .optional();
+
 // Mentor: Roadmap adım ekleme
 export const createStepSchema = z.object({
   title: z.string().min(1, "Başlık zorunlu"),
   description: z.string().min(1, "Açıklama zorunlu"),
   estimatedHours: z.number().int().positive().optional().nullable(),
   resources: z.array(z.string()).default([]),
+  githubIssueUrl: githubIssueUrlSchema,
 });
 
 // Mentor: Roadmap adım güncelleme
@@ -110,6 +128,7 @@ export const updateStepSchema = z.object({
   resources: z.array(z.string()).optional(),
   order: z.number().int().positive().optional(),
   status: z.enum(["TODO", "IN_PROGRESS", "COMPLETED"]).optional(),
+  githubIssueUrl: githubIssueUrlSchema,
 });
 
 // Mentor: Proje kaldırma


### PR DESCRIPTION
## Özet
Issue #50: Mentor bir roadmap adımına **GitHub issue linki** ekleyebilir/güncelleyebilir; öğrenci bu linki roadmap üzerinde görebilir. (#49'un `ProjectTemplate.githubRepoUrl`'ünden bağımsız — bu PR kavramsal olarak ilişkili ama teknik bağımlılığı yok, temiz `develop`'tan açıldı.)

## Değişiklikler
- **`prisma/schema.prisma` + migration** — `RoadmapStep.githubIssueUrl` (opsiyonel, nullable `TEXT`). Basit `ADD COLUMN`.
- **`lib/validations/api.ts`** — `githubIssueUrlSchema`: yalnızca **`https://github.com/<owner>/<repo>/issues/<number>`** formatı kabul edilir (repo linkinden daha spesifik — pull request/repo-only linkleri reddedilir). `createStepSchema`/`updateStepSchema`'ya eklendi.
- **`api/mentor/roadmap/[roadmapId]/steps` (POST)** — alan eşlemesine `githubIssueUrl` eklendi (`PUT` route'u zaten `parsed.data`'yı spread ile geçiriyordu, otomatik aktı).
- **Mentor roadmap editörü** (`roadmap/[roadmapId]/page.tsx`) — hem "adım düzenle" hem "yeni adım ekle" formuna input; boş string → `null` dönüşümü; submit başarısız olursa **toast** (önceden hata sessizce yutuluyordu — #49'daki gibi aynı boşluğu burada da düzelttim); görüntüleme modunda GitHub ikonlu link.
- **Öğrenci `RoadmapSteps.tsx`** — kilitli olmayan adımlarda (`!isLocked`, diğer alanlarla tutarlı) "GitHub Issue'yu Görüntüle" linki. Alan boşsa hiçbir şey render edilmez → mevcut UI bozulmaz (AC4).

## Prisma tip çıkarımı notu
Hem mentor GET `/api/mentor/roadmap/[roadmapId]` hem öğrenci `student-dashboard` sorgusu `steps: { orderBy: ... }` kullanıyor (select kısıtlaması yok) — yeni alan **otomatik** akıyor, okuma tarafında route değişikliği gerekmedi.

## Test
- `src/lib/validations/api.test.ts` — URL validasyonu: geçerli issue linki, issue no'suz repo linki, sayısal olmayan no, yanlış domain, pull request linki, bozuk URL, opsiyonel (9 test).
- `src/app/api/mentor/roadmap/[roadmapId]/steps/route.test.ts` — POST uçtan uca: 201/400/opsiyonel/başka mentor→403 (4 test).
- `npm test` (69/69 yeşil) · `npm run lint` (0 hata) · `npm run build` ✓

## Acceptance Criteria
- [x] Roadmap step GitHub issue linki saklayabilir
- [x] Mentor step issue linkini ekleyebilir/güncelleyebilir
- [x] Öğrenci issue linkini roadmap adımında görebilir
- [x] Issue alanı boşsa mevcut roadmap UI bozulmaz

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)