### PR TITLE
chore: birleşik demo seed verisi ekle

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,17 +392,18 @@ docker ps
 ```
 
 ## Seed Nasıl Çalıştırılır?
-🔹 Seed (Örnek Kullanıcıları Ekleme)
+🔹 Seed (Birleşik Demo Verisi)
 
-- Bu adımlar, Lokal geliştirme sırasında veritabanına hızlıca test edilebilecek 3 örnek kullanıcı eklemek için kullanılır.Seed script’i idempotent çalışır, yani aynı script tekrar tekrar çalıştırıldığında kullanıcılar çoğalmaz.
-
+- `npm run seed`, lokal geliştirme sırasında hızlıca test edilebilecek bir demo ortamı kurar:
+  - `admin@example.com` / `mentor@example.com` / `student@example.com` kullanıcıları,
+  - Student'ın Mentor'a atanmış bir `StudentProfile`'ı (deneyim seviyesi, ilgi alanı, hedef, uygunluk),
+  - Örnek proje şablonları (`scripts/seed-projects.ts`'ten, `seed.ts` tarafından çağrılır).
 - Şifreler güvenli şekilde **argon2** ile hashlenir.
-- Prisma Client kullanılarak veritabanına bağlantı sağlanır.
-
+- Script tamamen idempotent'tir — kullanıcılar `upsert`, profil `upsert`, proje şablonları title'a göre varlık kontrolüyle oluşturulur. Tekrar çalıştırmak duplicate veri üretmez.
 
 **Seed Script Çalıştırma**
 
-Seed’i çalıştırmak için terminalden proje klasöründe şu komutu çalıştır:
+Seed'i çalıştırmak için terminalden proje klasöründe şu komutu çalıştır:
 ```
 npm run seed
 ```
@@ -413,8 +414,13 @@ Script çalıştığında terminalde şöyle bir çıktı görürsün:
 ✅ ADMIN user created: admin@example.com
 ✅ MENTOR user created: mentor@example.com
 ✅ STUDENT user created: student@example.com
-Seed process completed! 3 users added!
+✅ Student, mentor'a atandı: student@example.com → mentor@example.com
+✅ Proje şablonu eklendi: Kişisel Portföy Web Sitesi
+...
+🎉 Seed tamamlandı — admin/mentor/student kullanıcıları, mentor-stajyer ataması ve proje şablonları hazır.
 ```
+
+Sadece proje şablonlarını ayrıca eklemek/kontrol etmek istersen (örn. mevcut bir DB'ye): `tsx scripts/seed-projects.ts`.
 
 ## Kimlik Doğrulama (NextAuth)
 
@@ -745,7 +751,8 @@ Uygulama Next.js App Router mimarisiyle yapılandırılmıştır. Dosya sistemi 
 │   ├── migrations/           # Prisma migration dosyaları
 ├── public/                   # Statik dosyalar (favicon, resimler vs.)
 ├── scripts/
-│   └── seed.ts               # Test kullanıcılarını ekleyen seed script
+│   ├── seed.ts               # Birleşik demo seed (kullanıcılar + mentor-stajyer + proje şablonları)
+│   └── seed-projects.ts      # Örnek proje şablonları (seed.ts tarafından çağrılır)
 ├── src/
 │   ├── app/
 │   │   ├── (admin)/          # Admin'e özel route grubu
@@ -813,9 +820,9 @@ Uygulama Next.js App Router mimarisiyle yapılandırılmıştır. Dosya sistemi 
   - `User` ve `Role` modeli tanımlandı  
   - Prisma singleton (`src/lib/db.ts`) ile bağlantı yönetimi sağlandı
 
-***Seed sistemi***:  
-  - `npx prisma db seed` ile 1 admin, 1 mentor, 1 öğrenci oluşturuluyor  
-  - Şifreler hashlenmiş (`argon2`) ve veritabanına kaydediliyor  
+***Seed sistemi***:
+  - `npm run seed` ile 1 admin, 1 mentor, 1 öğrenci + mentor-stajyer ataması + örnek proje şablonları oluşturuluyor (birleşik, idempotent akış — bkz. "Seed Nasıl Çalıştırılır?")
+  - Şifreler hashlenmiş (`argon2`) ve veritabanına kaydediliyor
   - Test kullanıcıları: `admin@example.com`, `mentor@example.com`, `student@example.com`
 
  ***Kimlik doğrulama (Auth)***:  

--- a/scripts/seed-projects.ts
+++ b/scripts/seed-projects.ts
@@ -1,8 +1,11 @@
 import { PrismaClient } from "@prisma/client";
+import { pathToFileURL } from "url";
 
-const prisma = new PrismaClient();
-
-async function main() {
+/**
+ * #56: scripts/seed.ts tarafından çağrılır (birleşik seed akışı); ayrıca
+ * `tsx scripts/seed-projects.ts` ile tek başına da çalıştırılabilir.
+ */
+export async function seedProjectTemplates(prisma: PrismaClient): Promise<void> {
   const templates = [
     {
       title: "Kişisel Portföy Web Sitesi",
@@ -124,30 +127,51 @@ WebSocket teknolojisi kullanarak gerçek zamanlı mesajlaşma uygulaması geliş
     },
   ];
 
+  let createdCount = 0;
   for (const template of templates) {
-    await prisma.projectTemplate.upsert({
-      where: {
-        id: template.title, // will not match, forces create
-      },
-      update: {},
-      create: {
+    // #56: ProjectTemplate.id bir cuid, title bir unique constraint değil —
+    // önceki `upsert({ where: { id: template.title } })` asla eşleşmiyordu,
+    // her çalıştırmada yeni bir kayıt oluşturuyordu (duplicate). title'a göre
+    // varlık kontrolü yapıp yalnızca yoksa oluşturuyoruz.
+    const existing = await prisma.projectTemplate.findFirst({
+      where: { title: template.title },
+      select: { id: true },
+    });
+
+    if (existing) {
+      console.log(`⏭️  Zaten mevcut, atlandı: ${template.title}`);
+      continue;
+    }
+
+    await prisma.projectTemplate.create({
+      data: {
         title: template.title,
         description: template.description,
         track: template.track,
         difficulty: template.difficulty,
       },
     });
+    createdCount++;
     console.log(`✅ Proje şablonu eklendi: ${template.title}`);
   }
 
-  console.log(`\n🎉 Toplam ${templates.length} proje şablonu başarıyla eklendi!`);
+  console.log(
+    `\n🎉 Proje şablonları hazır: ${createdCount} yeni, ${templates.length - createdCount} zaten mevcuttu (toplam ${templates.length}).`,
+  );
 }
 
-main()
-  .catch((e) => {
-    console.error("❌ Seed hatası:", e);
-    process.exit(1);
-  })
-  .finally(async () => {
-    await prisma.$disconnect();
-  });
+// Doğrudan `tsx scripts/seed-projects.ts` ile çalıştırılırsa (import edildiğinde değil).
+const isRunDirectly =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isRunDirectly) {
+  const prisma = new PrismaClient();
+  seedProjectTemplates(prisma)
+    .catch((e) => {
+      console.error("❌ Seed hatası:", e);
+      process.exit(1);
+    })
+    .finally(async () => {
+      await prisma.$disconnect();
+    });
+}

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,26 +1,23 @@
 import { PrismaClient } from "@prisma/client";
 import { hash } from "@node-rs/argon2";
+import { seedProjectTemplates } from "./seed-projects";
 
 const prisma = new PrismaClient();
 
+// #56: Tek komutla (npm run seed) admin/mentor/student kullanıcıları, mentor-stajyer
+// ataması ve örnek proje şablonları oluşturan birleşik demo seed akışı. Tüm adımlar
+// upsert/varlık-kontrolü ile idempotent — tekrar çalıştırmak duplicate üretmez.
 async function main() {
-  // Örnek kullanıcılar - roller: ADMIN, MENTOR, STUDENT
   const users: { email: string; name: string; role: "ADMIN" | "MENTOR" | "STUDENT" }[] = [
     { email: "admin@example.com", name: "Admin User", role: "ADMIN" },
     { email: "mentor@example.com", name: "Mentor User", role: "MENTOR" },
     { email: "student@example.com", name: "Student User", role: "STUDENT" },
   ];
 
-  for (const user of users) {
-
-
-
-    // Şifreyi hashle (argon2 ile)
-  const password = 'geçici_şifre';
+  const password = "geçici_şifre";
   const hashedPassword = await hash(password);
 
-
-
+  for (const user of users) {
     // Idempotent işlem: upsert kullanıyoruz
     await prisma.user.upsert({
       where: { email: user.email }, // Benzersiz email kontrolü
@@ -32,13 +29,39 @@ async function main() {
         password: hashedPassword, // string hash
       },
     });
-
-
-    
     console.log(`✅ ${user.role} user created: ${user.email}`);
   }
 
-  console.log("Seed process completed! 3 users added!");
+  // #56: Student'ı mentor'a ata + demo için gerçekçi bir profil oluştur.
+  // StudentProfile.userId @unique olduğu için upsert idempotent.
+  const mentor = await prisma.user.findUniqueOrThrow({
+    where: { email: "mentor@example.com" },
+    select: { id: true },
+  });
+  const student = await prisma.user.findUniqueOrThrow({
+    where: { email: "student@example.com" },
+    select: { id: true },
+  });
+
+  await prisma.studentProfile.upsert({
+    where: { userId: student.id },
+    update: { mentorId: mentor.id },
+    create: {
+      userId: student.id,
+      mentorId: mentor.id,
+      experienceLevel: "BEGINNER", // #54: kanonik UPPERCASE
+      interests: ["Web Development"],
+      goals: "Demo amaçlı örnek stajyer profili — full-stack bir proje geliştirmeyi hedefliyor.",
+      availability: "part-time",
+      birthYear: 2002,
+    },
+  });
+  console.log(`✅ Student, mentor'a atandı: student@example.com → mentor@example.com`);
+
+  // #56: Proje şablonlarını (idempotent) oluştur.
+  await seedProjectTemplates(prisma);
+
+  console.log("\n🎉 Seed tamamlandı — admin/mentor/student kullanıcıları, mentor-stajyer ataması ve proje şablonları hazır.");
 }
 
 main()


### PR DESCRIPTION
## Özet
Issue #56: `npm run seed` yalnızca 3 kullanıcı oluşturuyordu; proje havuzu, mentor-stajyer ilişkisi eksikti ve `seed-projects.ts` ana akışa hiç bağlı değildi. Ayrıca `seed-projects.ts`'te gerçek bir **idempotency bug'ı** buldum.

## Bulunan bug
```ts
await prisma.projectTemplate.upsert({
  where: { id: template.title }, // will not match, forces create
  ...
});
```
`ProjectTemplate.id` bir cuid, `title` ise unique constraint'li değil — bu `where` **hiçbir zaman eşleşmiyordu**, yani `upsert` her çalıştırmada `create` dalına düşüyordu. Script'i iki kez çalıştırınca proje şablonları **duplicate** oluyordu. `title`'a göre `findFirst` + koşullu `create`'e çevirdim (schema değişikliği gerekmedi).

## Değişiklikler
- **`scripts/seed-projects.ts`** — idempotency bug'ı düzeltildi; `seedProjectTemplates(prisma)` olarak dışa açıldı (fonksiyon, kendi `PrismaClient`'ını değil parametre olarak alıyor). `tsx scripts/seed-projects.ts` ile **tek başına da** çalışabilirliği korundu — `pathToFileURL` ile Windows-uyumlu bir "doğrudan mı çalıştırıldı mı import mu edildi" kontrolü eklendi.
- **`scripts/seed.ts`** — `seedProjectTemplates` çağrısı eklendi; öğrencinin `StudentProfile`'ı (mentorId, deneyim seviyesi, ilgi alanı, hedef, uygunluk) `upsert` ile oluşturulup mentor'a atanıyor. Tüm adımlar idempotent (`upsert`/varlık kontrolü).
- **`README.md`** — "Seed Nasıl Çalıştırılır?" bölümü gerçek davranışla uyumlu hale getirildi; hiçbir zaman çalışmayan (`prisma.seed` config'i olmayan) `npx prisma db seed` referansı `npm run seed`'e düzeltildi; klasör yapısı `seed-projects.ts`'i yansıtıyor.

## Test
> ⚠️ **Not:** Bu ortamda Docker'da çalışan Postgres container'ı bu projeye ait değildi (farklı isim/image, `docker-compose.yml`'deki `aisigner_db` ile eşleşmiyordu) — başka bir çalışmaya müdahale etmemek için ona bağlanıp script'i canlı çalıştırmadım. `npm test` (93/93 yeşil, regresyon yok), `npm run lint` (0 hata), `npm run build` ✓ ve dikkatli kod incelemesiyle doğruladım.

### Manuel test adımları (idempotency)
1. `npm run seed` çalıştır → admin/mentor/student oluşur, mentor ataması yapılır, ~6 proje şablonu eklenir.
2. `npm run seed`'i **tekrar** çalıştır → kullanıcı sayısı değişmez (upsert), mentor ataması aynı kalır, proje şablonları için `⏭️ Zaten mevcut, atlandı: ...` logları görünür — **hiçbir duplicate satır oluşmaz**.
3. `npx prisma studio` veya `SELECT COUNT(*) FROM "ProjectTemplate"` ile şablon sayısının 2. çalıştırmadan sonra **değişmediğini** doğrula.
4. `tsx scripts/seed-projects.ts` tek başına da çalışır (standalone kullanım korunuyor).

## Acceptance Criteria
- [x] Tek komutla admin/mentor/student kullanıcıları oluşur
- [x] Student bir mentora atanmış olur
- [x] Örnek proje şablonları oluşur
- [x] Seed tekrar çalıştırıldığında duplicate veri üretmez (bug düzeltildi)

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)