### PR TITLE
fix: githubRepoUrl validasyonunda query/hash içeren URL'leri reddet

### DIFF
--- a/src/lib/validations/api.test.ts
+++ b/src/lib/validations/api.test.ts
@@ -81,6 +81,28 @@ describe("createTemplateSchema — githubRepoUrl (#49)", () => {
     ).toBe(true);
   });
 
+  it("#111: query string içeren URL'i reddeder", () => {
+    for (const url of [
+      "https://github.com/kullanici/repo?tab=readme",
+      "https://github.com/kullanici/repo/?tab=readme",
+    ]) {
+      expect(createTemplateSchema.safeParse({ ...templateBase, githubRepoUrl: url }).success).toBe(
+        false,
+      );
+    }
+  });
+
+  it("#111: hash içeren URL'i reddeder", () => {
+    for (const url of [
+      "https://github.com/kullanici/repo#readme",
+      "https://github.com/kullanici/repo/#readme",
+    ]) {
+      expect(createTemplateSchema.safeParse({ ...templateBase, githubRepoUrl: url }).success).toBe(
+        false,
+      );
+    }
+  });
+
   it("http (https değil) reddedilir", () => {
     const result = createTemplateSchema.safeParse({
       ...templateBase,

--- a/src/lib/validations/api.ts
+++ b/src/lib/validations/api.ts
@@ -63,6 +63,9 @@ const githubRepoUrlSchema = z
     try {
       const url = new URL(val);
       if (url.protocol !== "https:" || url.hostname !== "github.com") return false;
+      // #111: Query/hash pathname'e girmediği için segment kontrolünü geçiyordu
+      // (ör. ...?tab=readme, ...#readme). Yalnızca temiz repo kökü kabul edilir.
+      if (url.search !== "" || url.hash !== "") return false;
       // #83: Yalnızca repo kökü (owner/repo) kabul edilir; tree/issues/pull gibi
       // daha derin yollar reddedilir (önceki >=2 kontrolü bunları da geçiriyordu).
       const segments = url.pathname.split("/").filter(Boolean);


### PR DESCRIPTION
## Summary
`githubRepoUrlSchema` yalnızca pathname segment sayısını kontrol ettiği için `https://github.com/org/repo?tab=readme` ve `...#readme` gibi URL'ler validasyonu geçiyordu (query/hash pathname'e girmez). Bu PR yalnızca temiz repo kökünü kabul edecek şekilde sıkılaştırır.

## Changes
- `src/lib/validations/api.ts` — refine'a `url.search === "" && url.hash === ""` kontrolü (+4 satır).
- `src/lib/validations/api.test.ts` — query ve hash için negatif test case'leri (mevcut #83 test kalıbıyla aynı stil).

## Test
- `npm test` → 120/120 (2 yeni test dahil) · `npm run lint` 0 error · `npm run build` ✓
- Mevcut kabul davranışı korunuyor: `https://github.com/owner/repo` ve `.../repo/` geçmeye devam ediyor (mevcut testler yeşil).

## Reviewer Notes
- Davranış değişikliği yalnızca reddetme yönünde; mevcut geçerli kayıtlar etkilenmez.
- `githubIssueUrl` şeması bu PR kapsamı dışında bırakıldı (issue #111 yalnızca repo URL'ini kapsıyor); aynı sıkılaştırma orada da isteniyorsa ayrı issue açılabilir.

Closes #111
Refs #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)
