### PR TITLE
fix: dokunmatik cihazlarda satır eylemlerini görünür yap (#93)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000,
+      "autoPort": false
+    }
+  ]
+}

--- a/src/app/(mentor)/mentor-dashboard/[studentId]/page.tsx
+++ b/src/app/(mentor)/mentor-dashboard/[studentId]/page.tsx
@@ -428,7 +428,7 @@ export default function StudentDetailPage() {
                       <div key={project.id} className="border rounded-lg p-5 relative group bg-white hover:shadow-md transition-all">
                         <button 
                          onClick={() => handleDeleteAssignment(project.id)}
-                         className="absolute top-3 right-3 p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-full transition-colors opacity-0 group-hover:opacity-100 z-10"
+                         className="absolute top-3 right-3 p-1.5 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-full transition-colors opacity-100 md:opacity-0 md:group-hover:opacity-100 z-10"
                          title="Atamayı Kaldır"
                           >
                            <Trash2 className="w-4 h-4" />

--- a/src/features/files/ui/StepFiles.tsx
+++ b/src/features/files/ui/StepFiles.tsx
@@ -274,7 +274,7 @@ export function StepFiles({ stepId, currentUserId, currentUserRole, isDraft }: P
                   </div>
 
                   {/* Aksiyonlar */}
-                  <div className="flex items-center gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <div className="flex items-center gap-1 shrink-0 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
                     {/* Önizle/İndir */}
                     {file.mimeType.startsWith("image/") || file.mimeType === "application/pdf" ? (
                       <a

--- a/src/features/messaging/ui/StepComments.tsx
+++ b/src/features/messaging/ui/StepComments.tsx
@@ -227,7 +227,7 @@ export function StepComments({ stepId, currentUserId, currentUserRole, isDraft }
                           <p className="text-xs text-gray-700 leading-relaxed whitespace-pre-wrap break-words">
                             {comment.content}
                           </p>
-                          <div className="flex gap-0.5 ml-2 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0">
+                          <div className="flex gap-0.5 ml-2 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity flex-shrink-0">
                             {comment.author.id === currentUserId && (
                               <button
                                 onClick={() => { setEditingId(comment.id); setEditContent(comment.content); }}


### PR DESCRIPTION
## Özet

Hover'a bağlı satır-içi eylem butonları (`opacity-0 group-hover:opacity-100`) dokunmatik cihazlarda hiçbir zaman görünmüyordu — `:hover` durumu olmadığından kullanıcı butonları hiç göremiyordu. Bu, DESIGN-UX-AUDIT.md bulgu #4 (P1).

Üç noktada `opacity-100 md:opacity-0 md:group-hover:opacity-100` kullanıldı:
- Mobilde (`md` altı) butonlar **her zaman görünür**.
- Masaüstünde eski **hover-ile-belir** davranışı korunur.

## Değişiklikler

| Dosya | Etkilenen eylemler |
|---|---|
| `features/files/ui/StepFiles.tsx` | Dosya indir / önizle / sil |
| `features/messaging/ui/StepComments.tsx` | Yorum düzenle / sil |
| `app/(mentor)/mentor-dashboard/[studentId]/page.tsx` | Proje atamasını kaldır |

**Kasıtlı olarak değiştirilmedi:** `AIChatBot.tsx`'teki hover tooltip'i — bu bir eylem butonu değil, tamamlayıcı etiket; mobilde kalıcı göstermek yanlış olur.

## Test / Doğrulama

- `npx next lint` → yeni uyarı yok (yalnızca önceden var olanlar).
- `npx next build` → başarılı.
- Yerel Postgres + auth session olmadığından tarayıcı önizlemesi yapılamadı. Manuel doğrulama adımları:
  1. DevTools'ta cihazı mobil boyuta (< 768px) küçült veya gerçek dokunmatik cihazda aç.
  2. Bir roadmap adımında **Dosyalar** panelini aç → dosya satırındaki indir/önizle/sil ikonları hover olmadan görünür olmalı.
  3. **Yorumlar** panelinde → düzenle/sil ikonları görünür olmalı.
  4. Mentor öğrenci detayında atanmış proje kartında → "Atamayı Kaldır" (çöp kutusu) ikonu görünür olmalı.
  5. Masaüstünde (≥ 768px) davranış eskisi gibi: ikonlar yalnızca kart/satır üzerine gelince belirir.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)
