### PR TITLE
fix: admin UI hata geri bildirimini iyileştir

### DIFF
--- a/src/app/(admin)/admin-dashboard/page.tsx
+++ b/src/app/(admin)/admin-dashboard/page.tsx
@@ -1,7 +1,7 @@
 // 🧭 Admin paneli — kullanıcı/rol yönetimi ve mentor atama
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import {
   Users,
@@ -60,6 +60,9 @@ export default function AdminDashboard() {
   const [users, setUsers] = useState<User[]>([]);
   const [mentors, setMentors] = useState<Mentor[]>([]);
   const [loading, setLoading] = useState(true);
+  // #59: Fetch başarısız olduğunda "kullanıcı yok" ile "istek başarısız oldu" birbirine
+  // karışmasın diye ayrı bir hata durumu (mentor-dashboard'daki desenle tutarlı).
+  const [loadError, setLoadError] = useState(false);
   const [updating, setUpdating] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [roleFilter, setRoleFilter] = useState<"ALL" | User["role"]>("ALL");
@@ -97,25 +100,33 @@ export default function AdminDashboard() {
     setAnalysisModalUser(null);
   }
 
-  useEffect(() => {
-    async function loadData() {
-      try {
-        const [usersRes, mentorsRes] = await Promise.all([
-          fetch("/api/admin/users"),
-          fetch("/api/admin/mentors"),
-        ]);
-        const usersData = usersRes.ok ? await usersRes.json() : [];
-        const mentorsData = mentorsRes.ok ? await mentorsRes.json() : [];
-        setUsers(usersData);
-        setMentors(mentorsData);
-      } catch (err) {
-        console.error("Fetch error:", err);
-      } finally {
-        setLoading(false);
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    setLoadError(false);
+    try {
+      const [usersRes, mentorsRes] = await Promise.all([
+        fetch("/api/admin/users"),
+        fetch("/api/admin/mentors"),
+      ]);
+      if (!usersRes.ok || !mentorsRes.ok) {
+        setLoadError(true);
+        return;
       }
+      const usersData = await usersRes.json();
+      const mentorsData = await mentorsRes.json();
+      setUsers(usersData);
+      setMentors(mentorsData);
+    } catch (err) {
+      console.error("Fetch error:", err);
+      setLoadError(true);
+    } finally {
+      setLoading(false);
     }
-    loadData();
   }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
 
   async function handleRoleChange(userId: string, role: User["role"]) {
     setUpdating(userId);
@@ -127,9 +138,24 @@ export default function AdminDashboard() {
       });
       if (response.ok) {
         setUsers((prev) => prev.map((u) => (u.id === userId ? { ...u, role } : u)));
+        toast.success("Rol güncellendi.");
+      } else {
+        // #59: Hata hem düz string (ör. "kendi rolünü değiştiremezsin" guard'ı, 403)
+        // hem zod fieldErrors objesi olarak gelebilir — ikisi de gösterilsin.
+        const data = await response.json().catch(() => null);
+        const fieldErrors = data?.error;
+        let message = "Rol güncellenemedi.";
+        if (typeof fieldErrors === "string" && fieldErrors.trim().length > 0) {
+          message = fieldErrors;
+        } else if (fieldErrors && typeof fieldErrors === "object") {
+          const firstMessage = Object.values(fieldErrors).flat()[0];
+          if (firstMessage) message = String(firstMessage);
+        }
+        toast.error(message);
       }
     } catch (error) {
       console.error("Error updating role:", error);
+      toast.error("Bağlantı hatası. Lütfen tekrar deneyin.");
     } finally {
       setUpdating(null);
     }
@@ -251,6 +277,28 @@ export default function AdminDashboard() {
       <div className="flex items-center justify-center min-h-screen bg-slate-50">
         <Loader2 className="animate-spin h-7 w-7 text-blue-600 mr-3" />
         <span className="text-slate-600 font-medium">Kullanıcılar yükleniyor...</span>
+      </div>
+    );
+  }
+
+  // #59: Fetch başarısız olduğunda "hiç kullanıcı yok" gibi görünmesin diye
+  // ayrı bir hata durumu (mentor-dashboard'daki desenle tutarlı).
+  if (loadError) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen bg-slate-50 px-4 text-center">
+        <div className="w-14 h-14 rounded-2xl bg-red-50 flex items-center justify-center mb-4">
+          <AlertCircle className="w-7 h-7 text-red-500" />
+        </div>
+        <h2 className="text-lg font-semibold text-slate-900">Kullanıcılar yüklenemedi</h2>
+        <p className="text-slate-500 text-sm mt-1 mb-5">
+          Bağlantıda bir sorun oluştu. Lütfen tekrar deneyin.
+        </p>
+        <button
+          onClick={loadData}
+          className="rounded-xl bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-5 py-2.5 transition-colors"
+        >
+          Tekrar Dene
+        </button>
       </div>
     );
   }

--- a/src/app/(admin)/admin-dashboard/projects/page.tsx
+++ b/src/app/(admin)/admin-dashboard/projects/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { Plus, Pencil, Trash2, X, ArrowLeft, FolderKanban, Github } from "lucide-react";
+import { Plus, Pencil, Trash2, X, ArrowLeft, FolderKanban, Github, AlertCircle } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
 
@@ -41,10 +41,14 @@ export default function ProjectsPage() {
   });
   const [loading, setLoading] = useState(false);
   const [pageLoading, setPageLoading] = useState(true); // Sayfa yükleniyor durumu
+  // #59: Fetch başarısız olduğunda "hiç şablon yok" ile "istek başarısız oldu"
+  // birbirine karışmasın diye ayrı bir hata durumu.
+  const [loadError, setLoadError] = useState(false);
 
   const loadTemplates = useCallback(async () => {
     try {
       setPageLoading(true);
+      setLoadError(false);
       const res = await fetch("/api/admin/project-templates");
 
       if (!res.ok) {
@@ -55,7 +59,7 @@ export default function ProjectsPage() {
       setTemplates(Array.isArray(data) ? data : []);
     } catch (error) {
       console.error("Failed to load templates:", error);
-      setTemplates([]);
+      setLoadError(true);
     } finally {
       setPageLoading(false);
     }
@@ -309,6 +313,21 @@ export default function ProjectsPage() {
         <div className="flex items-center justify-center py-12">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
           <span className="ml-3 text-slate-600">Şablonlar yükleniyor...</span>
+        </div>
+      ) : loadError ? (
+        /* #59: "Hiç şablon yok" ile "istek başarısız oldu" karışmasın diye ayrı hata durumu. */
+        <div className="text-center py-12">
+          <div className="w-14 h-14 rounded-2xl bg-red-50 flex items-center justify-center mx-auto mb-4">
+            <AlertCircle className="w-7 h-7 text-red-500" />
+          </div>
+          <h3 className="text-lg font-medium text-slate-900 mb-2">Şablonlar yüklenemedi</h3>
+          <p className="text-slate-600 mb-4">Bağlantıda bir sorun oluştu. Lütfen tekrar deneyin.</p>
+          <button
+            onClick={loadTemplates}
+            className="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
+          >
+            Tekrar Dene
+          </button>
         </div>
       ) : (
         <>


### PR DESCRIPTION
## Özet
Issue #59: Admin panelinde bazı fetch/action hataları sadece console'a yazılıyordu ya da hiç görünmüyordu. Mentor atama (#43) ve proje şablonu create/update/delete (#49) zaten önceki oturumlarda düzeltilmişti; bu PR kalan iki gerçek boşluğu kapatıyor + tutarlılık için bir üçüncüsünü.

## Bulunan boşluklar

### 1) Kullanıcı listeleme hatası (AC1) — gerçek bug
`loadData`, fetch başarısız olursa **sessizce boş listeye düşüyordu** — "hiç kullanıcı yok" ile "istek başarısız oldu" birbirinden ayırt edilemiyordu (bu oturumda #78/#80/#83'te defalarca düzelttiğim aynı sınıf hata). Ayrı bir `loadError` state'i + mentor-dashboard'da zaten var olan hata+"Tekrar Dene" ekranıyla **birebir tutarlı** bir çözüm ekledim.

### 2) Rol değiştirme hatası (AC2) — gerçek bug
`handleRoleChange` başarısız olunca (örn. admin kendi rolünü değiştirmeye çalışırsa → 403 guard) **hiçbir geri bildirim yoktu** — buton tıklanıyor, hiçbir şey olmuyormuş gibi görünüyordu. `toast.error` eklendi; hem düz string hem zod `fieldErrors` objesi şeklindeki hataları doğru ayrıştırıyor (#83'te kurduğum desenle tutarlı). Başarıda da `toast.success` eklendi.

### 3) Proje şablonu listeleme hatası — tutarlılık için
AC'de açıkça yok ama `loadTemplates` **aynı** boş/hata karışması bug'ını taşıyordu. Issue'nun Scope'unda "Loading ve empty state ayrımını korumak" dendiği için, admin-dashboard'da düzelttiğim aynı sorunu kardeş sayfada bırakmak tutarsız olurdu — aynı desenle düzelttim.

## Zaten düzeltilmiş olanlar (bu PR'da dokunulmadı)
- **Mentor atama hatası (AC3)** — #43'te `toast.error` eklenmişti.
- **Proje şablonu create/update/delete (AC4)** — #49'da `toast.success`/`toast.error` + zod fieldErrors ayrıştırması eklenmişti.

## Test
`npm test` (93/93 yeşil, regresyon yok) · `npm run lint` (0 hata) · `npm run build` ✓

Bu değişiklik salt UI state/render mantığı — mentor-dashboard'daki (zaten testsiz) error+retry desenini birebir takip ediyor; yeni test altyapısı gerektirmedi.

> ⚠️ Yerel Postgres bu ortamda mevcut değildi, tam tarayıcı akışını uçtan uca deneyemedim.

### Manuel test adımları
1. Admin panelini aç, DevTools → Network'ten `/api/admin/users` isteğini offline/fail yaptır (veya API'yi geçici durdur) → sayfa "Kullanıcılar yüklenemedi" + "Tekrar Dene" gösterir (boş liste değil).
2. Kendi rolünü değiştirmeye çalış → toast ile "Kendi rolünüzü değiştiremezsiniz." mesajı görünür (sessizce başarısız olmaz).
3. Başka bir kullanıcının rolünü değiştir → başarı toast'ı görünür ve liste güncellenir.
4. `/admin-dashboard/projects`'te `/api/admin/project-templates` isteğini fail yaptır → "Şablonlar yüklenemedi" + "Tekrar Dene" görünür.

## Acceptance Criteria
- [x] Kullanıcı listeleme hatası görünür mesaj üretir
- [x] Rol değiştirme hatası görünür mesaj üretir
- [x] Mentor atama hatası görünür mesaj üretir (zaten #43'te)
- [x] Proje şablonu create/update/delete hataları tutarlı gösterilir (zaten #49'da)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)