### PR TITLE
docs: kurulum dokümantasyonunu mevcut implementasyonla uyumlu hale getir

### DIFF
--- a/KURULUM.md
+++ b/KURULUM.md
@@ -1,185 +1,56 @@
-## Database Kurulumu
- 
- ### 1. Docker ile PostgreSQL'i Ayağa Kaldır
-PostgreSQL veritabanını Docker üzerinden ayağa kaldırmak için:
-```
-docker compose up -d
-```
-Veri tabanı çalışıyor mu test etmek için:
-```
- docker compose ps 
-```
+# Kurulum — Detaylı Sorun Giderme
 
- Başarılı çıktı:
- ```
-NAME          COMMAND                  SERVICE    STATUS      PORTS
-aisigner_db   "docker-entrypoint.s…"   postgres   Up 5 seconds   0.0.0.0:5432->5432/tcp
-```
-### 2. Prisma Kurulumu
- Bağımlılıkları yükle
-```
-npm install prisma --save-dev
+> Bu dosya, ana kurulum adımları için **değil**, yerel veritabanı kurulumunda karşılaşılabilecek
+> sorunları gidermek için bir referanstır. Adım adım kurulum için `README.md`'deki **"Hızlı
+> Kurulum"** bölümünü kullanın. Modellerin güncel/otoriter tanımı için `prisma/schema.prisma`
+> dosyasına bakın — bu dosyanın burada ayrı bir kopyası tutulmuyor (kopyalar kodla çelişip eskir).
 
-npm install @prisma/client
-```
-
-Prisma'yı başlat
-```
-npx prisma init
-```
-
-### .env dosyasını düzenle (DATABASE_URL'i ayarla)
-
-``` 
-DATABASE_URL="postgresql://postgres:postgres@localhost:5432/aisigner?schema=public" 
-
-NEXT_PUBLIC_APP_URL=http://localhost:3000
-AUTH_SECRET=change_me
-
-```
-
- ### Schema dosyasını düzenle (models ekle)
- **Mevcut Modeller**
-
-* **User Modeli**
-```
- model User {
-
-  id        String   @id @default(cuid())  
-  email     String   @unique                        
-  name      String?    
-  lastName  String?                                
-  password  String  //hashed password
-  phone     String?                                        
-  role      Role     @default(STUDENT)                
-  createdAt DateTime @default(now())                
-  updatedAt DateTime @updatedAt    
-
-  emailVerified DateTime?
-  sessions      Session[]
-  studentProfile  StudentProfile?  @relation("StudentUser")
-  menteeProfiles StudentProfile[] @relation("StudentMentor")
-}
-
-enum Role {
-  ADMIN
-  MENTOR  
-  STUDENT
-}
-
-```
-
-### 3. Migration Çalıştır
-
-İlk migration'ı oluştur ve uygula ve Prisma Client'i generate et 
-```
-npx prisma migrate dev --name init
-
-npx prisma generate
-
-```
-### 4. Veritabanını Kontrol Et
-
-
-* Tablolar oluştu mu?
-```
-docker exec -it aisigner_db psql -U postgres -d aisigner -c "\dt"
-```
- * User tablosu yapısı doğru mu?
-```
-docker exec -it aisigner_db psql -U postgres -d aisigner -c "\d users"
-```
- **Prisma Studio ile Görsel Test**
-
- * http://localhost:5555 adresinde web arayüzü açılacak, users tablosunu görebiliyor musun?
- ```
- npx prisma studio
- ```
-
-**Prisma Client dosyalarının oluştuğunu kontrol et**
-```
-ls node_modules/.prisma/client/
-```
-**TypeScript tip dosyalarını kontrol et**
-```
-ls node_modules/@prisma/client/
-``` 
-### 5. Test Verisi Ekleme
-
-**Prisma Studio ile görsel olarak**
-```
-npx prisma studio
-```
-* +Add record butonuna bas
-* verileri gir
-* save e bas
-
-**Veya terminalden**
-```
-docker exec -it aisigner_db psql -U postgres -d aisigner -c "
-INSERT INTO \"User\" (email, password, role) 
-VALUES ('test@example.com', 'geçici_şifre', 'STUDENT') 
-"
-``` 
-NOT: gerçek projede şifre hashlenmeli
-
-### 6. Eğer Hata Alırsan
-
-1) Docker container'ının çalıştığından emin ol: 
-```
-docker ps
-```
-2) .env dosyasındaki DATABASE_URL'i kontrol et
- 
-3) Önceki migration'ları resetle:
-```
- npx prisma migrate reset
-
-```
-
-## Seed Nasıl Çalıştırılır?
-🔹 Seed (Örnek Kullanıcıları Ekleme)
-
-- Bu adımlar, Lokal geliştirme sırasında veritabanına hızlıca test edilebilecek 3 örnek kullanıcı eklemek için kullanılır.Seed script’i idempotent çalışır, yani aynı script tekrar tekrar çalıştırıldığında kullanıcılar çoğalmaz.
-
-- Şifreler güvenli şekilde **argon2** ile hashlenir.
-- Prisma Client kullanılarak veritabanına bağlantı sağlanır.
-
-
-**Adım 1 – Gerekli Paketler**
-
-Önce proje bağımlılıklarını yükleyin:
+## 1. PostgreSQL (Docker)
 
 ```bash
-npm install @prisma/client @node-rs/argon2 tsx
-
-```
-Not: Canlı ortamda NODE_ENV=production ve doğru DATABASE_URL kullanılmalı.
-
-**Adım 2 - package.json Script**
-`package.json` dosyanızın `"scripts"` bölümüne aşağıdaki satırı ekleyin:
-
-```json
-"scripts": {
-  "seed": "tsx scripts/seed.ts"
-}
-
+docker compose up -d
+docker compose ps   # Servisin "Up" olduğunu doğrula
 ```
 
-**Adım 3 - Seed Script Çalıştırma**
+Beklenen çıktıda `aisigner_db` servisi `Up` durumda ve `0.0.0.0:5432->5432/tcp` portu açık olmalı.
 
-Seed’i çalıştırmak için terminalden proje klasöründe şu komutu çalıştır:
+## 2. Migration ve Prisma Client
+
+Bu repo migration geçmişini (`prisma/migrations/`) commit'lenmiş halde içerir. Fresh bir clone'da
+bunları **uygulamak** için (yeni migration oluşturmak için değil):
+
+```bash
+npx prisma migrate deploy
+npx prisma generate
 ```
+
+`npx prisma migrate dev` yalnızca `schema.prisma`'da **yeni bir değişiklik** yapıp yeni bir
+migration üretirken kullanılır — aktif geliştirme sırasında.
+
+**Tablolar doğru oluştu mu?**
+```bash
+docker exec -it aisigner_db bash -c "psql -U postgres -d aisigner -c '\dt'"
+```
+
+**Prisma Studio ile görsel kontrol** (`http://localhost:5555`):
+```bash
+npx prisma studio
+```
+
+## 3. Test Verisi
+
+```bash
 npm run seed
 ```
 
-Script çalıştığında terminalde şöyle bir çıktı görürsün:
-```
-✅ ADMIN user created: admin@example.com
-✅ MENTOR user created: mentor@example.com
-✅ STUDENT user created: student@example.com
-Seed process completed! 3 users added!
-```
+Ne oluşturduğu ve idempotency davranışı için `README.md`'deki **"Seed Nasıl Çalıştırılır?"**
+bölümüne bakın. Elle `INSERT` ile düz metin şifre eklemeyin — seed script argon2 ile hash'ler.
 
-Eğer script daha önce çalıştırıldıysa ve kullanıcılar zaten varsa, tekrar ekleme yapılmaz (idempotent davranış).
+## 4. Eğer Hata Alırsan
 
+1. Docker container'ının çalıştığından emin ol: `docker ps`
+2. `.env` dosyasındaki `DATABASE_URL`'i kontrol et (bkz. `.env.example`)
+3. Migration/schema uyumsuzluğu varsa (yalnızca lokal/geliştirme ortamında — **veri kaybına yol
+   açar**): `npx prisma migrate reset`
+4. `AUTH_SECRET` ortam değişkeninin tanımlı olduğundan emin ol (NextAuth v4 bunu bekler —
+   `NEXTAUTH_SECRET` değil).

--- a/README.md
+++ b/README.md
@@ -12,13 +12,19 @@ AISigner, stajyer/öğrencilerin kısa bir anketle güçlü yönlerini ve seviye
 - Admin’in mentör ataması
 - Mentörün proje havuzundan öğrenciye proje ataması
 - AI destekli roadmap üretimi ve adımların onaylanması
-- GitHub fork/PR akışına dayalı çalışma düzeni
+- GitHub fork/PR akışına dayalı çalışma düzeni (bkz. "GitHub Entegrasyonu — Mevcut Durum")
+
+### GitHub Entegrasyonu — Mevcut Durum
+
+- ✅ Proje şablonlarına GitHub repository URL'i eklenebilir (admin, `ProjectTemplate.githubRepoUrl`).
+- ✅ Roadmap adımlarına GitHub issue linki eklenebilir (mentor, `RoadmapStep.githubIssueUrl`); öğrenci roadmap üzerinde bu linki görür.
+- ❌ Henüz **yok**: otomatik fork/PR oluşturma, issue durumu senkronizasyonu, webhook/GitHub App entegrasyonu. Şu an akış tamamen link-bazlı ve manuel — öğrenci/mentor repo ve issue linklerini elle takip eder.
 
 ## Ön Gereksinimler
 
 Projeyi kurmadan önce sisteminizde aşağıdaki yazılımların kurulu olduğundan emin olun:
 
-- **Node.js** (v18 veya üzeri)  
+- **Node.js** (v20 veya üzeri — CI de bu sürümü kullanıyor)  
 - **npm** (Node.js ile birlikte gelir)  
 - **Docker** & **Docker Compose**  
 - **Git**
@@ -27,7 +33,7 @@ Projeyi kurmadan önce sisteminizde aşağıdaki yazılımların kurulu olduğun
 
 ##  Hızlı Kurulum
 
-> 1. `git clone https://github.com/elifgularslan/AISigner.git`  
+> 1. `git clone https://github.com/Posinowa/AISigner.git`  
 >    → Projeyi kendi bilgisayarına indir.
 
 > 2. `cd AISigner`  
@@ -37,16 +43,16 @@ Projeyi kurmadan önce sisteminizde aşağıdaki yazılımların kurulu olduğun
 >    → PostgreSQL veritabanını arka planda başlat.
 
 > 4. `.env` dosyasını oluştur  
->    → Ortam değişkenlerini `.env.example` dosyasına göre tanımla (örnek: `DATABASE_URL`, `NEXTAUTH_SECRET`).
+>    → Ortam değişkenlerini `.env.example` dosyasına göre tanımla (örnek: `DATABASE_URL`, `AUTH_SECRET` — NextAuth v4'ün beklediği değişken adı budur, `NEXTAUTH_SECRET` değil).
 
 > 5. `npm install`  
 >    → Proje bağımlılıklarını yükle (Next.js, Prisma, Argon2 vb.)
 
-> 6. `npx prisma migrate dev --name init`  
->    → Veritabanı tablolarını oluştur ve Prisma Client’i generate et.
+> 6. `npx prisma migrate deploy` ardından `npx prisma generate`  
+>    → Repoda hazır bulunan tüm migration'ları veritabanına uygula ve Prisma Client'i üret. (`migrate dev` yalnızca schema.prisma'da yeni bir değişiklik yapıp yeni migration üretirken kullanılır; mevcut projeyi ilk kez ayağa kaldırırken `deploy` doğru komuttur.)
 
 > 7. `npm run seed`  
->    → Test kullanıcılarını veritabanına ekle (admin, mentor, öğrenci).
+>    → Demo verisini oluştur: admin/mentor/student kullanıcıları, student'ın mentor'a ataması ve örnek proje şablonları (idempotent — tekrar çalıştırmak duplicate üretmez, bkz. "Seed Nasıl Çalıştırılır?").
 
 > 8. `npm run dev`  
 >    → Uygulamayı başlat (`http://localhost:3000` adresinde çalışır).
@@ -127,269 +133,31 @@ npm run seed
 
 
 
-##  Ana Bağımlılıkların Yüklenmesi
+## Database Kurulumu — Sorun Giderme
 
-### Tüm package.json bağımlılıklarını yükleyin
+> Adım adım kurulum için yukarıdaki **"Hızlı Kurulum"** bölümüne bakın. Burada yalnızca sık karşılaşılan sorunlar ve doğrulama komutları var. Modellerin güncel/otoriter tanımı için `prisma/schema.prisma` dosyasına bakın — bu dosyanın README'de ayrı bir kopyası tutulmuyor (kopyalar zamanla kodla çelişip eskiyor).
+
+**Docker/veritabanı çalışıyor mu?**
 ```bash
-npm install
-```
-Not: Bu adımı atlarsanız, proje çalışmaz çünkü gerekli kütüphaneler (Next.js, Prisma Client, Argon2 vb.) yüklü olmaz. Komutları çalıştırırken hata alırsınız.
-
-### .env dosyasını düzenle (DATABASE_URL'i ayarla)
-
-```bash 
-DATABASE_URL= "YOUR_DATABASE_URL"
-NEXT_PUBLIC_APP_URL= YOUR_LOCAL_HOST_URL
-AUTH_SECRET= change_me
-
+docker compose ps
 ```
 
-
-## Database Kurulumu
- 
- ### 1. Docker ile PostgreSQL'i Ayağa Kaldır
-PostgreSQL veritabanını Docker üzerinden ayağa kaldırmak için:
+**Tablolar doğru oluştu mu?**
 ```bash
-docker compose up -d
-```
-Veri tabanı çalışıyor mu test etmek için:
-```bash
- docker compose ps 
-```
-
- Başarılı çıktı:
- ```
-NAME          COMMAND                  SERVICE    STATUS      PORTS
-aisigner_db   "docker-entrypoint.s…"   postgres   Up 5 seconds   0.0.0.0:5432->5432/tcp
-```
-### 2. Prismayı başlat
-
-```bash
-npx prisma init
-```
-
-
-
- ### Schema dosyasını düzenle (models ekle)
- **Mevcut Modeller**
-
-* **User Modeli**
-```prisma
- model User {
-
-  id        String   @id @default(cuid())  
-  email     String   @unique                        
-  name      String?    
-  lastName  String?                                
-  password  String  //hashed password
-  phone     String?                                        
-  role      Role     @default(STUDENT)                
-  createdAt DateTime @default(now())                
-  updatedAt DateTime @updatedAt    
-
-  emailVerified DateTime?
-  sessions      Session[]
-  studentProfile  StudentProfile?  @relation("StudentUser")
-  menteeProfiles StudentProfile[] @relation("StudentMentor")
-}
-
-enum Role {
-  ADMIN
-  MENTOR  
-  STUDENT
-}
-
-```
-* **Session Modeli**
-```prisma
-model Session {
-  id           String    @id @default(cuid())
-  sessionToken String    @unique
-  userId       String
-  expires      DateTime
-
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
-}
-```
-
-* **StudentProfile Modeli**
-```prisma
-model StudentProfile {
-  id              String   @id @default(cuid())
-  userId          String   @unique
-  user            User     @relation("StudentUser", fields: [userId], references: [id], onDelete: Cascade)
-  birthYear       Int?
-  experienceLevel String
-  interests       String[]
-  goals           String?
-  availability    String?
-
-  mentorId        String?
-  mentor          User?    @relation("StudentMentor", fields: [mentorId], references: [id])
-
- assignedProjects AssignedProject[]
-
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
-
-}
-```
-
-
-* **ProjectTemplate Modeli**
-```prisma
-model ProjectTemplate{
-  id             String @id @default(cuid())
-  title          String
-  description    String     //md formatı
-  track          String[]   //["web" , "mobile"]
-  difficulty     Difficulty
-  
-  assignedProjects AssignedProject[]
-
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
-
-}
-
-enum Difficulty{
-  HARD
-  MEDIUM
-  EASY
-}
-
-```
-
-* **AssignedProject Modeli**
-```prisma
-model AssignedProject {
-  id                String   @id @default(cuid())
-  studentProfileId  String
-  projectTemplateId String
-  status            AssignmentStatus @default(PENDING)
-
-  studentProfile    StudentProfile @relation(fields: [studentProfileId], references: [id])
-  projectTemplate   ProjectTemplate @relation(fields: [projectTemplateId], references: [id])
-
-  roadmap           Roadmap?
-
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
-}
-
-enum AssignmentStatus {
-  PENDING
-  IN_PROGRESS
-  COMPLETED
-}
-```
-
-* **Roadmap Modeli**
-```prisma
-model Roadmap {
-  id                String        @id @default(cuid())
-  assignedProjectId String        @unique
-  assignedProject   AssignedProject @relation(fields: [assignedProjectId], references: [id], onDelete: Cascade)
-  title             String
-  status            RoadmapStatus @default(DRAFT)
-  steps             RoadmapStep[]
-  createdAt         DateTime      @default(now())
-  updatedAt         DateTime      @updatedAt
-}
-
-model RoadmapStep {
-  id             String     @id @default(cuid())
-  roadmapId      String
-  roadmap        Roadmap    @relation(fields: [roadmapId], references: [id], onDelete: Cascade)
-  order          Int
-  title          String
-  description    String
-  resources      String[]
-  estimatedHours Int?
-  status         StepStatus @default(TODO)
-  createdAt      DateTime   @default(now())
-  updatedAt      DateTime   @updatedAt
-}
-```
-### 3. Migration Çalıştır
-
-İlk migration'ı oluştur ve uygula ve Prisma Client'i generate et 
-```
-npx prisma migrate dev --name init
-
-npx prisma generate
-
-```
-### 4. Veritabanını Kontrol Et
-
-
-* Tablolar oluştu mu?
-```
 docker exec -it aisigner_db bash -c "psql -U postgres -d aisigner -c '\dt'"
+```
 
-```
- * User tablosu yapısı doğru mu?
-```
-docker exec -it aisigner_db bash -c "psql -U postgres -d aisigner -c '\d \"User\"'"
-```
- **Prisma Studio ile Görsel Test**
-
- * http://localhost:5555 adresinde web arayüzü açılacak, users tablosunu görebiliyor musun?
- ```
- npx prisma studio
- ```
-
-**Prisma Client dosyalarının oluştuğunu kontrol et**
-```
-ls node_modules/.prisma/client/
-```
-**TypeScript tip dosyalarını kontrol et**
-```
-ls node_modules/@prisma/client/
-``` 
-### 5. Test Verisi Ekleme
-
-**Otomatik olarak Seed'i çalıştırarak (önerilen yöntem):**
+**Prisma Studio ile görsel kontrol** (`http://localhost:5555`):
 ```bash
-npm run seed
-```
-**Ekstra Kontrol: Kullanıcı sayısı**
-Seed script’in doğru çalışıp çalışmadığını kontrol etmek için kullanın . Örneğin  sonucu → admin, mentor, student kullanıcıları başarıyla eklenmiş demektir.
-
-```bash
-docker exec -it aisigner_db bash -c "psql -U postgres -d aisigner -c 'SELECT COUNT(*) FROM \"User\"'"
-```
-
-**Veya Prisma Studio ile görsel olarak**
-```
 npx prisma studio
 ```
-* +Add record butonuna bas
-* verileri gir
-* save e bas
 
-**Veya terminalden**
+**Migration/schema uyumsuzluğu yaşıyorsan** (yalnızca lokal/geliştirme ortamında — veri kaybına yol açar):
+```bash
+npx prisma migrate reset
 ```
-docker exec -it aisigner_db psql -U postgres -d aisigner -c "
-INSERT INTO \"User\" (email, password, role) 
-VALUES ('test@example.com', 'geçici_şifre', 'STUDENT') 
-"
-``` 
-NOT: gerçek projede şifre hashlenmeli
 
-### 6. Eğer Hata Alırsan
-
-1) Docker container'ının çalıştığından emin ol: 
-```
-docker ps
-```
-2) .env dosyasındaki DATABASE_URL'i kontrol et
- 
-3) Önceki migration'ları resetle:
-```
- npx prisma migrate reset
-
-```
+**Test verisi eklemek için** `npm run seed` kullanın (bkz. "Seed Nasıl Çalıştırılır?") — argon2 ile şifreleri güvenli şekilde hash'ler. Elle `INSERT` ile düz metin şifre eklemeyin.
 
 ## Seed Nasıl Çalıştırılır?
 🔹 Seed (Örnek Kullanıcıları Ekleme)
@@ -481,7 +249,7 @@ Yeni gelen bir geliştirici aşağıdaki adımları izleyerek M2 sürecini uçta
    - E-posta: `student@example.com`
    - Şifre: `geçici_şifre`
 
-3. Oturum açıldıktan sonra http://localhost:3000/student-onboarding  sayfasına git.
+3. Oturum açıldıktan sonra http://localhost:3000/profile-setup sayfasına git. (Eski `/student-onboarding` URL'i hâlâ çalışır ama `/profile-setup`'a kalıcı yönlendirme yapar.)
 4. Formu 3 adımda doldur:
    - Kişisel Bilgiler
    - Deneyim Seviyesi
@@ -758,8 +526,8 @@ Uygulama Next.js App Router mimarisiyle yapılandırılmıştır. Dosya sistemi 
 │   │   │   └── layout.tsx
 │   │   ├── (student)/        # Öğrenci'ye özel route grubu
 |   |   |   ├── student-dashboard/
-|   |   |   |
-|   |   |   ├── student-onboarding/# Öğrenci kayıt/karşılama süreci
+|   |   |   ├── profile-setup/      # Öğrenci onboarding/profil formu (gerçek sayfa)
+|   |   |   ├── student-onboarding/ # Eski URL — /profile-setup'a kalıcı yönlendirme
 │   │   │   └── layout.tsx
 │   │   ├── (auth)/           # Giriş / Kayıt / Çıkış sayfaları
 │   │   │   ├── signin/


### PR DESCRIPTION
## Özet
Issue #57: README ve `KURULUM.md`'de güncel kodla çelişen/eskimiş bilgiler vardı.

## Düzeltilenler
- **`NEXTAUTH_SECRET` → `AUTH_SECRET`** — kod (`nextauth.ts`, `middleware.ts`) her zaman `AUTH_SECRET` kullanıyor, `.env.example` zaten doğruydu; README'de tek çelişen referans vardı.
- **Stale clone URL'i** — `github.com/elifgularslan/AISigner` yerine gerçek repo `github.com/Posinowa/AISigner`.
- **`/student-onboarding` → `/profile-setup`** — `/student-onboarding` artık yalnızca `/profile-setup`'a yönlendiren bir stub (`redirect("/profile-setup")`); README gerçek route'u yazacak şekilde düzeltildi, klasör yapısı da bunu yansıtıyor.
- **Migration komutu** — `npx prisma migrate dev --name init` yerine `npx prisma migrate deploy` + `npx prisma generate`. Proje zaten committed migration'lara sahip; `deploy` fresh clone için doğru komut (`dev` yalnızca schema değişikliği yaparken kullanılır, gereksiz yere yeni migration oluşturma isteği çıkarabilirdi).
- **Node.js sürümü** v18 → v20 (CI ile uyumlu, `.github/workflows/ci.yml` üzerinden doğrulandı).
- **GitHub entegrasyonu — açık durum notu** eklendi: repo URL (#49) ve issue linki (#50) alanları **var**; otomatik fork/PR oluşturma, issue senkronizasyonu, webhook **yok**.

## Tekrar azaltma (asıl büyük bulgu)
README'nin içinde **kendi Hızlı Kurulum'unu VE `KURULUM.md`'yi tekrar eden, 260+ satırlık bir "Database Kurulumu" bloğu** vardı. Daha kötüsü, bu blok gerçek `prisma/schema.prisma`'yla **çelişen eski bir schema dökümü** içeriyordu:
- Yanlış ilişki adları (`StudentUser`/`StudentMentor` — gerçek şema `StudentProfile_userIdToUser`/`StudentProfile_mentorIdToUser` kullanıyor),
- Eksik modeller/alanlar (`accountStatus`, `ProfileAnalysis`, `SurveyQuestion`/`SurveyAnswer`, `githubRepoUrl`/`githubIssueUrl` vb. hiç yoktu).

Bu blok kaldırılıp kısa bir **"Sorun Giderme"** bölümüne indirgendi — schema'nın tek kaynağı artık `prisma/schema.prisma`'nın kendisi (dokümanda kopyası tutulmuyor, çünkü kopyalar tam olarak bu şekilde eskiyip çelişki üretiyor).

`KURULUM.md` da aynı mantıkla sadeleştirildi: `npx prisma init` gibi sıfırdan-proje adımları, uydurma schema parçası, düz metin şifreyle SQL `INSERT` önerisi kaldırıldı — artık README'ye tamamlayıcı kısa bir referans.

**Net: -361 satır** (419 silme, 58 ekleme), yalnızca 2 doküman dosyası.

## Test
Doküman-only değişiklik; kod dokunulmadı. `git diff --stat` ile yalnızca `README.md`/`KURULUM.md` değiştiğini doğruladım. Markdown code fence sayısı dengeli (26, çift).

## Acceptance Criteria
- [x] Auth secret dokümanda `AUTH_SECRET` olarak geçer
- [x] Prisma migrate/seed adımları gerçek scriptlerle uyumludur
- [x] Güncel onboarding route'u `/profile-setup` olarak yazılır
- [x] GitHub entegrasyonu için mevcut durum (kısmi: repo/issue link alanları var, otomasyon yok) açıkça belirtilir

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)