### PR TITLE
fix: mesajlaşma hata durumu + görünürlük-farkında polling (#97)

### DIFF
--- a/src/features/messaging/ui/MessagingPanel.tsx
+++ b/src/features/messaging/ui/MessagingPanel.tsx
@@ -47,6 +47,8 @@ export function MessagingPanel({ currentUserId }: Props) {
   const [loading, setLoading] = useState(true);
   const [sending, setSending] = useState(false);
   const [loadingMessages, setLoadingMessages] = useState(false);
+  const [conversationsError, setConversationsError] = useState(false);
+  const [messagesError, setMessagesError] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const pollRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -65,9 +67,13 @@ export function MessagingPanel({ currentUserId }: Props) {
       if (res.ok) {
         const data = await res.json();
         setConversations(data.conversations);
+        setConversationsError(false);
+      } else {
+        setConversationsError(true);
       }
     } catch (error) {
       console.error("Konuşmalar yüklenemedi:", error);
+      setConversationsError(true);
     } finally {
       setLoading(false);
     }
@@ -75,15 +81,22 @@ export function MessagingPanel({ currentUserId }: Props) {
 
   // Mesajları yükle
   const loadMessages = useCallback(async (partnerId: string, isPolling = false) => {
-    if (!isPolling) setLoadingMessages(true);
+    if (!isPolling) {
+      setLoadingMessages(true);
+      setMessagesError(false);
+    }
     try {
       const res = await fetch(`/api/messages?conversationWith=${partnerId}`);
       if (res.ok) {
         const data = await res.json();
         setMessages(data.messages.reverse()); // Eski → Yeni sırala
+      } else if (!isPolling) {
+        // Polling hatalarını sessiz geç — mevcut mesajları ekranda tut.
+        setMessagesError(true);
       }
     } catch (error) {
       console.error("Mesajlar yüklenemedi:", error);
+      if (!isPolling) setMessagesError(true);
     } finally {
       if (!isPolling) setLoadingMessages(false);
     }
@@ -99,9 +112,12 @@ export function MessagingPanel({ currentUserId }: Props) {
 
     loadMessages(selectedPartner.id);
 
-    // Polling: 5 saniyede bir yeni mesajları kontrol et
+    // Polling: 5 saniyede bir yeni mesajları kontrol et.
+    // Sekme arka plandayken istek atma (görünürlük-farkında).
     pollRef.current = setInterval(() => {
-      loadMessages(selectedPartner.id, true);
+      if (document.visibilityState === "visible") {
+        loadMessages(selectedPartner.id, true);
+      }
     }, 5000);
 
     return () => {
@@ -177,7 +193,21 @@ export function MessagingPanel({ currentUserId }: Props) {
           </h3>
         </div>
         <div className="flex-1 overflow-y-auto">
-          {conversations.length === 0 ? (
+          {conversationsError ? (
+            <div className="text-center py-12 px-4">
+              <MessageCircle className="w-10 h-10 text-gray-300 mx-auto mb-3" />
+              <p className="text-sm text-gray-600">Konuşmalar yüklenemedi.</p>
+              <button
+                onClick={() => {
+                  setLoading(true);
+                  loadConversations();
+                }}
+                className="mt-3 px-4 py-1.5 text-xs font-medium text-blue-600 border border-blue-200 rounded-lg hover:bg-blue-50 transition-colors"
+              >
+                Tekrar Dene
+              </button>
+            </div>
+          ) : conversations.length === 0 ? (
             <div className="text-center py-12 px-4">
               <MessageCircle className="w-10 h-10 text-gray-300 mx-auto mb-3" />
               <p className="text-sm text-gray-500">Henüz konuşma bulunmuyor.</p>
@@ -261,6 +291,18 @@ export function MessagingPanel({ currentUserId }: Props) {
               {loadingMessages ? (
                 <div className="flex items-center justify-center h-full">
                   <Loader2 className="w-5 h-5 animate-spin text-blue-600" />
+                </div>
+              ) : messagesError ? (
+                <div className="flex items-center justify-center h-full">
+                  <div className="text-center">
+                    <p className="text-sm text-gray-600">Mesajlar yüklenemedi.</p>
+                    <button
+                      onClick={() => loadMessages(selectedPartner.id)}
+                      className="mt-3 px-4 py-1.5 text-xs font-medium text-blue-600 border border-blue-200 rounded-lg hover:bg-blue-50 transition-colors"
+                    >
+                      Tekrar Dene
+                    </button>
+                  </div>
                 </div>
               ) : messages.length === 0 ? (
                 <div className="flex items-center justify-center h-full text-gray-400">

--- a/src/features/messaging/ui/UnreadBadge.tsx
+++ b/src/features/messaging/ui/UnreadBadge.tsx
@@ -16,6 +16,8 @@ export function UnreadBadge({ className = "" }: Props) {
 
   useEffect(() => {
     async function fetchCount() {
+      // Sekme arka plandayken istek atma (görünürlük-farkında polling).
+      if (document.visibilityState === "hidden") return;
       try {
         const res = await fetch("/api/messages/unread-count");
         if (res.ok) {
@@ -29,7 +31,17 @@ export function UnreadBadge({ className = "" }: Props) {
 
     fetchCount();
     const interval = setInterval(fetchCount, 15000); // 15 saniyede bir kontrol
-    return () => clearInterval(interval);
+
+    // Sekme tekrar öne geldiğinde beklemeden tazele.
+    const onVisible = () => {
+      if (document.visibilityState === "visible") fetchCount();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
   }, []);
 
   return (


### PR DESCRIPTION
## Özet

DESIGN-UX-AUDIT.md bulgu #7 (P2). Mesajlaşmadaki iki pürüz giderildi.

### 1. Sessiz liste hatası → "Tekrar Dene"
`loadConversations`/`loadMessages` istek başarısız olduğunda sessizce boş liste gösteriyordu — kullanıcı **"hiç konuşma yok"** ile **"istek başarısız"** durumunu ayırt edemiyordu. Admin sayfalarında [PR #88](https://github.com/Posinowa/AISigner/pull/88)'de uygulanan desenin aynısı:

- **Konuşma listesi:** `conversationsError` → hata mesajı + "Tekrar Dene" butonu.
- **Mesaj alanı:** `messagesError` → hata mesajı + "Tekrar Dene" butonu.
- **Polling hataları sessiz geçilir** — arka plandaki 5 sn'lik tazeleme başarısız olsa bile ekrandaki mevcut mesajlar silinmez.

### 2. Görünürlük-farkında polling
Panel (5 sn) ve `UnreadBadge` (15 sn) polling'leri sekme arka plandayken de istek atıyordu. Artık:
- `document.visibilityState === "visible"` değilken istek atlanır.
- `UnreadBadge` sekme tekrar öne geldiğinde `visibilitychange` ile 15 sn beklemeden hemen tazeler.

## Değişiklikler
- `src/features/messaging/ui/MessagingPanel.tsx`
- `src/features/messaging/ui/UnreadBadge.tsx`

## Test / Doğrulama
- `npx vitest run` → 118 test geçti (regresyon yok).
- `npx next lint` → değişen dosyalarda yeni uyarı yok.
- `npx next build` → başarılı.
- Yerel Postgres + auth session olmadığından tarayıcı önizlemesi yapılmadı. Manuel doğrulama:
  1. Mesajlar sayfasını aç → API'yi (DevTools > Network > offline) kes → "Konuşmalar yüklenemedi" + "Tekrar Dene" görünmeli; tıklayınca yeniden denemeli.
  2. Bir konuşma seçip API'yi kesince mesaj alanında aynı hata + retry görünmeli.
  3. Sekmeyi arka plana al → Network'te `conversations`/`unread-count` isteklerinin durduğunu, öne alınca tekrar başladığını gözlemle.

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)
