### PR TITLE
feat: native confirm() yerine ortak ConfirmDialog

### DIFF
--- a/src/app/(admin)/admin-dashboard/projects/page.tsx
+++ b/src/app/(admin)/admin-dashboard/projects/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback } from "react";
 import { Plus, Pencil, Trash2, X, ArrowLeft, FolderKanban, Github, AlertCircle } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
+import { useConfirm } from "@/components/ui/ConfirmDialog";
 
 type ProjectTemplate = {
   id: string;
@@ -29,6 +30,7 @@ const difficultyColors = {
 };
 
 export default function ProjectsPage() {
+  const confirm = useConfirm();
   const [templates, setTemplates] = useState<ProjectTemplate[]>([]);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -140,7 +142,13 @@ export default function ProjectsPage() {
   }
 
   async function handleDelete(id: string) {
-    if (!confirm("Bu proje şablonunu silmek istediğinizden emin misiniz?")) return;
+    const ok = await confirm({
+      title: "Proje şablonunu sil",
+      description: "Bu proje şablonunu silmek istediğinizden emin misiniz?",
+      confirmLabel: "Sil",
+      danger: true,
+    });
+    if (!ok) return;
 
     try {
       const res = await fetch(`/api/admin/project-templates/${id}`, { 

--- a/src/app/(mentor)/mentor-dashboard/[studentId]/page.tsx
+++ b/src/app/(mentor)/mentor-dashboard/[studentId]/page.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { toast } from "sonner";
 import { experienceLevelLabel } from "@/lib/experience-level";
 import { ProfileAnalysisCard, type ProfileAnalysisData } from "@/features/ai/ui/ProfileAnalysisCard";
+import { useConfirm } from "@/components/ui/ConfirmDialog";
 
 type ProjectTemplate = {
   id: string;
@@ -75,6 +76,7 @@ const difficultyConfig = {
 };
 
 export default function StudentDetailPage() {
+  const confirm = useConfirm();
   const params = useParams();
   const searchParams = useSearchParams();
   const studentId = params.studentId as string;
@@ -196,12 +198,13 @@ export default function StudentDetailPage() {
   }
 
   async function handleDeleteAssignment(assignedProjectId: string) {
-    if (
-      !confirm(
-        "Bu proje atamasını kaldırmak istediğinizden emin misiniz? (Bağlı yol haritası da silinir)",
-      )
-    )
-      return;
+    const ok = await confirm({
+      title: "Proje atamasını kaldır",
+      description: "Bu proje atamasını kaldırmak istediğinizden emin misiniz? Bağlı yol haritası da silinir.",
+      confirmLabel: "Kaldır",
+      danger: true,
+    });
+    if (!ok) return;
 
     async function doDelete(force: boolean) {
       const res = await fetch("/api/mentor/unassign-project", {
@@ -218,12 +221,13 @@ export default function StudentDetailPage() {
       // Backend öğrenci ilerlemesi varsa 409 döner — ek onay iste
       if (res.status === 409) {
         const data = await res.json().catch(() => ({}));
-        const msg =
-          data?.error ||
-          "Bu projede öğrenci ilerlemesi var.";
-        const confirmed = confirm(
-          `${msg}\n\nYine de silmek istediğinden EMİN misin? Tüm ilerleme ve yol haritası kaybolacak.`,
-        );
+        const msg = data?.error || "Bu projede öğrenci ilerlemesi var.";
+        const confirmed = await confirm({
+          title: "Öğrenci ilerlemesi var",
+          description: `${msg}\n\nYine de silmek istediğinden emin misin? Tüm ilerleme ve yol haritası kaybolacak.`,
+          confirmLabel: "Yine de sil",
+          danger: true,
+        });
         if (!confirmed) return;
         res = await doDelete(true);
       }

--- a/src/app/(mentor)/mentor-dashboard/roadmap/[roadmapId]/page.tsx
+++ b/src/app/(mentor)/mentor-dashboard/roadmap/[roadmapId]/page.tsx
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 import { StepComments } from "@/features/messaging/ui/StepComments";
 import { StepFiles } from "@/features/files/ui/StepFiles";
+import { useConfirm } from "@/components/ui/ConfirmDialog";
 
 /* ─── Tipler ─── */
 type RoadmapStep = {
@@ -92,6 +93,7 @@ async function extractErrorMessage(res: Response, fallback: string): Promise<str
 
 /* ─── Sayfa ─── */
 export default function RoadmapReviewPage() {
+  const confirm = useConfirm();
   const params = useParams();
   const router = useRouter();
   const { data: sessionData } = useSession();
@@ -241,7 +243,13 @@ export default function RoadmapReviewPage() {
 
   /* ─── Adım Silme ─── */
   async function handleDeleteStep(stepId: string) {
-    if (!confirm("Bu adımı silmek istediğinize emin misiniz?")) return;
+    const ok = await confirm({
+      title: "Adımı sil",
+      description: "Bu adımı silmek istediğinize emin misiniz?",
+      confirmLabel: "Sil",
+      danger: true,
+    });
+    if (!ok) return;
     try {
       const res = await fetch(
         `/api/mentor/roadmap/${roadmapId}/steps/${stepId}`,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { DebugNavbar } from "@/components/DebugNavbar"
 import { SessionProvider } from "@/components/SessionProvider"
+import { ConfirmDialogProvider } from "@/components/ui/ConfirmDialog"
 import { Toaster } from "sonner"
 
 const geistSans = Geist({
@@ -32,12 +33,15 @@ export default function RootLayout({
       >
         {/* 🔐 NextAuth oturum sağlayıcısı */}
         <SessionProvider>
+          {/* #92: Uygulama geneli onay dialogu (native confirm yerine) */}
+          <ConfirmDialogProvider>
 
        {/* 🧭 Debug bar - sadece development ortamında görünür */}
         {process.env.NODE_ENV === "development" && <DebugNavbar />}
 
         {children}
         <Toaster richColors position="top-right" />
+          </ConfirmDialogProvider>
         </SessionProvider>
       </body>
     </html>

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,132 @@
+// #92: Native confirm() yerine tasarım diliyle uyumlu, söz-tabanlı (promise) onay dialogu.
+//
+// Kullanım:
+//   const confirm = useConfirm();
+//   if (!(await confirm({ title: "...", description: "...", danger: true }))) return;
+//
+// Root layout'ta bir kez <ConfirmDialogProvider> sarmalanır; tek bir dialog örneği
+// uygulama genelinde paylaşılır. Escape / backdrop / İptal → false, Onayla → true.
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
+import { AlertTriangle } from "lucide-react";
+
+export type ConfirmOptions = {
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** true → onay butonu kırmızı (silme gibi geri alınamaz aksiyonlar). */
+  danger?: boolean;
+};
+
+type ConfirmFn = (options: ConfirmOptions) => Promise<boolean>;
+
+const ConfirmContext = createContext<ConfirmFn | null>(null);
+
+export function useConfirm(): ConfirmFn {
+  const ctx = useContext(ConfirmContext);
+  if (!ctx) {
+    throw new Error("useConfirm, <ConfirmDialogProvider> içinde kullanılmalıdır.");
+  }
+  return ctx;
+}
+
+type PendingState = {
+  options: ConfirmOptions;
+  resolve: (value: boolean) => void;
+};
+
+export function ConfirmDialogProvider({ children }: { children: React.ReactNode }) {
+  const [pending, setPending] = useState<PendingState | null>(null);
+  const confirmBtnRef = useRef<HTMLButtonElement>(null);
+
+  const confirm = useCallback<ConfirmFn>((options) => {
+    return new Promise<boolean>((resolve) => {
+      setPending({ options, resolve });
+    });
+  }, []);
+
+  const close = useCallback(
+    (result: boolean) => {
+      setPending((current) => {
+        current?.resolve(result);
+        return null;
+      });
+    },
+    [],
+  );
+
+  // Açılışta onay butonuna odaklan + Escape ile iptal.
+  useEffect(() => {
+    if (!pending) return;
+    confirmBtnRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close(false);
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [pending, close]);
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      {pending && (
+        <div
+          className="fixed inset-0 z-[60] bg-slate-900/50 backdrop-blur-sm flex items-center justify-center p-4"
+          onClick={() => close(false)}
+          role="presentation"
+        >
+          <div
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="confirm-title"
+            className="bg-white rounded-2xl shadow-xl w-full max-w-md overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="p-6">
+              <div className="flex items-start gap-3">
+                {pending.options.danger && (
+                  <div className="w-10 h-10 rounded-xl bg-red-50 flex items-center justify-center shrink-0">
+                    <AlertTriangle className="w-5 h-5 text-red-600" />
+                  </div>
+                )}
+                <div className="min-w-0">
+                  <h2 id="confirm-title" className="text-lg font-semibold text-slate-900">
+                    {pending.options.title}
+                  </h2>
+                  {pending.options.description && (
+                    <p className="mt-1.5 text-sm text-slate-600 leading-relaxed whitespace-pre-line">
+                      {pending.options.description}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+            <div className="flex items-center justify-end gap-2 px-6 py-4 bg-slate-50 border-t border-slate-100">
+              <button
+                type="button"
+                onClick={() => close(false)}
+                className="px-4 py-2 rounded-xl text-sm font-medium text-slate-700 bg-white border border-slate-200 hover:bg-slate-100 transition-colors"
+              >
+                {pending.options.cancelLabel ?? "İptal"}
+              </button>
+              <button
+                ref={confirmBtnRef}
+                type="button"
+                onClick={() => close(true)}
+                className={`px-4 py-2 rounded-xl text-sm font-semibold text-white transition-colors ${
+                  pending.options.danger
+                    ? "bg-red-600 hover:bg-red-700"
+                    : "bg-blue-600 hover:bg-blue-700"
+                }`}
+              >
+                {pending.options.confirmLabel ?? "Onayla"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </ConfirmContext.Provider>
+  );
+}

--- a/src/features/files/ui/StepFiles.tsx
+++ b/src/features/files/ui/StepFiles.tsx
@@ -14,6 +14,7 @@ import {
   X,
   Eye,
 } from "lucide-react";
+import { useConfirm } from "@/components/ui/ConfirmDialog";
 
 type StepFile = {
   id: string;
@@ -38,6 +39,7 @@ type Props = {
 };
 
 export function StepFiles({ stepId, currentUserId, currentUserRole, isDraft }: Props) {
+  const confirm = useConfirm();
   // #52: Taslak roadmap'te öğrenci dosya yükleyemez (mentor inceleme için yükleyebilir).
   const interactionLocked = isDraft && currentUserRole === "STUDENT";
   const [files, setFiles] = useState<StepFile[]>([]);
@@ -125,7 +127,13 @@ export function StepFiles({ stepId, currentUserId, currentUserRole, isDraft }: P
   }
 
   async function handleDelete(fileId: string) {
-    if (!confirm("Bu dosyayı silmek istediğinizden emin misiniz?")) return;
+    const ok = await confirm({
+      title: "Dosyayı sil",
+      description: "Bu dosyayı silmek istediğinizden emin misiniz?",
+      confirmLabel: "Sil",
+      danger: true,
+    });
+    if (!ok) return;
 
     try {
       const res = await fetch(`/api/steps/${stepId}/files/${fileId}`, {

--- a/src/features/messaging/ui/StepComments.tsx
+++ b/src/features/messaging/ui/StepComments.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { MessageSquare, Send, Loader2, Trash2, Pencil, X, User } from "lucide-react";
+import { useConfirm } from "@/components/ui/ConfirmDialog";
 import { toast } from "sonner";
 
 type Comment = {
@@ -26,6 +27,7 @@ type Props = {
 };
 
 export function StepComments({ stepId, currentUserId, currentUserRole, isDraft }: Props) {
+  const confirm = useConfirm();
   // #52: Taslak roadmap'te öğrenci yorum ekleyemez (mentor inceleme için ekleyebilir).
   const interactionLocked = isDraft && currentUserRole === "STUDENT";
   const [comments, setComments] = useState<Comment[]>([]);
@@ -118,7 +120,13 @@ export function StepComments({ stepId, currentUserId, currentUserRole, isDraft }
   }
 
   async function handleDelete(commentId: string) {
-    if (!confirm("Bu yorumu silmek istediğinizden emin misiniz?")) return;
+    const ok = await confirm({
+      title: "Yorumu sil",
+      description: "Bu yorumu silmek istediğinizden emin misiniz?",
+      confirmLabel: "Sil",
+      danger: true,
+    });
+    if (!ok) return;
 
     try {
       const res = await fetch(`/api/steps/${stepId}/comments/${commentId}`, {


### PR DESCRIPTION
## Özet
Denetim raporu ([docs/DESIGN-UX-AUDIT.md](docs/DESIGN-UX-AUDIT.md)) bulgu **#3**. 6 silme/onay noktası tarayıcının ham `confirm()`'ünü kullanıyordu — tasarım diliyle uyumsuz, buton metinleri tarayıcı diline bağlı ("OK/Cancel"), atama kaldırmada üst üste **iki** confirm çıkıyordu.

> Denetim planındaki **PR 2/3 (P1)**.

## Değişiklikler
- **`components/ui/ConfirmDialog.tsx`** (yeni) — söz-tabanlı (promise) onay dialogu:
  - `ConfirmDialogProvider` (root layout'ta bir kez) + `useConfirm()` hook.
  - Native `confirm` ergonomisini taklit eder → çağrı yerlerinde minimal değişiklik: `if (!(await confirm({ title, description, danger }))) return`.
  - `danger` varyantı kırmızı buton + uyarı ikonu; **Escape / backdrop / İptal → false**; açılışta onay butonuna focus; `role="alertdialog"` + `aria-modal`.
- **6 çağrı yeri** değiştirildi:
  - Admin şablon silme, roadmap adım silme, StepFiles dosya silme, StepComments yorum silme (basit).
  - Mentor **atama kaldırma** — iki aşamalı 409 akışı (ilerleme varsa ikinci onay) artık tek dialog deseniyle, ardışık iki native popup yerine iki ayrı stilize dialog.
- Root layout'a provider eklendi (`SessionProvider` içinde).

Kalan native `confirm()` **yok** (tarama ile doğrulandı).

## Test
`npm run build` ✓ · `npm run lint` (0 hata) · `npm test` (118/118 yeşil, regresyon yok).

> ⚠️ ConfirmDialog bir UI bileşeni; yerel Postgres/auth olmadan tam tarayıcı akışında (login → sil → dialog) uçtan uca göremedim. Build + izole doğrulukla teyit ettim.

### Manuel test adımları
1. Admin → Proje Şablonları → bir kartta **Sil** → stilize kırmızı onay dialogu açılır; **Escape**/dışarı tıklama iptal eder; **Sil** siler.
2. Mentor → öğrenci detay → **ilerlemesi olan** bir proje atamasını kaldır → önce "atamayı kaldır" dialogu, ardından backend 409 dönerse "öğrenci ilerlemesi var / Yine de sil" ikinci dialogu (iki ayrı stilize onay, ard arda tarayıcı popup'ı değil).
3. Roadmap editörü → adım sil; öğrenci/mentor → StepFiles dosya sil, StepComments yorum sil → hepsi aynı dialog.

## Acceptance Criteria
- [x] Tüm `confirm()` çağrıları ConfirmDialog ile değişir
- [x] Escape ve dışarı tıklama ile kapanır
- [x] Tehlikeli aksiyonlar (sil) görsel olarak ayrışır (kırmızı + uyarı ikonu)

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)