### PR TITLE
chore: merge sonrası GitHub/profil PR'larını sertleştir

### DIFF
--- a/src/app/(admin)/admin-dashboard/page.tsx
+++ b/src/app/(admin)/admin-dashboard/page.tsx
@@ -22,7 +22,11 @@ import {
 import { toast } from "sonner";
 import LogoutButton from "@/components/LogoutButton";
 import { UnreadBadge } from "@/features/messaging/ui/UnreadBadge";
-import { ProfileAnalysisCard, type ProfileAnalysisData } from "@/features/ai/ui/ProfileAnalysisCard";
+import {
+  ProfileAnalysisCard,
+  parseProfileAnalysisApiResponse,
+  type ProfileAnalysisData,
+} from "@/features/ai/ui/ProfileAnalysisCard";
 
 type User = {
   id: string;
@@ -77,15 +81,12 @@ export default function AdminDashboard() {
     setAnalysisLoading(true);
     try {
       const res = await fetch(`/api/admin/students/${user.id}/profile-analysis`);
-      if (res.ok) {
-        const data = await res.json();
-        setAnalysisData(data.analysis);
-      } else {
-        const data = await res.json().catch(() => null);
-        setAnalysisError(
-          (data && typeof data.error === "string" && data.error) || "Analiz yüklenemedi.",
-        );
-      }
+      const body = await res.json().catch(() => null);
+      // #83: Yorumlama saf bir fonksiyona taşındı — "analiz yok" (ok+null) ile
+      // "istek başarısız oldu" (!ok) net ayrılıyor ve ayrı test ediliyor.
+      const { analysis, error } = parseProfileAnalysisApiResponse(res.ok, body);
+      setAnalysisData(analysis);
+      setAnalysisError(error);
     } catch {
       setAnalysisError("Bağlantı hatası. Lütfen tekrar deneyin.");
     } finally {

--- a/src/app/(student)/profile-setup/page.tsx
+++ b/src/app/(student)/profile-setup/page.tsx
@@ -20,8 +20,12 @@ export default async function ProfileSetupPage() {
   });
 
   // #46: Admin'in tanımladığı aktif anket sorularını göster. Hata olursa form
-  // mevcut akışı bozmadan çalışmalı → boş dizi ile devam et (soru adımı gizlenir).
+  // mevcut akışı bozmadan çalışmalı → boş dizi ile devam et.
+  // #83: Ama "gerçekten hiç soru yok" ile "yükleme başarısız oldu" aynı boş
+  // diziyle sonuçlanmasın diye ayrı bir flag taşınıyor — form bunu görüp
+  // kullanıcıya açık bir hata mesajı gösterebiliyor.
   let surveyQuestions: SurveyQuestionView[] = [];
+  let surveyLoadFailed = false;
   try {
     const questions = await listSurveyQuestions({ activeOnly: true });
     surveyQuestions = questions.map((q) => ({
@@ -31,6 +35,7 @@ export default async function ProfileSetupPage() {
     }));
   } catch (error) {
     console.error("profile-setup: anket soruları yüklenemedi", error);
+    surveyLoadFailed = true;
   }
 
   return (
@@ -41,6 +46,7 @@ export default async function ProfileSetupPage() {
         phoneNumber: user?.phone ?? undefined,
       }}
       surveyQuestions={surveyQuestions}
+      surveyLoadFailed={surveyLoadFailed}
     />
   );
 }

--- a/src/features/ai/ui/ProfileAnalysisCard.test.ts
+++ b/src/features/ai/ui/ProfileAnalysisCard.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveProfileAnalysisViewState,
+  parseProfileAnalysisApiResponse,
+  type ProfileAnalysisData,
+} from "./ProfileAnalysisCard";
+
+const sampleAnalysis: ProfileAnalysisData = {
+  level: "Orta",
+  summary: "özet",
+  strengths: [],
+  developmentAreas: [],
+  technicalTracks: [],
+  recommendedPath: "",
+  recommendations: [],
+};
+
+describe("resolveProfileAnalysisViewState (#83)", () => {
+  it("loading=true iken her zaman 'loading' döner (error/analysis olsa bile)", () => {
+    expect(resolveProfileAnalysisViewState({ analysis: null, loading: true, error: null })).toBe(
+      "loading",
+    );
+    expect(
+      resolveProfileAnalysisViewState({ analysis: sampleAnalysis, loading: true, error: "hata" }),
+    ).toBe("loading");
+  });
+
+  it("loading=false + error varsa 'error' döner (analysis olsa bile)", () => {
+    expect(
+      resolveProfileAnalysisViewState({ analysis: null, loading: false, error: "Bağlantı hatası" }),
+    ).toBe("error");
+    expect(
+      resolveProfileAnalysisViewState({
+        analysis: sampleAnalysis,
+        loading: false,
+        error: "Bağlantı hatası",
+      }),
+    ).toBe("error");
+  });
+
+  it("hata yok + analiz yok (null/undefined) → 'empty' — 'fetch başarısız' ile karışmaz", () => {
+    expect(resolveProfileAnalysisViewState({ analysis: null, loading: false, error: null })).toBe(
+      "empty",
+    );
+    expect(
+      resolveProfileAnalysisViewState({ analysis: undefined, loading: false, error: undefined }),
+    ).toBe("empty");
+  });
+
+  it("hata yok + analiz var → 'data'", () => {
+    expect(
+      resolveProfileAnalysisViewState({ analysis: sampleAnalysis, loading: false, error: null }),
+    ).toBe("data");
+  });
+
+  it("loading/error belirtilmezse (undefined) analiz varlığına göre karar verir", () => {
+    expect(resolveProfileAnalysisViewState({ analysis: sampleAnalysis })).toBe("data");
+    expect(resolveProfileAnalysisViewState({ analysis: null })).toBe("empty");
+  });
+});
+
+describe("parseProfileAnalysisApiResponse (#83)", () => {
+  it("ok + analysis:null → analiz yok (empty) — HATA DEĞİL", () => {
+    const result = parseProfileAnalysisApiResponse(true, { analysis: null });
+    expect(result).toEqual({ analysis: null, error: null });
+  });
+
+  it("ok + analysis:{...} → analiz döner, error null", () => {
+    const result = parseProfileAnalysisApiResponse(true, { analysis: sampleAnalysis });
+    expect(result).toEqual({ analysis: sampleAnalysis, error: null });
+  });
+
+  it("!ok + string error (404/400 mesajı) → error döner, analysis null", () => {
+    const result = parseProfileAnalysisApiResponse(false, { error: "Öğrenci profili bulunamadı." });
+    expect(result).toEqual({ analysis: null, error: "Öğrenci profili bulunamadı." });
+  });
+
+  it("!ok + body yok/boş → fallback mesaj", () => {
+    expect(parseProfileAnalysisApiResponse(false, null)).toEqual({
+      analysis: null,
+      error: "Analiz yüklenemedi.",
+    });
+    expect(parseProfileAnalysisApiResponse(false, {})).toEqual({
+      analysis: null,
+      error: "Analiz yüklenemedi.",
+    });
+  });
+
+  it("ok=true ama body null (beklenmeyen şekil) → yine de empty sayılır, error atılmaz", () => {
+    // Sunucu her zaman {analysis: ...} döner ama savunma amaçlı: ok=true iken
+    // asla error state'ine düşülmemeli.
+    expect(parseProfileAnalysisApiResponse(true, null)).toEqual({ analysis: null, error: null });
+  });
+});

--- a/src/features/ai/ui/ProfileAnalysisCard.tsx
+++ b/src/features/ai/ui/ProfileAnalysisCard.tsx
@@ -20,8 +20,49 @@ type Props = {
   error?: string | null;
 };
 
+export type ProfileAnalysisViewState = "loading" | "error" | "empty" | "data";
+
+/**
+ * #83: Kartın hangi durumu göstereceğine karar veren saf fonksiyon — bileşenden
+ * ayrı test edilebilsin diye çıkarıldı. Öncelik sırası kasıtlı ve sabit:
+ * loading > error > empty > data. Örn. loading sırasında eski bir error/analysis
+ * hâlâ prop'larda olsa bile loading gösterilir (yarış durumu / stale veri karışmasın).
+ */
+export function resolveProfileAnalysisViewState(
+  props: Pick<Props, "analysis" | "loading" | "error">,
+): ProfileAnalysisViewState {
+  if (props.loading) return "loading";
+  if (props.error) return "error";
+  if (!props.analysis) return "empty";
+  return "data";
+}
+
+/**
+ * #83: `GET /api/admin/students/[studentId]/profile-analysis` yanıtını yorumlayan
+ * saf fonksiyon (fetch/IO'dan ayrık, test edilebilir). API sözleşmesi:
+ * - ok + `{analysis: null}`  → analiz henüz üretilmemiş (empty state, HATA DEĞİL).
+ * - ok + `{analysis: {...}}` → analiz bulundu.
+ * - !ok                      → gerçek hata (404 profil yok, 500 vb.) — mesaj gösterilir.
+ * Bu ayrım olmadan "analiz yok" ile "istek başarısız oldu" birbirine karışabilir.
+ */
+export function parseProfileAnalysisApiResponse(
+  ok: boolean,
+  body: { analysis?: ProfileAnalysisData | null; error?: unknown } | null,
+): { analysis: ProfileAnalysisData | null; error: string | null } {
+  if (ok) {
+    return { analysis: body?.analysis ?? null, error: null };
+  }
+  const message =
+    body && typeof body.error === "string" && body.error.trim().length > 0
+      ? body.error
+      : "Analiz yüklenemedi.";
+  return { analysis: null, error: message };
+}
+
 export function ProfileAnalysisCard({ analysis, loading, error }: Props) {
-  if (loading) {
+  const viewState = resolveProfileAnalysisViewState({ analysis, loading, error });
+
+  if (viewState === "loading") {
     return (
       <div className="bg-white rounded-xl border border-slate-200 p-8 flex items-center justify-center gap-3 text-slate-500">
         <Loader2 className="w-5 h-5 animate-spin" />
@@ -30,7 +71,7 @@ export function ProfileAnalysisCard({ analysis, loading, error }: Props) {
     );
   }
 
-  if (error) {
+  if (viewState === "error") {
     return (
       <div className="bg-white rounded-xl border border-red-200 p-8 flex flex-col items-center justify-center gap-2 text-center">
         <AlertCircle className="w-6 h-6 text-red-500" />
@@ -39,7 +80,7 @@ export function ProfileAnalysisCard({ analysis, loading, error }: Props) {
     );
   }
 
-  if (!analysis) {
+  if (viewState === "empty" || !analysis) {
     return (
       <div className="bg-white rounded-xl border border-slate-200 p-8 flex flex-col items-center justify-center gap-2 text-center">
         <Sparkles className="w-6 h-6 text-slate-300" />

--- a/src/features/student/ui/OnboardingForm.tsx
+++ b/src/features/student/ui/OnboardingForm.tsx
@@ -8,9 +8,13 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { saveOnboarding } from "@/features/student/server/onboarding";
-import { CheckCircle, User, Target, Award, ArrowRight, ArrowLeft, Rocket, Terminal, BookOpen, Clock, ClipboardList } from "lucide-react";
+import { CheckCircle, User, Target, Award, ArrowRight, ArrowLeft, Rocket, Terminal, BookOpen, Clock, ClipboardList, AlertCircle } from "lucide-react";
 import { toast } from "sonner";
-import { buildSurveyAnswerPayload, type SurveyQuestionView } from "@/features/survey/answers";
+import {
+  buildSurveyAnswerPayload,
+  extractSurveyErrorMessage,
+  type SurveyQuestionView,
+} from "@/features/survey/answers";
 
 import type { FieldPath } from "react-hook-form";
 
@@ -75,12 +79,19 @@ type OnboardingInitialValues = {
 export default function OnboardingForm({
   initial,
   surveyQuestions = [],
+  surveyLoadFailed = false,
 }: {
   initial?: OnboardingInitialValues;
   surveyQuestions?: SurveyQuestionView[];
+  /** #83: Sorular admin tarafından tanımlanmamış (gerçek boş) mu, yoksa fetch mi
+   *  başarısız oldu? İkisi de surveyQuestions=[] ile sonuçlanır; bu flag onları
+   *  ayırt eder — fetch hatasında adım gizlenmez, açık bir hata mesajı gösterir. */
+  surveyLoadFailed?: boolean;
 } = {}) {
   // #46: Admin anket soruları varsa forma ek bir "Ek Sorular" adımı eklenir.
-  const hasSurvey = surveyQuestions.length > 0;
+  // #83: Sorular yüklenemediyse de (gerçek boş değilse) adım gösterilir — kullanıcı
+  // hatayı görsün, adımın "hiç soru yokmuş" gibi sessizce kaybolması yerine.
+  const hasSurvey = surveyQuestions.length > 0 || surveyLoadFailed;
   const allSteps = hasSurvey
     ? [
         ...steps,
@@ -183,9 +194,9 @@ export default function OnboardingForm({
         });
         if (!res.ok) {
           const data = await res.json().catch(() => null);
-          const msg =
-            data && typeof data.error === "string" ? data.error : "Anket cevapları kaydedilemedi.";
-          toast.error(msg);
+          // #83: Hata hem düz string (SurveyValidationError/500) hem zod fieldErrors
+          // objesi (400 validation) olarak gelebilir — ikisi de doğru gösterilsin.
+          toast.error(extractSurveyErrorMessage(data?.error, "Anket cevapları kaydedilemedi."));
           return; // Profil kaydedildi; kullanıcı cevapları tekrar gönderebilir.
         }
       }
@@ -407,6 +418,17 @@ export default function OnboardingForm({
             {/* ADIM 4 (opsiyonel): ADMIN ANKET SORULARI */}
             {hasSurvey && step === allSteps.length - 1 && (
               <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-500">
+                {/* #83: Sorular yüklenemedi (fetch hatası) — "hiç soru yok" ile
+                    karıştırılmasın diye açık bir uyarı gösterilir. */}
+                {surveyLoadFailed && (
+                  <div className="flex items-start gap-3 p-4 bg-amber-50 border border-amber-200 rounded-xl">
+                    <AlertCircle className="w-5 h-5 text-amber-600 shrink-0 mt-0.5" />
+                    <p className="text-sm text-amber-800">
+                      Ek sorular şu anda yüklenemedi. Bu adımı boş bırakarak kayıt işlemine devam edebilirsiniz;
+                      sorunu daha sonra profilinizden yanıtlayabilirsiniz.
+                    </p>
+                  </div>
+                )}
                 {surveyQuestions.map((q) => (
                   <div key={q.id} className="space-y-3">
                     <label className="block text-sm font-semibold text-gray-700">{q.question}</label>
@@ -440,7 +462,9 @@ export default function OnboardingForm({
                     )}
                   </div>
                 ))}
-                <p className="text-xs text-gray-400">Bu sorular opsiyoneldir; boş bırakabilirsiniz.</p>
+                {surveyQuestions.length > 0 && (
+                  <p className="text-xs text-gray-400">Bu sorular opsiyoneldir; boş bırakabilirsiniz.</p>
+                )}
               </div>
             )}
 

--- a/src/features/survey/answers.test.ts
+++ b/src/features/survey/answers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildSurveyAnswerPayload } from "./answers";
+import { buildSurveyAnswerPayload, extractSurveyErrorMessage } from "./answers";
 
 describe("buildSurveyAnswerPayload (#46)", () => {
   it("dolu cevapları {questionId, answer} dizisine çevirir", () => {
@@ -24,5 +24,37 @@ describe("buildSurveyAnswerPayload (#46)", () => {
   it("hiç dolu cevap yoksa boş dizi döner", () => {
     expect(buildSurveyAnswerPayload({ q1: "", q2: "   " })).toEqual([]);
     expect(buildSurveyAnswerPayload({})).toEqual([]);
+  });
+});
+
+describe("extractSurveyErrorMessage (#83)", () => {
+  it("düz string hatayı olduğu gibi döner (SurveyValidationError/500)", () => {
+    expect(extractSurveyErrorMessage("Öğrenci profili bulunamadı.", "fallback")).toBe(
+      "Öğrenci profili bulunamadı.",
+    );
+  });
+
+  it("zod fieldErrors objesindeki ilk mesajı çıkarır (400 validation) — önceki bug", () => {
+    // Önceki kod yalnızca string kontrolü yapıyordu; obje gelince bu mesaj
+    // kayboluyor ve kullanıcı genel/anlamsız bir hata görüyordu.
+    expect(extractSurveyErrorMessage({ answers: ["En az bir cevap gerekli"] }, "fallback")).toBe(
+      "En az bir cevap gerekli",
+    );
+  });
+
+  it("birden fazla alan hatası varsa ilkini döner", () => {
+    expect(
+      extractSurveyErrorMessage(
+        { answers: ["Hata 1"], other: ["Hata 2"] },
+        "fallback",
+      ),
+    ).toBe("Hata 1");
+  });
+
+  it("tanınmayan şekil (null/undefined/boş obje) → fallback", () => {
+    expect(extractSurveyErrorMessage(null, "fallback")).toBe("fallback");
+    expect(extractSurveyErrorMessage(undefined, "fallback")).toBe("fallback");
+    expect(extractSurveyErrorMessage({}, "fallback")).toBe("fallback");
+    expect(extractSurveyErrorMessage("", "fallback")).toBe("fallback");
   });
 });

--- a/src/features/survey/answers.ts
+++ b/src/features/survey/answers.ts
@@ -22,3 +22,24 @@ export function buildSurveyAnswerPayload(
     .map(([questionId, answer]) => ({ questionId, answer: answer.trim() }))
     .filter((a) => a.answer.length > 0);
 }
+
+/**
+ * #83: POST /api/student/survey-answers hatasını okunabilir tek mesaja indirger.
+ * Hata iki şekilde gelebilir: düz string (SurveyValidationError/500) veya zod
+ * fieldErrors objesi (`{ answers: ["mesaj"] }`, 400 validation). Önceki kod
+ * yalnızca string'i kontrol ediyordu; obje gelince genel/anlamsız bir mesaja
+ * düşüyordu — validation hatası kullanıcıya görünmüyordu.
+ */
+export function extractSurveyErrorMessage(
+  errorField: unknown,
+  fallback: string,
+): string {
+  if (typeof errorField === "string" && errorField.trim().length > 0) {
+    return errorField;
+  }
+  if (errorField && typeof errorField === "object") {
+    const firstMessage = Object.values(errorField as Record<string, unknown>).flat()[0];
+    if (firstMessage) return String(firstMessage);
+  }
+  return fallback;
+}

--- a/src/lib/validations/api.test.ts
+++ b/src/lib/validations/api.test.ts
@@ -50,6 +50,37 @@ describe("createTemplateSchema — githubRepoUrl (#49)", () => {
     expect(result.success).toBe(false);
   });
 
+  it("#83: repo kökünden daha derin yolları reddeder (tree/issues/pull)", () => {
+    for (const url of [
+      "https://github.com/kullanici/repo/tree/main",
+      "https://github.com/kullanici/repo/issues/1",
+      "https://github.com/kullanici/repo/pull/1",
+      "https://github.com/kullanici/repo/blob/main/README.md",
+    ]) {
+      expect(createTemplateSchema.safeParse({ ...templateBase, githubRepoUrl: url }).success).toBe(
+        false,
+      );
+    }
+  });
+
+  it("#83: yalnızca tam repo kökünü (owner/repo) kabul eder", () => {
+    expect(
+      createTemplateSchema.safeParse({
+        ...templateBase,
+        githubRepoUrl: "https://github.com/kullanici/repo",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("#83: sondaki / repo kökü kabulünü bozmaz", () => {
+    expect(
+      createTemplateSchema.safeParse({
+        ...templateBase,
+        githubRepoUrl: "https://github.com/kullanici/repo/",
+      }).success,
+    ).toBe(true);
+  });
+
   it("http (https değil) reddedilir", () => {
     const result = createTemplateSchema.safeParse({
       ...templateBase,

--- a/src/lib/validations/api.ts
+++ b/src/lib/validations/api.ts
@@ -63,8 +63,10 @@ const githubRepoUrlSchema = z
     try {
       const url = new URL(val);
       if (url.protocol !== "https:" || url.hostname !== "github.com") return false;
+      // #83: Yalnızca repo kökü (owner/repo) kabul edilir; tree/issues/pull gibi
+      // daha derin yollar reddedilir (önceki >=2 kontrolü bunları da geçiriyordu).
       const segments = url.pathname.split("/").filter(Boolean);
-      return segments.length >= 2;
+      return segments.length === 2;
     } catch {
       return false;
     }


### PR DESCRIPTION
## Özet
Issue #83: PR #78/#79/#80/#81/#82 merge edildi ama üç sertleştirme boşluğu kalmıştı. Bu PR üçünü de kapatıyor.

## 1) `githubRepoUrl` validasyonu çok gevşekti (#81)
**Bug:** `segments.length >= 2` kontrolü `https://github.com/owner/repo/tree/main` gibi (4 segment) URL'leri de geçiriyordu — "yalnızca repo kökü" garantisi yoktu.
**Düzeltme:** `segments.length === 2`. `tree`, `issues`, `pull`, `blob` gibi daha derin yollar artık reddediliyor; sondaki `/` repo kökü kabulünü bozmuyor.

## 2) Anket akışı (#78)
- **Fetch hatası "hiç soru yok" ile karışıyordu:** `profile-setup/page.tsx`'te `listSurveyQuestions` hata verirse `surveyQuestions = []` ile devam ediliyordu — bu, "admin hiç aktif soru tanımlamamış" durumuyla **aynı** görünüyordu, kullanıcı hiçbir şey fark etmiyordu. Artık `surveyLoadFailed` flag'i taşınıyor; `OnboardingForm` adımı gizlemek yerine açık bir uyarı gösteriyor ("Ek sorular şu anda yüklenemedi... boş bırakarak devam edebilirsiniz").
- **Validation hatası görünmüyordu:** Cevap gönderme hatası yalnızca `typeof data.error === "string"` kontrolü yapıyordu. Zod validation hatası (400) `{ answers: ["mesaj"] }` **objesi** olarak geliyor — bu durumda kullanıcı gerçek sebep yerine genel "Anket cevapları kaydedilemedi." mesajını görüyordu. `extractSurveyErrorMessage` (yeni, `features/survey/answers.ts`) iki şekli de doğru okunabilir mesaja çeviriyor.

## 3) AI analiz gösterimi (#80)
Kod zaten loading/error/empty durumlarını doğru ayırıyordu (kontrol ettim — mantık hatası yoktu). Asıl eksik **regresyon testiydi**: bu ayrımın gelecekte bozulmayacağını garanti eden hiçbir test yoktu. İki saf fonksiyon çıkarıldı:
- `resolveProfileAnalysisViewState` — kartın önceliğini kilitler: **loading > error > empty > data**.
- `parseProfileAnalysisApiResponse` — admin modalının fetch yanıtını yorumlar: `ok+analysis:null` → **empty (hata değil)**; `!ok` → **error**. Bu ayrımı garanti altına alıyor.

## Test
- `githubRepoUrl` derin-yol reddi + sondaki `/` (2 yeni test).
- `extractSurveyErrorMessage` — string/obje/tanınmayan şekil (4 test).
- `resolveProfileAnalysisViewState` + `parseProfileAnalysisApiResponse` (10 test).
- `npm test` (110/110 yeşil) · `npm run lint` (0 hata) · `npm run build` ✓

## Acceptance Criteria
- [x] Survey setup, sorular yüklenemediğinde açık bir kullanıcı durumu gösterir
- [x] AI analiz UI'ı loading/empty/error'ı temiz ayırır (kod + artık test'le garanti)
- [x] Repository URL validasyonu root-olmayan GitHub URL'lerini reddedecek kadar sıkı
- [x] Yukarıdaki edge case'ler test kapsamında

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)