### PR TITLE
fix: ProjectTemplate.title için DB seviyesinde unique constraint

### DIFF
--- a/prisma/migrations/20260717145931_add_project_template_title_unique/migration.sql
+++ b/prisma/migrations/20260717145931_add_project_template_title_unique/migration.sql
@@ -1,0 +1,14 @@
+-- #112: ProjectTemplate.title unique constraint.
+-- Önce olası duplicate title'lar veri kaybı OLMADAN benzersizleştirilir:
+-- aynı title'a sahip daha yeni kayıtların sonuna kendi id'leri eklenir.
+-- (Silme yapılmaz: AssignedProject FK'ları RESTRICT olduğundan silme zaten riskli olurdu.)
+UPDATE "ProjectTemplate" t
+SET "title" = t."title" || ' (' || t."id" || ')'
+WHERE EXISTS (
+  SELECT 1 FROM "ProjectTemplate" t2
+  WHERE t2."title" = t."title"
+    AND (t2."createdAt" < t."createdAt" OR (t2."createdAt" = t."createdAt" AND t2."id" < t."id"))
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProjectTemplate_title_key" ON "ProjectTemplate"("title");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,7 +61,8 @@ model StudentProfile {
 
 model ProjectTemplate {
   id            String   @id @default(cuid())
-  title         String
+  // #112: Seed idempotency title lookup'ına dayanır; DB seviyesinde de benzersiz olmalı.
+  title         String   @unique
   description   String
   track         String[]
   difficulty    Difficulty

--- a/src/app/api/admin/project-templates/[id]/route.ts
+++ b/src/app/api/admin/project-templates/[id]/route.ts
@@ -18,6 +18,13 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ id: st
     const updated = await updateTemplate(id, parsed.data);
     return NextResponse.json(updated);
   } catch (error) {
+    // #112: Title güncellemesi mevcut bir şablonla çakışırsa → 409
+    if ((error as { code?: string })?.code === "DUPLICATE_TITLE") {
+      return NextResponse.json(
+        { error: "Bu başlıkta bir proje şablonu zaten var." },
+        { status: 409 }
+      );
+    }
     console.error("PATCH /api/admin/project-templates/[id] error:", error);
     return NextResponse.json({ error: "Failed to update template" }, { status: 500 });
   }

--- a/src/app/api/admin/project-templates/route.test.ts
+++ b/src/app/api/admin/project-templates/route.test.ts
@@ -70,3 +70,31 @@ describe("POST /api/admin/project-templates — githubRepoUrl (#49)", () => {
     expect(res.status).toBe(201);
   });
 });
+
+describe("POST /api/admin/project-templates — duplicate title (#112)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("aynı title ile ikinci şablonda 409 döner", async () => {
+    authAdmin();
+    prismaMock.projectTemplate.create.mockRejectedValue(
+      Object.assign(new Error("Unique constraint failed on title"), { code: "P2002" }),
+    );
+
+    const res = await POST(postReq(validBody));
+    const json = await res.json();
+
+    expect(res.status).toBe(409);
+    expect(json.error).toBe("Bu başlıkta bir proje şablonu zaten var.");
+  });
+
+  it("P2002 dışındaki DB hataları 500 olarak kalır", async () => {
+    authAdmin();
+    prismaMock.projectTemplate.create.mockRejectedValue(new Error("connection lost"));
+
+    const res = await POST(postReq(validBody));
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/admin/project-templates/route.ts
+++ b/src/app/api/admin/project-templates/route.ts
@@ -37,6 +37,13 @@ export async function POST(req: Request) {
     const newTemplate = await createTemplate(parsed.data);
     return NextResponse.json(newTemplate, { status: 201 });
   } catch (error) {
+    // #112: Aynı title ile ikinci şablon → 409 (500 değil)
+    if ((error as { code?: string })?.code === "DUPLICATE_TITLE") {
+      return NextResponse.json(
+        { error: "Bu başlıkta bir proje şablonu zaten var." },
+        { status: 409 }
+      );
+    }
     console.error("POST /api/admin/project-templates error:", error);
     return NextResponse.json(
       { error: "Failed to create template" },

--- a/src/features/projects/server/templates.ts
+++ b/src/features/projects/server/templates.ts
@@ -11,6 +11,18 @@ export type CreateTemplateData = {
 
 export type UpdateTemplateData = Partial<CreateTemplateData>;
 
+// #112: Prisma unique ihlalini (P2002) route'un 409'a çevirebileceği
+// ayırt edilebilir bir hataya dönüştürür (unassignProject'teki code kalıbı).
+function throwIfDuplicateTitle(error: unknown): void {
+  if ((error as { code?: string })?.code === "P2002") {
+    const err = new Error("Bu başlıkta bir proje şablonu zaten var.") as Error & {
+      code?: string;
+    };
+    err.code = "DUPLICATE_TITLE";
+    throw err;
+  }
+}
+
 export async function listTemplates() {
   try {
     return await prisma.projectTemplate.findMany({
@@ -37,6 +49,7 @@ export async function createTemplate(data: CreateTemplateData) {
     });
   } catch (error) {
     console.error("Error creating template:", error);
+    throwIfDuplicateTitle(error);
     throw new Error("Failed to create template");
   }
 }
@@ -49,6 +62,7 @@ export async function updateTemplate(id: string, data: UpdateTemplateData) {
     });
   } catch (error) {
     console.error("Error updating template:", error);
+    throwIfDuplicateTitle(error);
     throw new Error("Failed to update template");
   }
 }


### PR DESCRIPTION
## Summary
Seed, title-bazlı idempotent çalışıyordu ama DB seviyesinde `ProjectTemplate.title` unique değildi — eşzamanlı oluşturmada yarış koşuluyla çift şablon oluşabiliyordu. Bu PR kısıtı DB'ye taşır ve API'yi kullanıcı dostu hale getirir.

## Changes
- `prisma/schema.prisma` — `title` alanına `@unique`.
- Yeni migration — **veri kaybı yok**: önce olası duplicate title'lar id-suffix ile yeniden adlandırılır (AssignedProject FK'ları RESTRICT olduğundan silme yerine rename), sonra unique index oluşturulur.
- `templates.ts` — P2002'yi ayırt edilebilir `DUPLICATE_TITLE` hatasına çevirir (repodaki mevcut `err.code` kalıbı — `unassignProject` ile aynı desen).
- POST `/api/admin/project-templates` + PATCH `.../[id]` — duplicate title'da **409** + Türkçe mesaj (önceden 500).
- `route.test.ts` — 409 ve "diğer hatalar 500 kalır" testleri (mevcut vi.hoisted mock kalıbıyla).

## Test
- `npm test` → 120/120 (2 yeni) · lint 0 error · build ✓
- Migration lokalde uygulandı, `prisma migrate status` senkron.
- **Seed idempotency doğrulandı**: seed iki kez çalıştırıldı → ikinci çalıştırma "0 yeni, 6 zaten mevcuttu" (kısıtla uyumlu, hata yok).

## Reviewer Notes
- Migration dosyası PR Guard'da warning üretir (beklenen). SQL'deki dedup adımı yalnızca migration sırasında bir kez çalışır ve mevcut veriyi silmez.
- UI tarafında 409 mesajı, admin projelerindeki mevcut hata gösterimi (#59) üzerinden otomatik görünür.

Closes #112
Refs #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)
