### PR TITLE
chore: merge sonrası sertleştirme takip işleri

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ Yeni gelen bir geliştirici aşağıdaki adımları izleyerek M3 sürecini uçta
 Detaylı katkı rehberi için [CONTRIBUTING.md](CONTRIBUTING.md) dosyasına bakın.
 - Fork → branch → PR akışı ile katkı verin.
 - Küçük ve odaklı PR’lar tercih edilir.
+- Merge/deploy öncesi hızlı doğrulama için [docs/SMOKE-CHECKLIST.md](docs/SMOKE-CHECKLIST.md) (lint/test/build + kritik akış smoke adımları).
 
 ## Lisans
 MIT

--- a/docs/SMOKE-CHECKLIST.md
+++ b/docs/SMOKE-CHECKLIST.md
@@ -1,0 +1,68 @@
+# Merge Sonrası Smoke Checklist
+
+> Bir PR develop'a merge edildikten sonra (veya deploy öncesi) çalıştırılacak
+> minimal doğrulama listesi. Amaç: hızlı, düşük maliyetli regresyon yakalama.
+> Kapsamlı test değil — kritik akışların "hâlâ ayakta mı" kontrolü. (#89)
+
+## 1. Otomatik kontroller (zorunlu)
+
+Sırayla çalıştır; hepsi yeşil olmalı:
+
+```bash
+npm run lint     # 0 hata
+npm test         # tüm testler geçer
+npm run build    # başarılı derleme
+```
+
+> CI (`.github/workflows/ci.yml`) bunları her PR'da zaten çalıştırır. Bu bölüm,
+> lokal/deploy öncesi hızlı bir teyit içindir. `npm ci` sonrası Prisma client
+> otomatik üretilir; lokalde şema değiştiyse `npx prisma generate` gerekebilir.
+
+## 2. Manuel smoke — kritik akışlar
+
+Gerekirse önce demo verisi: `npm run seed` (admin/mentor/student + mentor ataması
++ proje şablonları; idempotent). Test kullanıcıları için bkz. README.
+
+### 2.1 Öğrenci profil kurulumu (`/profile-setup`) — #55/#83
+
+- [ ] **Profil yok + soru yok:** Yeni öğrenci `/profile-setup`'a girer → 4 adımlı
+      form boş gelir; "Ek Sorular" adımı görünmez; tamamlayınca dashboard'a gider.
+- [ ] **Profil var (prefill):** Onboarding'i tamamlamış öğrenci tekrar girer →
+      ad/soyad/telefon/doğum yılı, deneyim seviyesi radio'su (doğru seçili),
+      ilgi alanları (işaretli), hedef metinleri (knownTech/futureGoal/learningStyle
+      dolu) prefill gelir. Değiştirip kaydet → yeni kayıt oluşmaz, mevcut güncellenir.
+- [ ] **Profil var + aktif survey soruları:** Admin en az 1 aktif soru tanımlamışsa
+      son adımda "Ek Sorular" görünür; boş bırakılabilir; doldurulunca kaydedilir.
+- [ ] **Survey yüklenemedi (fetch failure):** Survey fetch başarısız olursa "Ek
+      Sorular" adımı **açık bir uyarı** gösterir ("şu anda yüklenemedi, boş bırakıp
+      devam edebilirsiniz") — sessizce boş/kayıp gibi görünmez.
+
+### 2.2 Admin paneli (`/admin-dashboard`) — #59/#89
+
+- [ ] **Normal yükleme:** Kullanıcı listesi + mentor listesi gelir.
+- [ ] **Kullanıcı listesi fetch fail** (DevTools → Network offline / API durdur):
+      "Kullanıcılar yüklenemedi" + "Tekrar Dene" görünür — boş liste değil.
+- [ ] **Mentor listesi fetch fail:** Aynı hata ekranı (usersRes veya mentorsRes
+      başarısızsa error state).
+- [ ] **Rol güncelleme — başarı:** Başka kullanıcının rolü değişir, başarı toast'ı.
+- [ ] **Rol güncelleme — guard hatası:** Admin kendi rolünü değiştirmeye çalışır →
+      "Kendi rolünüzü değiştiremezsiniz." toast'ı (string mesaj doğru gösterilir).
+- [ ] **Mentor atama:** Geçerli öğrenci-mentor → başarı; geçersiz → anlamlı hata.
+
+### 2.3 Proje şablonları (`/admin-dashboard/projects`) — #49/#59/#89
+
+- [ ] **Liste fetch fail:** "Şablonlar yüklenemedi" + "Tekrar Dene" — empty state'e
+      düşmez (boş/hata ayrımı korunur).
+- [ ] **Oluştur/güncelle — başarı:** Toast + liste güncellenir.
+- [ ] **Geçersiz GitHub repo URL:** `https://github.com/org/repo?tab=readme` (query),
+      `.../repo#readme` (hash), `.../repo/tree/main` (derin yol) → validation hatası
+      toast'ı; **yalnızca** `https://github.com/org/repo` (ve trailing slash) kabul.
+- [ ] **Sil:** Onay sonrası şablon listeden kalkar.
+
+## 3. Notlar
+
+- Bu doküman referans içindir; her madde her PR'da tekrar edilmek zorunda değil —
+  değişen alana göre ilgili bölüm(ler) yeterli.
+- Otomatik kapsanan mantık (URL validasyonu, hata-mesaj ayrıştırma, goals
+  compile/parse round-trip, experienceLevel map) için birim testler mevcut; bu
+  liste onların **kapsamadığı UI-render/akış** kısımlarını hedefler.

--- a/scripts/seed-projects.ts
+++ b/scripts/seed-projects.ts
@@ -4,6 +4,21 @@ import { pathToFileURL } from "url";
 /**
  * #56: scripts/seed.ts tarafından çağrılır (birleşik seed akışı); ayrıca
  * `tsx scripts/seed-projects.ts` ile tek başına da çalıştırılabilir.
+ *
+ * #89 — Idempotency / DB seviyesi kararı:
+ * Aşağıdaki title-bazlı `findFirst` + koşullu `create` yaklaşımı KORUNUYOR;
+ * `ProjectTemplate.title` üzerine unique constraint EKLENMEDİ. Gerekçe:
+ *  1) Seed tek bir süreçte SIRAYLA çalışır — gerçek bir yarış koşulu (aynı anda
+ *     iki çağrı) senaryosu yok; endişe teoriktir.
+ *  2) title bir domain-unique alan DEĞİL — admin bilinçli olarak aynı başlıkla
+ *     varyant şablonlar oluşturabilir; unique constraint bu esnekliği kaldırır.
+ *  3) Mevcut DB'lerde eski hatalı seed'in (bkz. #56) ürettiği duplicate-title
+ *     satırlar olabilir; unique index ekleyen bir migration bu satırlarda
+ *     BAŞARISIZ olur — güvenli eklemek önce dedup migration'ı gerektirir, bu da
+ *     bu sertleştirme kapsamının dışında (ayrı, dikkatli bir iş).
+ * Sonuç: teknik gerekçeyle ertelendi. Gerçek eşzamanlı yazım ihtiyacı doğarsa
+ * (admin API'sinden toplu içe aktarma vb.) o zaman dedup + unique index + upsert
+ * birlikte değerlendirilmeli.
  */
 export async function seedProjectTemplates(prisma: PrismaClient): Promise<void> {
   const templates = [

--- a/src/app/(admin)/admin-dashboard/page.tsx
+++ b/src/app/(admin)/admin-dashboard/page.tsx
@@ -27,6 +27,7 @@ import {
   parseProfileAnalysisApiResponse,
   type ProfileAnalysisData,
 } from "@/features/ai/ui/ProfileAnalysisCard";
+import { extractApiErrorMessage } from "@/lib/api-error";
 
 type User = {
   id: string;
@@ -141,18 +142,10 @@ export default function AdminDashboard() {
         setUsers((prev) => prev.map((u) => (u.id === userId ? { ...u, role } : u)));
         toast.success("Rol güncellendi.");
       } else {
-        // #59: Hata hem düz string (ör. "kendi rolünü değiştiremezsin" guard'ı, 403)
-        // hem zod fieldErrors objesi olarak gelebilir — ikisi de gösterilsin.
+        // #59/#89: Hata hem düz string (ör. "kendi rolünü değiştiremezsin" guard'ı, 403)
+        // hem zod fieldErrors objesi olarak gelebilir — ortak helper ikisini de gösterir.
         const data = await response.json().catch(() => null);
-        const fieldErrors = data?.error;
-        let message = "Rol güncellenemedi.";
-        if (typeof fieldErrors === "string" && fieldErrors.trim().length > 0) {
-          message = fieldErrors;
-        } else if (fieldErrors && typeof fieldErrors === "object") {
-          const firstMessage = Object.values(fieldErrors).flat()[0];
-          if (firstMessage) message = String(firstMessage);
-        }
-        toast.error(message);
+        toast.error(extractApiErrorMessage(data?.error, "Rol güncellenemedi."));
       }
     } catch (error) {
       console.error("Error updating role:", error);

--- a/src/app/(admin)/admin-dashboard/projects/page.tsx
+++ b/src/app/(admin)/admin-dashboard/projects/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback } from "react";
 import { Plus, Pencil, Trash2, X, ArrowLeft, FolderKanban, Github, AlertCircle } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
+import { extractApiErrorMessage } from "@/lib/api-error";
 
 type ProjectTemplate = {
   id: string;
@@ -115,16 +116,9 @@ export default function ProjectsPage() {
       }
 
       if (!res.ok) {
+        // #89: string veya zod fieldErrors objesi — ortak helper ikisini de gösterir.
         const data = await res.json().catch(() => null);
-        const fieldErrors = data?.error;
-        let message = "Şablon kaydedilemedi.";
-        if (fieldErrors && typeof fieldErrors === "object") {
-          const firstMessage = Object.values(fieldErrors).flat()[0];
-          if (firstMessage) message = String(firstMessage);
-        } else if (typeof fieldErrors === "string") {
-          message = fieldErrors;
-        }
-        toast.error(message);
+        toast.error(extractApiErrorMessage(data?.error, "Şablon kaydedilemedi."));
         return;
       }
 

--- a/src/features/student/models/compiledGoals.test.ts
+++ b/src/features/student/models/compiledGoals.test.ts
@@ -52,3 +52,23 @@ describe("parseCompiledGoals — fallback (#55)", () => {
     expect(parseCompiledGoals("   ")).toEqual({ knownTech: "", futureGoal: "", learningStyle: "" });
   });
 });
+
+// #89: Prefill regresyon koruması — kayıtlı goals'ı forma açıp (parse) tekrar
+// kaydetmek (compile) ilk kaydı bozmamalı. DB'de saklanan string, prefill sonrası
+// yeniden derlendiğinde birebir aynı kalmalı (kullanıcı hiçbir alanı değiştirmezse).
+describe("prefill round-trip stabilitesi (#89)", () => {
+  it("stored → parse → compile aynı stored string'i üretir (stabil)", () => {
+    const original = compileGoals({
+      knownTech: "Python temel seviye",
+      futureGoal: "Backend geliştirici olmak",
+      learningStyle: "Proje yaparak öğrenirim",
+    });
+
+    const fieldsFromDb = parseCompiledGoals(original);
+    const recompiled = compileGoals(fieldsFromDb);
+
+    expect(recompiled).toBe(original);
+    // Ve tekrar parse edilince alanlar hâlâ aynı.
+    expect(parseCompiledGoals(recompiled)).toEqual(fieldsFromDb);
+  });
+});

--- a/src/features/survey/answers.ts
+++ b/src/features/survey/answers.ts
@@ -1,5 +1,7 @@
 // #46: İstemci ve sunucu arasında paylaşılan saf yardımcılar (prisma/React bağımlılığı yok).
 
+import { extractApiErrorMessage } from "@/lib/api-error";
+
 export type SurveyQuestionView = {
   id: string;
   question: string;
@@ -25,21 +27,9 @@ export function buildSurveyAnswerPayload(
 
 /**
  * #83: POST /api/student/survey-answers hatasını okunabilir tek mesaja indirger.
- * Hata iki şekilde gelebilir: düz string (SurveyValidationError/500) veya zod
- * fieldErrors objesi (`{ answers: ["mesaj"] }`, 400 validation). Önceki kod
- * yalnızca string'i kontrol ediyordu; obje gelince genel/anlamsız bir mesaja
- * düşüyordu — validation hatası kullanıcıya görünmüyordu.
+ * #89: Ortak `extractApiErrorMessage`'e delege edildi — aynı davranış, tek kaynak.
+ * Bu isim survey çağrı yerleri ve mevcut testler için korunuyor.
  */
-export function extractSurveyErrorMessage(
-  errorField: unknown,
-  fallback: string,
-): string {
-  if (typeof errorField === "string" && errorField.trim().length > 0) {
-    return errorField;
-  }
-  if (errorField && typeof errorField === "object") {
-    const firstMessage = Object.values(errorField as Record<string, unknown>).flat()[0];
-    if (firstMessage) return String(firstMessage);
-  }
-  return fallback;
+export function extractSurveyErrorMessage(errorField: unknown, fallback: string): string {
+  return extractApiErrorMessage(errorField, fallback);
 }

--- a/src/lib/api-error.test.ts
+++ b/src/lib/api-error.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { extractApiErrorMessage } from "./api-error";
+
+describe("extractApiErrorMessage (#89)", () => {
+  it("düz string hatayı olduğu gibi döner (guard/iş kuralı mesajı)", () => {
+    expect(extractApiErrorMessage("Kendi rolünüzü değiştiremezsiniz.", "fallback")).toBe(
+      "Kendi rolünüzü değiştiremezsiniz.",
+    );
+  });
+
+  it("zod fieldErrors objesindeki ilk alanın ilk mesajını çıkarır", () => {
+    expect(
+      extractApiErrorMessage({ githubRepoUrl: ["Geçerli bir GitHub repository URL'i girin"] }, "fallback"),
+    ).toBe("Geçerli bir GitHub repository URL'i girin");
+  });
+
+  it("birden fazla alan hatası varsa ilkini döner", () => {
+    expect(
+      extractApiErrorMessage({ title: ["Başlık gerekli"], description: ["Açıklama gerekli"] }, "fallback"),
+    ).toBe("Başlık gerekli");
+  });
+
+  it("tanınmayan şekil (null/undefined/boş obje/boş string) → fallback", () => {
+    expect(extractApiErrorMessage(null, "fallback")).toBe("fallback");
+    expect(extractApiErrorMessage(undefined, "fallback")).toBe("fallback");
+    expect(extractApiErrorMessage({}, "fallback")).toBe("fallback");
+    expect(extractApiErrorMessage("", "fallback")).toBe("fallback");
+    expect(extractApiErrorMessage("   ", "fallback")).toBe("fallback");
+  });
+});

--- a/src/lib/api-error.ts
+++ b/src/lib/api-error.ts
@@ -1,0 +1,23 @@
+// #89: API hata yanıtlarını okunabilir tek bir mesaja indirgeyen ortak yardımcı.
+//
+// Route'larımız hatayı iki şekilde döndürüyor:
+//  - düz string:  { error: "Kendi rolünüzü değiştiremezsiniz." }        (guard/iş kuralı, 4xx/5xx)
+//  - zod objesi:  { error: { githubRepoUrl: ["Geçerli bir ... girin"] } } (validation, 400)
+// İstemci tarafındaki "sadece string kontrol et" yaklaşımı obje geldiğinde mesajı
+// kaybediyordu; bu helper ikisini de doğru gösterir. Admin panelinde ve anket
+// akışında paylaşılır.
+
+/**
+ * `errorField` bir string ise onu, zod `fieldErrors` objesi ise ilk alan mesajını
+ * döndürür; tanınmayan/boş şekillerde `fallback`.
+ */
+export function extractApiErrorMessage(errorField: unknown, fallback: string): string {
+  if (typeof errorField === "string" && errorField.trim().length > 0) {
+    return errorField;
+  }
+  if (errorField && typeof errorField === "object") {
+    const firstMessage = Object.values(errorField as Record<string, unknown>).flat()[0];
+    if (firstMessage) return String(firstMessage);
+  }
+  return fallback;
+}

--- a/src/lib/experience-level.test.ts
+++ b/src/lib/experience-level.test.ts
@@ -68,4 +68,18 @@ describe("experienceLevelToFormValue (#55)", () => {
     expect(experienceLevelToFormValue(null)).toBe("beginner");
     expect(experienceLevelToFormValue(undefined)).toBe("beginner");
   });
+
+  // #89: Prefill regresyon koruması — kanonik → form değeri eşlemesi SABİT kalmalı.
+  // OnboardingForm'un radio value'ları bu tam eşlemeye bağlı; biri değişirse prefill
+  // yanlış seçili gelir. Tablo bilinçli olarak burada kilitleniyor.
+  it("kanonik → form değeri eşlemesi tam olarak beklenen tabloya eşittir", () => {
+    const mapping: Record<string, "beginner" | "intermediate" | "advanced"> = {
+      BEGINNER: "beginner",
+      INTERMEDIATE: "intermediate",
+      ADVANCED: "advanced",
+    };
+    for (const [canonical, formValue] of Object.entries(mapping)) {
+      expect(experienceLevelToFormValue(canonical)).toBe(formValue);
+    }
+  });
 });

--- a/src/lib/validations/api.test.ts
+++ b/src/lib/validations/api.test.ts
@@ -81,6 +81,26 @@ describe("createTemplateSchema — githubRepoUrl (#49)", () => {
     ).toBe(true);
   });
 
+  it("#89: query (?tab=...) içeren URL'i reddeder", () => {
+    for (const url of [
+      "https://github.com/org/repo?tab=readme",
+      "https://github.com/org/repo/?tab=readme",
+    ]) {
+      expect(createTemplateSchema.safeParse({ ...templateBase, githubRepoUrl: url }).success).toBe(
+        false,
+      );
+    }
+  });
+
+  it("#89: hash (#readme) içeren URL'i reddeder", () => {
+    expect(
+      createTemplateSchema.safeParse({
+        ...templateBase,
+        githubRepoUrl: "https://github.com/org/repo#readme",
+      }).success,
+    ).toBe(false);
+  });
+
   it("http (https değil) reddedilir", () => {
     const result = createTemplateSchema.safeParse({
       ...templateBase,

--- a/src/lib/validations/api.ts
+++ b/src/lib/validations/api.ts
@@ -63,6 +63,9 @@ const githubRepoUrlSchema = z
     try {
       const url = new URL(val);
       if (url.protocol !== "https:" || url.hostname !== "github.com") return false;
+      // #89: Yalnızca tam repo kökü kabul edilir — query (?tab=...) veya hash (#readme)
+      // içeren URL'ler reddedilir; kök form kanonik kalsın.
+      if (url.search !== "" || url.hash !== "") return false;
       // #83: Yalnızca repo kökü (owner/repo) kabul edilir; tree/issues/pull gibi
       // daha derin yollar reddedilir (önceki >=2 kontrolü bunları da geçiriyordu).
       const segments = url.pathname.split("/").filter(Boolean);


### PR DESCRIPTION
## Özet
Issue #89: PR #84-88 merge edildikten sonra kalan 5 sertleştirme takip işi. Tek issue altında toplandığı için tek PR.

## 1) GitHub repo URL — query/hash reddi
`githubRepoUrlSchema` artık `url.search`/`url.hash` boş değilse reddediyor:
- ❌ `https://github.com/org/repo?tab=readme` (query)
- ❌ `https://github.com/org/repo#readme` (hash)
- ✅ `https://github.com/org/repo` ve `.../repo/` (trailing slash) korunuyor.
Negatif test case'ler eklendi (`api.test.ts`).

## 3) Admin hata-mesaj ayrıştırma → ortak tested helper
Admin panelinde (rol değiştirme, şablon submit) **tekrar eden** "string mi zod fieldErrors objesi mi" ayrıştırma mantığı vardı. Ortak saf bir helper'a çıkardım:
- **`lib/api-error.ts`** → `extractApiErrorMessage(errorField, fallback)` + kapsamlı birim test (string / fieldErrors objesi / null / boş).
- `admin-dashboard` rol değiştirme + `projects` submit artık bunu kullanıyor (inline duplikasyon kalktı).
- `survey/answers.ts`'teki `extractSurveyErrorMessage` ona **delege** ediyor — isim ve mevcut çağrı yerleri/testler korundu, tek kaynak.

Bu, item 3'ün "string ve fieldErrors mesajları doğru gösteriliyor mu" gereksinimine **otomatik test** kazandırıyor.

## 2) Profile-setup prefill regresyon koruması
UI-render kısmı manuel checklist'te (bkz. item 5); saf mantık için guard testler:
- **compileGoals round-trip stabilitesi:** `stored → parse → compile` birebir aynı string'i üretir (prefill sonrası yeniden kaydetme kaydı bozmaz).
- **experienceLevel map kilidi:** kanonik `BEGINNER/INTERMEDIATE/ADVANCED` → form değeri eşlemesinin tam beklenen tabloya eşitliği (biri değişirse prefill yanlış seçili gelir).

## 4) Seed idempotency kararı → **teknik gerekçeyle ertelendi**
`ProjectTemplate.title` unique constraint **eklenmedi**. Gerekçe (`seed-projects.ts`'e yorum olarak yazıldı):
1. Seed tek süreçte sırayla çalışır — gerçek yarış koşulu yok, endişe teorik.
2. `title` domain-unique değil (admin aynı başlıkla varyant isteyebilir).
3. Mevcut DB'lerde eski hatalı seed'in (#56) bıraktığı duplicate-title satırlar olabilir → unique index ekleyen migration **başarısız olur**; güvenli eklemek önce dedup migration'ı gerektirir (bu kapsamın dışında).

Mevcut title-bazlı `findFirst` + koşullu `create` (idempotent) korunuyor.

## 5) Smoke checklist
**`docs/SMOKE-CHECKLIST.md`** — merge/deploy öncesi: `lint`/`test`/`build` + kritik akışların (profile-setup, admin dashboard, project templates) manuel smoke adımları. Item 2 ve 3'ün UI-render senaryolarını da içeriyor. README'den referans verildi.

## Test
`npm test` (126/126 yeşil) · `npm run lint` (0 hata) · `npm run build` ✓

## Acceptance Criteria
- [x] `githubRepoUrl` query/hash içeren URL'leri reddeder; testleri geçer
- [x] Profile setup 3 ana senaryosu test/checklist ile kapsanır (guard testler + smoke checklist)
- [x] Admin panel error-state davranışı test/checklist ile doğrulanır (extractApiErrorMessage testi + smoke checklist)
- [x] Seed idempotency kararı netleşti (teknik gerekçeyle ertelendi, belgelendi)
- [x] Merge sonrası smoke checklist repoda erişilebilir (`docs/SMOKE-CHECKLIST.md`)

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)