### PR TITLE
feat: rol bazlı kalıcı üst navigasyon (AppShell) (#109)

### DIFF
--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,6 +1,7 @@
 import { getServerSession } from "next-auth"
 import { authOptions } from "@/lib/auth/nextauth"
 import { redirect } from "next/navigation"
+import { AppShell } from "@/components/AppShell"
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
   const session = await getServerSession(authOptions)
@@ -11,5 +12,10 @@ export default async function AdminLayout({ children }: { children: React.ReactN
   // Rol admin değilse → anasayfaya yönlendir
   if (session.user.role !== "ADMIN") redirect("/")
 
-  return <>{children}</>
+  return (
+    <>
+      <AppShell role="ADMIN" />
+      {children}
+    </>
+  )
 }

--- a/src/app/(mentor)/layout.tsx
+++ b/src/app/(mentor)/layout.tsx
@@ -1,6 +1,7 @@
 import { getServerSession } from "next-auth"
 import { authOptions } from "@/lib/auth/nextauth"
 import { redirect } from "next/navigation"
+import { AppShell } from "@/components/AppShell"
 
 // 🔐 Bu layout, sadece mentor rolüne sahip kullanıcıların erişebileceği sayfaları korur.
 
@@ -15,5 +16,10 @@ export default async function MentorLayout({ children }: { children: React.React
     redirect("/")
   }
 
-  return <>{children}</>
+  return (
+    <>
+      <AppShell role="MENTOR" />
+      {children}
+    </>
+  )
 }

--- a/src/app/(student)/layout.tsx
+++ b/src/app/(student)/layout.tsx
@@ -2,6 +2,7 @@ import { getServerSession } from "next-auth"
 import { authOptions } from "@/lib/auth/nextauth"
 import { redirect } from "next/navigation"
 import { AIChatBot } from "@/features/ai/ui/AIChatBot"
+import { AppShell } from "@/components/AppShell"
 
 // 🔐 Bu layout, sadece student rolüne sahip kullanıcıların erişebileceği sayfaları korur.
 
@@ -18,6 +19,7 @@ export default async function StudentLayout({ children }: { children: React.Reac
 
   return (
     <>
+      <AppShell role="STUDENT" />
       {children}
       <AIChatBot />
     </>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { GraduationCap } from "lucide-react";
+import LogoutButton from "@/components/LogoutButton";
+import { UnreadBadge } from "@/features/messaging/ui/UnreadBadge";
+
+type Role = "ADMIN" | "MENTOR" | "STUDENT";
+type NavLink = { href: string; label: string };
+
+// Rol bazlı kalıcı üst navigasyon (#2). Route-group layout'larına gömülür.
+const navByRole: Record<Role, { home: string; links: NavLink[] }> = {
+  ADMIN: {
+    home: "/admin-dashboard",
+    links: [
+      { href: "/admin-dashboard", label: "Panel" },
+      { href: "/admin-dashboard/projects", label: "Projeler" },
+      { href: "/admin-dashboard/messages", label: "Mesajlar" },
+    ],
+  },
+  MENTOR: {
+    home: "/mentor-dashboard",
+    links: [
+      { href: "/mentor-dashboard", label: "Panel" },
+      { href: "/mentor-dashboard/messages", label: "Mesajlar" },
+    ],
+  },
+  STUDENT: {
+    home: "/student-dashboard",
+    links: [
+      { href: "/student-dashboard", label: "Panel" },
+      { href: "/student-dashboard/messages", label: "Mesajlar" },
+    ],
+  },
+};
+
+// Tam ekran akışlarda (onboarding / profil kurulumu) kabuk gizlenir.
+const HIDDEN_PREFIXES = ["/student-onboarding", "/profile-setup"];
+
+export function AppShell({ role }: { role: Role }) {
+  const pathname = usePathname();
+
+  if (HIDDEN_PREFIXES.some((p) => pathname.startsWith(p))) {
+    return null;
+  }
+
+  const { home, links } = navByRole[role];
+
+  // Ana panel linki tam eşleşme ister (alt sayfalarda vurgulanmasın);
+  // diğerleri (Mesajlar/Projeler) prefix eşleşmesiyle vurgulanır.
+  const isActive = (href: string) =>
+    href === home ? pathname === href : pathname.startsWith(href);
+
+  return (
+    <header className="sticky top-0 z-40 bg-white/90 backdrop-blur border-b border-slate-200">
+      <nav className="max-w-7xl mx-auto px-4 sm:px-6 h-14 flex items-center gap-3">
+        <Link href={home} className="flex items-center gap-2 shrink-0">
+          <span className="w-8 h-8 rounded-lg bg-gradient-to-br from-blue-600 to-indigo-600 text-white flex items-center justify-center shadow-sm">
+            <GraduationCap className="w-5 h-5" />
+          </span>
+          <span className="font-bold text-slate-900 hidden sm:inline">AISigner</span>
+        </Link>
+
+        <div className="flex items-center gap-1 overflow-x-auto">
+          {links.map((l) => {
+            const active = isActive(l.href);
+            const isMessages = l.href.endsWith("/messages");
+            return (
+              <Link
+                key={l.href}
+                href={l.href}
+                aria-current={active ? "page" : undefined}
+                className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium whitespace-nowrap transition-colors ${
+                  active
+                    ? "bg-blue-50 text-blue-700"
+                    : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                }`}
+              >
+                {isMessages && <UnreadBadge className="text-current" />}
+                {l.label}
+              </Link>
+            );
+          })}
+        </div>
+
+        <div className="ml-auto shrink-0">
+          <LogoutButton />
+        </div>
+      </nav>
+    </header>
+  );
+}


### PR DESCRIPTION
## Özet

DESIGN-UX-AUDIT.md bulgu #2 (P1) — **kademeli entegrasyon**. Route-group layout'ları şimdiye kadar yalnızca RBAC guard'dı; hiç görsel iskelet yoktu. Bu PR rol bazlı kalıcı bir üst navigasyon ekler.

### Yeni: `src/components/AppShell.tsx`
Sticky, ince bir üst navbar:
- **Logo** → role göre panele link (AISigner).
- **Rol bazlı linkler:** ADMIN → Panel · Projeler · Mesajlar; MENTOR & STUDENT → Panel · Mesajlar.
- **UnreadBadge** Mesajlar linkinde (okunmamış sayısı).
- **Aktif sayfa vurgusu** (`aria-current="page"`) — panel linki tam eşleşme, diğerleri prefix eşleşmesi.
- Sağda **LogoutButton**.
- Tam ekran akışlarda (**/student-onboarding**, **/profile-setup**) `usePathname` ile gizlenir.

Üç layout'a (`(admin)`/`(mentor)`/`(student)`) gömüldü.

## Kademeli karar (önemli)
Seçildiği üzere **mevcut sayfa header'larına dokunulmadı**. Bu yüzden bazı sayfalarda geçici olarak **navbar + sayfanın kendi header'ı** birlikte görünür (ör. çift LogoutButton). Bu bilinçli bir ara durum:

> **Takip adımı:** Sayfa header'larındaki tekrar eden "başlık + logout + unread" blokları ayrı bir PR'da temizlenecek; böylece üst gezinme tek yerden gelir ve sayfalar yalnızca kendi içerik başlıklarını tutar.

## Test / Doğrulama
- `npx vitest run` → 118 test geçti.
- `npx next lint` → yeni uyarı yok.
- `npx next build` → başarılı.
- Görsel doğrulama yerel Postgres + auth session gerektirdiğinden yapılmadı. Manuel doğrulama:
  1. Her rsolle giriş yap → üstte navbar görünmeli; linkler doğru sayfalara gitmeli; bulunulan sayfa vurgulanmalı.
  2. Mesajlar linkinde okunmamış rozeti görünmeli.
  3. Öğrenci onboarding / profil kurulumu sayfalarında navbar **görünmemeli**.
  4. Logo'ya tıklayınca role uygun panele dönmeli.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)
