### PR TITLE
fix: dar ekran taşma/sarma düzeltmeleri + küçük-metin bumpı (#107)

### DIFF
--- a/src/app/(admin)/admin-dashboard/page.tsx
+++ b/src/app/(admin)/admin-dashboard/page.tsx
@@ -306,7 +306,7 @@ export default function AdminDashboard() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/30 to-indigo-50/30">
-      <div className="max-w-7xl mx-auto p-6">
+      <div className="max-w-7xl mx-auto p-4 sm:p-6">
         {/* Header */}
         <div className="flex items-start justify-between mb-8 pt-2 gap-4 flex-wrap">
           <div>

--- a/src/app/(admin)/admin-dashboard/projects/page.tsx
+++ b/src/app/(admin)/admin-dashboard/projects/page.tsx
@@ -163,7 +163,7 @@ export default function ProjectsPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/30 to-indigo-50/30">
-      <div className="max-w-6xl mx-auto p-6">
+      <div className="max-w-6xl mx-auto p-4 sm:p-6">
       {/* Geri linki */}
       <Link
         href="/admin-dashboard"

--- a/src/app/(mentor)/mentor-dashboard/[studentId]/page.tsx
+++ b/src/app/(mentor)/mentor-dashboard/[studentId]/page.tsx
@@ -295,7 +295,7 @@ export default function StudentDetailPage() {
 
   if (!student) {
     return (
-      <div className="max-w-6xl mx-auto p-6">
+      <div className="max-w-6xl mx-auto p-4 sm:p-6">
         <div className="text-center py-12">
           <h3 className="text-lg font-medium text-gray-900 mb-2">Öğrenci bulunamadı</h3>
           <p className="text-gray-600 mb-4">Bu öğrenci size atanmamış olabilir.</p>
@@ -308,7 +308,7 @@ export default function StudentDetailPage() {
   }
 
   return (
-    <div className="max-w-6xl mx-auto p-6">
+    <div className="max-w-6xl mx-auto p-4 sm:p-6">
       {/* Header */}
       <div className="flex items-center mb-6">
         <Link href="/mentor-dashboard" className="mr-4 text-gray-600 hover:text-gray-900">

--- a/src/app/(mentor)/mentor-dashboard/roadmap/[roadmapId]/page.tsx
+++ b/src/app/(mentor)/mentor-dashboard/roadmap/[roadmapId]/page.tsx
@@ -357,24 +357,24 @@ export default function RoadmapReviewPage() {
 
   /* ─── Render ─── */
   return (
-    <div className="max-w-5xl mx-auto p-6">
+    <div className="max-w-5xl mx-auto p-4 sm:p-6">
       {/* Header */}
-      <div className="flex items-center justify-between mb-6">
-        <div className="flex items-center gap-3">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div className="flex items-center gap-3 min-w-0">
           <button
             onClick={() => router.back()}
             className="p-2 text-gray-500 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors"
           >
             <ArrowLeft className="w-5 h-5" />
           </button>
-          <div>
+          <div className="min-w-0">
             {editingTitle ? (
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 min-w-0">
                 <input
                   type="text"
                   value={titleValue}
                   onChange={(e) => setTitleValue(e.target.value)}
-                  className="text-xl font-bold text-gray-900 border-b-2 border-purple-500 outline-none bg-transparent py-1"
+                  className="min-w-0 flex-1 text-xl font-bold text-gray-900 border-b-2 border-purple-500 outline-none bg-transparent py-1"
                   autoFocus
                 />
                 <button onClick={handleSaveTitle} disabled={saving} className="text-purple-600 hover:text-purple-800">

--- a/src/features/messaging/ui/StepComments.tsx
+++ b/src/features/messaging/ui/StepComments.tsx
@@ -188,7 +188,7 @@ export function StepComments({ stepId, currentUserId, currentUserRole, isDraft }
                         <span className="text-xs font-semibold text-gray-800">
                           {getFullName(comment.author)}
                         </span>
-                        <span className={`px-1.5 py-0.5 text-[9px] font-bold rounded ${roleInfo.color}`}>
+                        <span className={`px-1.5 py-0.5 text-[10px] font-bold rounded ${roleInfo.color}`}>
                           {roleInfo.label}
                         </span>
                         <span className="text-[10px] text-gray-400">

--- a/src/features/messaging/ui/UnreadBadge.tsx
+++ b/src/features/messaging/ui/UnreadBadge.tsx
@@ -36,7 +36,7 @@ export function UnreadBadge({ className = "" }: Props) {
     <span className={`relative inline-flex ${className}`}>
       <MessageCircle className="w-5 h-5" />
       {count > 0 && (
-        <span className="absolute -top-1.5 -right-1.5 w-4 h-4 flex items-center justify-center text-[9px] font-bold text-white bg-red-500 rounded-full">
+        <span className="absolute -top-1.5 -right-1.5 w-4 h-4 flex items-center justify-center text-[10px] font-bold text-white bg-red-500 rounded-full">
           {count > 9 ? "9+" : count}
         </span>
       )}


### PR DESCRIPTION
## Özet

DESIGN-UX-AUDIT.md bulgu #8 + #6'dan ertelenen küçük-metin (P2). Görsel doğrulama gerektirmeyen, **güvenli ve düşük riskli** kod düzeyi responsive düzeltmeleri.

### Düzeltilenler
- **Roadmap editörü header'ı** — `justify-between` düzeninde sol başlık + sağ "Onayla ve Yayınla" butonu 375px'te yatay taşıyordu → `flex-col sm:flex-row` + `gap`. Başlık alanına `min-w-0`, başlık düzenleme input'una `min-w-0 flex-1` (taşma yerine daralma).
- **Sayfa container padding'leri** mobilde daraltıldı: roadmap editörü, mentor `[studentId]`, admin dashboard, admin projects → `p-4 sm:p-6` (mobilde daha fazla içerik genişliği).
- **Küçük-metin okunabilirlik bumpı** (#6'dan ertelenen): StepComments rol rozeti + UnreadBadge sayacı `text-[9px]` → `text-[10px]`.

### Kapsam notu
Bu **kod düzeyinde güvenli tur**tur — net taşma/sarma kalıpları hedeflendi. `grep` ile roadmap editöründe responsive-olmayan sabit grid bulunmadığı doğrulandı. Step\*/ProfileAnalysisCard gibi bileşenlerin ince görsel ayarı, **tarayıcıda gerçek genişliklerde (375px) doğrulanacak ayrı bir tur** olarak bırakıldı (kör düzeltmede regresyon riskini önlemek için).

## Test / Doğrulama
- `npx vitest run` → 118 test geçti.
- `npx next lint` → yeni uyarı yok.
- `npx next build` → başarılı.
- Manuel doğrulama (375px): roadmap editörü başlığı ve yayınla butonu alt alta akmalı, yatay kaydırma olmamalı; sayfa kenar boşlukları mobilde daha dar olmalı.

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)
