### PR TITLE
refactor: loading göstergelerini Loader2'de standartlaştır (#103)

### DIFF
--- a/src/app/(admin)/admin-dashboard/projects/page.tsx
+++ b/src/app/(admin)/admin-dashboard/projects/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { Plus, Pencil, Trash2, X, ArrowLeft, FolderKanban, Github, AlertCircle } from "lucide-react";
+import { Plus, Pencil, Trash2, X, ArrowLeft, FolderKanban, Github, AlertCircle, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
 
@@ -311,7 +311,7 @@ export default function ProjectsPage() {
       {/* Loading State */}
       {pageLoading ? (
         <div className="flex items-center justify-center py-12">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+          <Loader2 className="w-8 h-8 animate-spin text-blue-600" />
           <span className="ml-3 text-slate-600">Şablonlar yükleniyor...</span>
         </div>
       ) : loadError ? (

--- a/src/app/(mentor)/mentor-dashboard/[studentId]/page.tsx
+++ b/src/app/(mentor)/mentor-dashboard/[studentId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useParams, useSearchParams } from "next/navigation";
-import { ArrowLeft, User, Calendar, Target, Clock, BookOpen, Plus, CheckCircle, AlertCircle, Trash2, Sparkles, Map, Github } from "lucide-react"; // Map ikonu eklendi
+import { ArrowLeft, User, Calendar, Target, Clock, BookOpen, Plus, CheckCircle, AlertCircle, Trash2, Sparkles, Map, Github, Loader2 } from "lucide-react"; // Map ikonu eklendi
 import Link from "next/link";
 import { toast } from "sonner";
 import { experienceLevelLabel } from "@/lib/experience-level";
@@ -287,7 +287,7 @@ export default function StudentDetailPage() {
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+        <Loader2 className="w-8 h-8 animate-spin text-blue-600" />
         <span className="ml-3 text-gray-600">Öğrenci detayları yükleniyor...</span>
       </div>
     );
@@ -505,7 +505,7 @@ export default function StudentDetailPage() {
                               >
                                 {generatingRoadmapId === project.id ? (
                                   <>
-                                    <div className="animate-spin w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full mr-2" /> 
+                                    <Loader2 className="w-3.5 h-3.5 animate-spin mr-2" />
                                     Harita Çiziliyor...
                                   </>
                                 ) : (
@@ -557,7 +557,7 @@ export default function StudentDetailPage() {
                   }`}
                 >
                   {isAIThinking || templatesLoading ? (
-                    <div className="animate-spin w-4 h-4 border-2 border-current border-t-transparent rounded-full" />
+                    <Loader2 className="w-4 h-4 animate-spin" />
                   ) : (
                     <Sparkles className="w-4 h-4" />
                   )}

--- a/src/app/(mentor)/mentor-dashboard/roadmap/[roadmapId]/page.tsx
+++ b/src/app/(mentor)/mentor-dashboard/roadmap/[roadmapId]/page.tsx
@@ -21,6 +21,7 @@ import {
   ChevronDown,
   ChevronUp,
   Github,
+  Loader2,
 } from "lucide-react";
 import { StepComments } from "@/features/messaging/ui/StepComments";
 import { StepFiles } from "@/features/files/ui/StepFiles";
@@ -333,7 +334,7 @@ export default function RoadmapReviewPage() {
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-600" />
+        <Loader2 className="w-8 h-8 animate-spin text-purple-600" />
         <span className="ml-3 text-gray-600">Yol haritası yükleniyor...</span>
       </div>
     );
@@ -422,7 +423,7 @@ export default function RoadmapReviewPage() {
             }`}
           >
             {publishing ? (
-              <div className="animate-spin w-4 h-4 border-2 border-current border-t-transparent rounded-full" />
+              <Loader2 className="w-4 h-4 animate-spin" />
             ) : isDraft ? (
               <Send className="w-4 h-4" />
             ) : (

--- a/src/features/student/ui/OnboardingForm.tsx
+++ b/src/features/student/ui/OnboardingForm.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { saveOnboarding } from "@/features/student/server/onboarding";
-import { CheckCircle, User, Target, Award, ArrowRight, ArrowLeft, Rocket, Terminal, BookOpen, Clock, ClipboardList, AlertCircle } from "lucide-react";
+import { CheckCircle, User, Target, Award, ArrowRight, ArrowLeft, Rocket, Terminal, BookOpen, Clock, ClipboardList, AlertCircle, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import {
   buildSurveyAnswerPayload,
@@ -517,7 +517,7 @@ export default function OnboardingForm({
                   className="h-12 px-10 rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-bold transition-all shadow-lg shadow-blue-200 disabled:opacity-70"
                 >
                   {isSubmitting ? (
-                    <><div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin mr-3" /> Kaydediliyor...</>
+                    <><Loader2 className="w-5 h-5 animate-spin mr-3" /> Kaydediliyor...</>
                   ) : (
                     <><CheckCircle className="w-5 h-5 mr-2" /> Kaydı Tamamla</>
                   )}


### PR DESCRIPTION
## Özet

DESIGN-UX-AUDIT.md bulgu #11 (P2). Uygulamada üç farklı loading deseni bir aradaydı; hepsi tek standart olan `Loader2`'ye çevrildi.

### Çevrilenler
**Bölüm (tam ekran/alan) spinnerları — `border-b-2` dönen div → `Loader2`:**
- `app/(admin)/admin-dashboard/projects/page.tsx` — şablonlar yükleniyor
- `app/(mentor)/mentor-dashboard/roadmap/[roadmapId]/page.tsx` — yol haritası yükleniyor
- `app/(mentor)/mentor-dashboard/[studentId]/page.tsx` — sayfa yükleniyor

**Buton içi spinnerlar — `border-current border-t-transparent` → `Loader2`:**
- roadmap editörü: Yayınla
- `[studentId]`: "Harita Çiziliyor" + AI Öner (atama modalı)
- OnboardingForm: Kaydediliyor

`Loader2` de `currentColor`'ı miras aldığından buton içi renkler (beyaz/mor) korunur.

### Bilinçli korunan
`AIChatBot`'taki üç zıplayan nokta **jenerik loading spinner değil**, "bot yazıyor" göstergesidir (yerleşik sohbet UX deseni). Spinner'a çevirmek anlamı bozardı — olduğu gibi bırakıldı.

## Test / Doğrulama
- Kalan custom spinner taraması → 0.
- `npx vitest run` → 118 test geçti.
- `npx next lint` → yeni uyarı yok.
- `npx next build` → başarılı.

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)
