### PR TITLE
chore: admin hata mesajı mantığını ortak helper'a taşı ve test kapsamına al

### DIFF
--- a/src/app/(admin)/admin-dashboard/page.tsx
+++ b/src/app/(admin)/admin-dashboard/page.tsx
@@ -3,6 +3,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { extractApiErrorMessage } from "@/lib/api-error-message";
 import {
   Users,
   GraduationCap,
@@ -141,18 +142,10 @@ export default function AdminDashboard() {
         setUsers((prev) => prev.map((u) => (u.id === userId ? { ...u, role } : u)));
         toast.success("Rol güncellendi.");
       } else {
-        // #59: Hata hem düz string (ör. "kendi rolünü değiştiremezsin" guard'ı, 403)
-        // hem zod fieldErrors objesi olarak gelebilir — ikisi de gösterilsin.
+        // #59/#114: Hata hem düz string (guard, 403) hem zod fieldErrors objesi
+        // olarak gelebilir — ortak, test edilen helper ikisini de ele alır.
         const data = await response.json().catch(() => null);
-        const fieldErrors = data?.error;
-        let message = "Rol güncellenemedi.";
-        if (typeof fieldErrors === "string" && fieldErrors.trim().length > 0) {
-          message = fieldErrors;
-        } else if (fieldErrors && typeof fieldErrors === "object") {
-          const firstMessage = Object.values(fieldErrors).flat()[0];
-          if (firstMessage) message = String(firstMessage);
-        }
-        toast.error(message);
+        toast.error(extractApiErrorMessage(data, "Rol güncellenemedi."));
       }
     } catch (error) {
       console.error("Error updating role:", error);
@@ -189,11 +182,9 @@ export default function AdminDashboard() {
         );
         toast.success(mentorId === "" ? "Mentor ataması kaldırıldı." : "Mentor atandı.");
       } else {
-        // #43: Geçersiz rol gibi 4xx hatalarında anlamlı mesajı göster.
+        // #43/#114: Geçersiz rol gibi 4xx hatalarında anlamlı mesajı göster.
         const data = await response.json().catch(() => null);
-        const msg =
-          data && typeof data.error === "string" ? data.error : "Mentor atanamadı.";
-        toast.error(msg);
+        toast.error(extractApiErrorMessage(data, "Mentor atanamadı."));
       }
     } catch (error) {
       console.error("Error assigning mentor:", error);
@@ -224,9 +215,7 @@ export default function AdminDashboard() {
         );
       } else {
         const data = await response.json().catch(() => null);
-        const msg =
-          data && typeof data.error === "string" ? data.error : "Durum güncellenemedi.";
-        toast.error(msg);
+        toast.error(extractApiErrorMessage(data, "Durum güncellenemedi."));
       }
     } catch {
       toast.error("Bağlantı hatası. Lütfen tekrar deneyin.");

--- a/src/app/(admin)/admin-dashboard/projects/page.tsx
+++ b/src/app/(admin)/admin-dashboard/projects/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback } from "react";
 import { Plus, Pencil, Trash2, X, ArrowLeft, FolderKanban, Github, AlertCircle } from "lucide-react";
 import Link from "next/link";
 import { toast } from "sonner";
+import { extractApiErrorMessage } from "@/lib/api-error-message";
 
 type ProjectTemplate = {
   id: string;
@@ -115,16 +116,9 @@ export default function ProjectsPage() {
       }
 
       if (!res.ok) {
+        // #114: string / fieldErrors ayrımı ortak helper'da (test edilen tek kaynak).
         const data = await res.json().catch(() => null);
-        const fieldErrors = data?.error;
-        let message = "Şablon kaydedilemedi.";
-        if (fieldErrors && typeof fieldErrors === "object") {
-          const firstMessage = Object.values(fieldErrors).flat()[0];
-          if (firstMessage) message = String(firstMessage);
-        } else if (typeof fieldErrors === "string") {
-          message = fieldErrors;
-        }
-        toast.error(message);
+        toast.error(extractApiErrorMessage(data, "Şablon kaydedilemedi."));
         return;
       }
 

--- a/src/lib/api-error-message.test.ts
+++ b/src/lib/api-error-message.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { extractApiErrorMessage } from "./api-error-message";
+
+const FALLBACK = "İşlem başarısız.";
+
+describe("extractApiErrorMessage (#114)", () => {
+  it("düz string hatayı aynen döner (guard/iş kuralı mesajları)", () => {
+    expect(
+      extractApiErrorMessage({ error: "Kendi rolünüzü değiştiremezsiniz." }, FALLBACK),
+    ).toBe("Kendi rolünüzü değiştiremezsiniz.");
+  });
+
+  it("zod fieldErrors objesinden ilk mesajı döner", () => {
+    const body = { error: { title: ["Başlık gerekli"], description: ["Açıklama gerekli"] } };
+    expect(extractApiErrorMessage(body, FALLBACK)).toBe("Başlık gerekli");
+  });
+
+  it("boş string hatada fallback döner", () => {
+    expect(extractApiErrorMessage({ error: "" }, FALLBACK)).toBe(FALLBACK);
+    expect(extractApiErrorMessage({ error: "   " }, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("boş fieldErrors objesinde/boş dizilerde fallback döner", () => {
+    expect(extractApiErrorMessage({ error: {} }, FALLBACK)).toBe(FALLBACK);
+    expect(extractApiErrorMessage({ error: { title: [] } }, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("gövde null/undefined/bozuk ise fallback döner (json parse fail senaryosu)", () => {
+    expect(extractApiErrorMessage(null, FALLBACK)).toBe(FALLBACK);
+    expect(extractApiErrorMessage(undefined, FALLBACK)).toBe(FALLBACK);
+    expect(extractApiErrorMessage("duz metin govde", FALLBACK)).toBe(FALLBACK);
+    expect(extractApiErrorMessage({}, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("error alanı beklenmeyen tipteyse (sayı/bool) fallback döner", () => {
+    expect(extractApiErrorMessage({ error: 42 }, FALLBACK)).toBe(FALLBACK);
+    expect(extractApiErrorMessage({ error: true }, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("fieldErrors dizi olmayan değer içerse de String'e çevirip döner", () => {
+    expect(extractApiErrorMessage({ error: { userId: "Kullanıcı ID gerekli" } }, FALLBACK)).toBe(
+      "Kullanıcı ID gerekli",
+    );
+  });
+});

--- a/src/lib/api-error-message.ts
+++ b/src/lib/api-error-message.ts
@@ -1,0 +1,26 @@
+/**
+ * #114: API hata gövdesinden kullanıcıya gösterilecek mesajı çıkarır.
+ *
+ * API'lerimiz hatayı iki şekilde döner:
+ *  - düz string:      `{ error: "Kendi rolünüzü değiştiremezsiniz." }` (guard/iş kuralı)
+ *  - zod fieldErrors: `{ error: { title: ["Başlık gerekli"], ... } }` (validasyon)
+ *
+ * Bu iki şekli tek yerde ele alır; boş/tanımsız/bozuk gövdede fallback döner.
+ * Admin sayfalarındaki kopyalanmış inline mantığın tek, test edilen kaynağıdır.
+ */
+export function extractApiErrorMessage(body: unknown, fallback: string): string {
+  const error = (body as { error?: unknown } | null | undefined)?.error;
+
+  if (typeof error === "string" && error.trim().length > 0) {
+    return error;
+  }
+
+  if (error && typeof error === "object") {
+    const first = Object.values(error as Record<string, unknown>).flat()[0];
+    if (first !== undefined && first !== null && String(first).trim().length > 0) {
+      return String(first);
+    }
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
## Summary
Admin panelindeki "string vs zod fieldErrors" hata mesajı çıkarma mantığı 4 yerde kopyalanmıştı ve hiçbiri test edilemiyordu (#89 madde 3). Bu PR mantığı tek, tam test edilen bir helper'da toplar.

## Changes
- `src/lib/api-error-message.ts` — `extractApiErrorMessage(body, fallback)`: düz string, fieldErrors objesi, boş/bozuk gövde, beklenmeyen tipler.
- `src/lib/api-error-message.test.ts` — 7 unit test (#89-3'ün "string ve fieldErrors mesajları doğru gösteriliyor mu" maddesini tam kapsar).
- Admin dashboard (rol güncelleme, mentor atama, hesap durumu) + projects sayfası helper'a bağlandı.

## Test
- `npm test` → 125/125 (7 yeni) · lint 0 error · build ✓

## Reviewer Notes
- Rol güncelleme ve şablon kaydetme için davranış birebir aynı (mantık taşındı). Mentor atama ve hesap durumu için küçük bir iyileşme: önceden yalnızca string hata gösteriliyordu, artık fieldErrors objesi de doğru mesaja çevriliyor (#59'un amacıyla uyumlu).
- #89-3'ün "fetch fail → error state" maddeleri kod düzeyinde zaten mevcut (`loadError` state'i: admin page ve projects page). Bunların render doğrulaması component-test altyapısı (jsdom/@testing-library) gerektirir — repoda henüz yok; ayrı bir altyapı issue'su olarak değerlendirilebilir.

Closes #114
Refs #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)
