### PR TITLE
fix: dosya yüklemede içerik imzası (magic bytes) doğrulaması

### DIFF
--- a/src/app/api/steps/[stepId]/files/route.test.ts
+++ b/src/app/api/steps/[stepId]/files/route.test.ts
@@ -85,3 +85,49 @@ describe("POST /api/steps/[stepId]/files — taslak (DRAFT) guard (#52/#69)", ()
     expect(prismaMock.stepFile.count).toHaveBeenCalledOnce();
   });
 });
+
+describe("POST /api/steps/[stepId]/files — içerik imzası (#113)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.stepFile.count.mockResolvedValue(0);
+  });
+
+  function makeUploadRequest(fileName: string, content: Uint8Array | string) {
+    const form = new FormData();
+    form.set("file", new File([content], fileName));
+    return new Request("http://test/api/steps/step-1/files", {
+      method: "POST",
+      body: form,
+    });
+  }
+
+  it("png uzantılı ama png imzası taşımayan içerik 400 ile reddedilir", async () => {
+    authAs(MENTOR_USER, "MENTOR");
+    prismaMock.roadmapStep.findUnique.mockResolvedValue(buildStep("PUBLISHED"));
+
+    const res = await POST(makeUploadRequest("evil.png", "bu bir metin, png degil"), ctx);
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toContain("uzantısıyla uyuşmuyor");
+  });
+
+  it("metin dosyasında (.txt) içerik kontrolü atlanır — imza hatası dönmez", async () => {
+    authAs(MENTOR_USER, "MENTOR");
+    prismaMock.roadmapStep.findUnique.mockResolvedValue(buildStep("PUBLISHED"));
+
+    const res = await POST(makeUploadRequest("notlar.txt", "serbest metin icerik"), ctx);
+
+    // İmza kontrolüne takılmadı (400 "uzantısıyla uyuşmuyor" değil);
+    // akış diske yazma/DB aşamasına ilerledi.
+    if (res.status === 400) {
+      const json = await res.json();
+      expect(String(json.error)).not.toContain("uzantısıyla uyuşmuyor");
+    }
+  });
+});
+
+// #113: fs erişimi mock'lanır (vi.mock hoist edilir, tüm dosya için geçerli) —
+// imza testleri gerçek diske yazmasın. Önceki testler fs'e zaten ulaşmıyor.
+vi.mock("fs/promises", () => ({ writeFile: vi.fn(), mkdir: vi.fn() }));
+vi.mock("fs", () => ({ existsSync: vi.fn(() => true) }));

--- a/src/app/api/steps/[stepId]/files/route.ts
+++ b/src/app/api/steps/[stepId]/files/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { requireAuth } from "@/lib/auth/guard";
 import { createRateLimiter } from "@/lib/rate-limit";
+import { matchesExtensionSignature } from "@/lib/file-signature";
 import { writeFile, mkdir } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
@@ -188,8 +189,19 @@ export async function POST(
       await mkdir(UPLOAD_DIR, { recursive: true });
     }
 
-    // Dosyayı diske yaz
     const buffer = Buffer.from(await file.arrayBuffer());
+
+    // #113: Binary formatlarda dosya içeriği (magic bytes) uzantıyla eşleşmeli.
+    // Uzantı whitelist'i tek başına yeterli değil — .png adlı bir çalıştırılabilir
+    // içerik burada reddedilir. Metin/kod dosyaları için kontrol atlanır.
+    if (!matchesExtensionSignature(ext, buffer)) {
+      return NextResponse.json(
+        { error: "Dosya içeriği uzantısıyla uyuşmuyor. Lütfen geçerli bir dosya yükleyin." },
+        { status: 400 }
+      );
+    }
+
+    // Dosyayı diske yaz
     const filePath = path.join(UPLOAD_DIR, storedName);
     await writeFile(filePath, buffer);
 

--- a/src/lib/file-signature.test.ts
+++ b/src/lib/file-signature.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { matchesExtensionSignature } from "./file-signature";
+
+const PNG_HEADER = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+const JPEG_HEADER = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00]);
+const GIF_HEADER = new Uint8Array([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
+const PDF_HEADER = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]);
+const ZIP_HEADER = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x14]);
+const WEBP_HEADER = new Uint8Array([
+  0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+]);
+const EXE_HEADER = new Uint8Array([0x4d, 0x5a, 0x90, 0x00]); // "MZ" — Windows PE
+const TEXT_BYTES = new Uint8Array([0x6d, 0x65, 0x72, 0x68, 0x61, 0x62, 0x61]); // "merhaba"
+
+describe("matchesExtensionSignature (#113)", () => {
+  it("geçerli binary imzaları kabul eder", () => {
+    expect(matchesExtensionSignature(".png", PNG_HEADER)).toBe(true);
+    expect(matchesExtensionSignature(".jpg", JPEG_HEADER)).toBe(true);
+    expect(matchesExtensionSignature(".jpeg", JPEG_HEADER)).toBe(true);
+    expect(matchesExtensionSignature(".gif", GIF_HEADER)).toBe(true);
+    expect(matchesExtensionSignature(".webp", WEBP_HEADER)).toBe(true);
+    expect(matchesExtensionSignature(".pdf", PDF_HEADER)).toBe(true);
+    expect(matchesExtensionSignature(".zip", ZIP_HEADER)).toBe(true);
+  });
+
+  it("PNG uzantılı ama PNG imzası taşımayan içeriği reddeder", () => {
+    expect(matchesExtensionSignature(".png", EXE_HEADER)).toBe(false);
+    expect(matchesExtensionSignature(".png", TEXT_BYTES)).toBe(false);
+    expect(matchesExtensionSignature(".png", JPEG_HEADER)).toBe(false);
+  });
+
+  it("uzantı-içerik çaprazlamalarını reddeder", () => {
+    expect(matchesExtensionSignature(".pdf", ZIP_HEADER)).toBe(false);
+    expect(matchesExtensionSignature(".zip", PDF_HEADER)).toBe(false);
+    expect(matchesExtensionSignature(".jpg", PNG_HEADER)).toBe(false);
+    expect(matchesExtensionSignature(".webp", GIF_HEADER)).toBe(false);
+  });
+
+  it("boş/çok kısa içerik binary uzantıda reddedilir", () => {
+    expect(matchesExtensionSignature(".png", new Uint8Array(0))).toBe(false);
+    expect(matchesExtensionSignature(".webp", new Uint8Array([0x52, 0x49]))).toBe(false);
+  });
+
+  it("metin/kod uzantılarında kontrol atlanır (her içerik geçer)", () => {
+    expect(matchesExtensionSignature(".txt", EXE_HEADER)).toBe(true);
+    expect(matchesExtensionSignature(".md", TEXT_BYTES)).toBe(true);
+    expect(matchesExtensionSignature(".js", TEXT_BYTES)).toBe(true);
+    expect(matchesExtensionSignature(".py", new Uint8Array(0))).toBe(true);
+  });
+
+  it("uzantıyı büyük/küçük harf duyarsız değerlendirir", () => {
+    expect(matchesExtensionSignature(".PNG", PNG_HEADER)).toBe(true);
+    expect(matchesExtensionSignature(".PNG", TEXT_BYTES)).toBe(false);
+  });
+});

--- a/src/lib/file-signature.ts
+++ b/src/lib/file-signature.ts
@@ -1,0 +1,42 @@
+/**
+ * #113: Uzantı ↔ dosya içeriği (magic bytes) doğrulaması.
+ *
+ * Yalnızca binary formatlar kontrol edilir — metin/kod dosyalarının (txt, md,
+ * js, py...) güvenilir bir imzası olmadığından onlar için kontrol atlanır.
+ * Harici bağımlılık gerektirmez; yalnızca dosyanın ilk baytları karşılaştırılır.
+ */
+
+function startsWith(bytes: Uint8Array, prefix: number[]): boolean {
+  if (bytes.length < prefix.length) return false;
+  return prefix.every((value, index) => bytes[index] === value);
+}
+
+const BINARY_SIGNATURES: Record<string, (bytes: Uint8Array) => boolean> = {
+  ".png": (b) => startsWith(b, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  ".jpg": (b) => startsWith(b, [0xff, 0xd8, 0xff]),
+  ".jpeg": (b) => startsWith(b, [0xff, 0xd8, 0xff]),
+  ".gif": (b) => startsWith(b, [0x47, 0x49, 0x46, 0x38]), // "GIF8"
+  ".webp": (b) =>
+    // RIFF....WEBP — 0-3 "RIFF", 8-11 "WEBP" (4-7 dosya boyutudur, atlanır)
+    startsWith(b, [0x52, 0x49, 0x46, 0x46]) &&
+    b.length >= 12 &&
+    b[8] === 0x57 &&
+    b[9] === 0x45 &&
+    b[10] === 0x42 &&
+    b[11] === 0x50,
+  ".pdf": (b) => startsWith(b, [0x25, 0x50, 0x44, 0x46]), // "%PDF"
+  ".zip": (b) =>
+    startsWith(b, [0x50, 0x4b, 0x03, 0x04]) || // normal arşiv
+    startsWith(b, [0x50, 0x4b, 0x05, 0x06]) || // boş arşiv
+    startsWith(b, [0x50, 0x4b, 0x07, 0x08]), // bölünmüş arşiv
+};
+
+/**
+ * Dosya içeriğinin uzantısıyla tutarlı olup olmadığını döner.
+ * Binary olmayan uzantılar (imza tanımı yok) her zaman `true` döner.
+ */
+export function matchesExtensionSignature(ext: string, bytes: Uint8Array): boolean {
+  const check = BINARY_SIGNATURES[ext.toLowerCase()];
+  if (!check) return true;
+  return check(bytes);
+}


### PR DESCRIPTION
## Summary
Upload route yalnızca dosya uzantısını whitelist'e göre kontrol ediyordu; içerik doğrulanmıyordu. `.png` adlı bir çalıştırılabilir/metin içerik kabul ediliyordu. Bu PR binary formatlar için dosyanın ilk baytlarını (magic bytes) uzantıyla eşleştirir.

## Changes
- `src/lib/file-signature.ts` — png/jpg/jpeg/gif/webp/pdf/zip imza kontrolü (harici bağımlılık yok; saf fonksiyon). Metin/kod uzantılarında kontrol atlanır.
- `files/route.ts` — buffer okunduktan sonra, diske yazmadan önce imza kontrolü; uyumsuzlukta **400** + Türkçe mesaj.
- `src/lib/file-signature.test.ts` — 6 saf unit test (geçerli imzalar, çaprazlamalar, boş içerik, case-insensitive).
- `files/route.test.ts` — route seviyesinde negatif/pozitif case + fs mock'u (testler gerçek diske yazmaz).

## Test
- `npm test` → 126/126 (8 yeni) · lint 0 error · build ✓
- Reddedilen istek diske yazma ve DB aşamasına hiç ulaşmaz (kontrol writeFile'dan önce).

## Reviewer Notes
- Mevcut savunma katmanları (nosniff, CSP sandbox, attachment disposition) korunuyor; bu kontrol ek katman.
- Metin/kod dosyaları (txt/md/js/py...) için güvenilir imza olmadığından davranışları değişmedi.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)
