### PR TITLE
feat: AIChatBot intro tonu + markdown formatlama (#105)

### DIFF
--- a/src/features/ai/ui/AIChatBot.tsx
+++ b/src/features/ai/ui/AIChatBot.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, type ReactNode } from "react";
 import { X, Send, Loader2, GraduationCap, Minus } from "lucide-react";
 
 type ChatMessage = {
@@ -15,7 +15,7 @@ export function AIChatBot() {
     {
       role: "assistant",
       content:
-        "Merhaba! Ben Posilog. Yazılım, programlama ve proje adımların hakkında sorularını yanıtlayabilirim. Nasıl yardımcı olabilirim? 🎓",
+        "Merhaba! Ben Posilog. Ödevini senin yerine yapmam ama yazılım, programlama ve proje adımlarında yol gösteririm — kavramları açıklar, ipuçları veririm. Takıldığın yeri anlat, birlikte çözelim! 🎓",
     },
   ]);
   const [input, setInput] = useState("");
@@ -171,11 +171,9 @@ export function AIChatBot() {
               }`}
             >
               {msg.role === "assistant" ? (
-                <div className="whitespace-pre-wrap">
-                  {formatMessage(msg.content)}
-                </div>
+                <div className="space-y-1">{renderMessage(msg.content)}</div>
               ) : (
-                <p>{msg.content}</p>
+                <p className="whitespace-pre-wrap">{msg.content}</p>
               )}
             </div>
           </div>
@@ -228,8 +226,95 @@ export function AIChatBot() {
 }
 
 /**
- * Basit markdown formatlama (bold, code, bullet list)
+ * Satır içi markdown → React node'ları.
+ * Desteklenen: **kalın** ve `kod`. XSS-güvenli (HTML enjeksiyonu yok, sadece
+ * React elemanları üretir).
  */
-function formatMessage(text: string): string {
-  return text;
+function renderInline(text: string, keyPrefix: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  const regex = /(\*\*[^*]+\*\*|`[^`]+`)/g;
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  let i = 0;
+
+  while ((match = regex.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(text.slice(lastIndex, match.index));
+    }
+    const token = match[0];
+    if (token.startsWith("**")) {
+      nodes.push(
+        <strong key={`${keyPrefix}-b-${i}`} className="font-semibold">
+          {token.slice(2, -2)}
+        </strong>,
+      );
+    } else {
+      nodes.push(
+        <code
+          key={`${keyPrefix}-c-${i}`}
+          className="px-1 py-0.5 rounded bg-gray-100 text-purple-700 text-[13px] font-mono"
+        >
+          {token.slice(1, -1)}
+        </code>,
+      );
+    }
+    lastIndex = match.index + token.length;
+    i++;
+  }
+  if (lastIndex < text.length) {
+    nodes.push(text.slice(lastIndex));
+  }
+  return nodes;
+}
+
+/**
+ * Blok seviyesinde hafif markdown render'ı (bağımlılıksız, XSS-güvenli).
+ * Desteklenen: başlıklar, madde listeleri, paragraflar ve satır içi
+ * kalın/kod. Gemini yanıtlarındaki ham işaretleri temizler.
+ */
+function renderMessage(text: string): ReactNode {
+  const lines = text.split("\n");
+  const blocks: ReactNode[] = [];
+  let listItems: string[] = [];
+  let key = 0;
+
+  const flushList = () => {
+    if (listItems.length === 0) return;
+    const items = listItems;
+    const k = key++;
+    blocks.push(
+      <ul key={`ul-${k}`} className="list-disc pl-5 space-y-0.5">
+        {items.map((it, idx) => (
+          <li key={idx}>{renderInline(it, `li-${k}-${idx}`)}</li>
+        ))}
+      </ul>,
+    );
+    listItems = [];
+  };
+
+  for (const line of lines) {
+    const bullet = line.match(/^\s*[-*]\s+(.*)$/);
+    const heading = line.match(/^\s*#{1,6}\s+(.*)$/);
+    if (bullet) {
+      listItems.push(bullet[1]);
+      continue;
+    }
+    flushList();
+    if (heading) {
+      const k = key++;
+      blocks.push(
+        <p key={`h-${k}`} className="font-semibold">
+          {renderInline(heading[1], `h-${k}`)}
+        </p>,
+      );
+    } else if (line.trim() === "") {
+      blocks.push(<div key={`sp-${key++}`} className="h-1" />);
+    } else {
+      const k = key++;
+      blocks.push(<p key={`p-${k}`}>{renderInline(line, `p-${k}`)}</p>);
+    }
+  }
+  flushList();
+
+  return blocks;
 }


### PR DESCRIPTION
## Özet

DESIGN-UX-AUDIT.md bulgu #5 (P2). AIChatBot'taki iki tutarsızlık giderildi.

### 1. Intro tonu hizalandı
Frontend karşılama mesajı hâlâ "sorularını yanıtlayabilirim" diyordu; backend [#70](https://github.com/Posinowa/AISigner/pull/70)'te guidance-only'ye çevrilmişti. İkisi çelişiyordu. Yeni intro guidance-only politikayla uyumlu: "Ödevini senin yerine yapmam ama yol gösteririm…".

### 2. `formatMessage` no-op → gerçek markdown render'ı
Fonksiyon docstring'i "basit markdown formatlama" diyordu ama metni olduğu gibi döndürüyordu; kullanıcı `**kalın**`, `` `kod` ``, `-` liste gibi ham işaretleri görüyordu. Yerine **bağımlılıksız, XSS-güvenli** (hiç `dangerouslySetInnerHTML` yok, yalnızca React elemanları) hafif bir formatlayıcı:
- `renderInline`: `**kalın**` → `<strong>`, `` `kod` `` → `<code>`
- `renderMessage`: başlık (`#..`), madde listesi (`-`/`*`), paragraf blokları

> **Neden react-markdown değil:** `react-markdown` + `MarkdownContent` [#91](https://github.com/Posinowa/AISigner/pull/91)'de eklendi ama henüz `develop`'ta değil. Bu PR'ı ona bağımlı kılmamak için bağımsız, küçük bir çözüm yazıldı. #91 merge edilince istenirse `MarkdownContent`'e geçirilebilir.

Sohbet "yazıyor" göstergesi (üç zıplayan nokta) korundu — jenerik loading değil, sohbet UX deseni.

## Test / Doğrulama
- `npx vitest run` → 118 test geçti.
- `npx next lint` → yeni uyarı yok.
- `npx next build` → başarılı.
- Manuel doğrulama: Öğrenci panelinde Posilog'u aç → bir yanıtta `**kalın**`, `` `kod` `` ve `-` listelerin ham işaretler yerine biçimli göründüğünü doğrula.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
