### PR TITLE
chore: profile-setup prefill regresyon testleri

### DIFF
--- a/src/features/student/models/onboardingInitial.test.ts
+++ b/src/features/student/models/onboardingInitial.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { buildOnboardingDefaultValues, shouldShowSurveyStep } from "./onboardingInitial";
+import { compileGoals } from "./compiledGoals";
+
+describe("buildOnboardingDefaultValues (#115)", () => {
+  it("profil YOK (initial undefined) → tüm alanlar boş varsayılanlarla döner", () => {
+    const d = buildOnboardingDefaultValues(undefined);
+
+    expect(d.personal).toEqual({
+      firstName: "",
+      lastName: "",
+      birthYear: undefined,
+      phoneNumber: "",
+    });
+    expect(d.experience).toEqual({ level: "", knownTech: "" });
+    expect(d.vision).toEqual({ interest: [], futureGoal: "" });
+    expect(d.workingStyle).toEqual({ learningStyle: "", availability: "" });
+  });
+
+  it("yalnızca signup verisi (profil alanları yok) → personal dolu, gerisi boş", () => {
+    const d = buildOnboardingDefaultValues({
+      firstName: "Alper",
+      lastName: "Ersü",
+      phoneNumber: "05551234567",
+    });
+
+    expect(d.personal.firstName).toBe("Alper");
+    expect(d.personal.lastName).toBe("Ersü");
+    expect(d.personal.phoneNumber).toBe("05551234567");
+    expect(d.experience.level).toBe("");
+    expect(d.vision.interest).toEqual([]);
+  });
+
+  it("profil VAR → tüm alanlar prefill edilir; compiled goals round-trip bozulmaz", () => {
+    // #89-2: goals compile → parse round-trip'inin prefill ile bozulmadığını doğrula.
+    const compiled = compileGoals({
+      knownTech: "C++ gördüm, HTML/CSS ile site yaptım",
+      futureGoal: "AI destekli web uygulaması geliştirmek",
+      learningStyle: "Adım adım doküman okuyarak",
+    });
+
+    const d = buildOnboardingDefaultValues({
+      firstName: "Alper",
+      lastName: "Ersü",
+      phoneNumber: "05551234567",
+      birthYear: 2002,
+      experienceLevel: "INTERMEDIATE",
+      interests: ["AI", "Web Development"],
+      goals: compiled,
+      availability: "part-time",
+    });
+
+    expect(d.personal.birthYear).toBe(2002);
+    expect(d.experience.knownTech).toBe("C++ gördüm, HTML/CSS ile site yaptım");
+    expect(d.vision.futureGoal).toBe("AI destekli web uygulaması geliştirmek");
+    expect(d.workingStyle.learningStyle).toBe("Adım adım doküman okuyarak");
+    expect(d.vision.interest).toEqual(["AI", "Web Development"]);
+    expect(d.workingStyle.availability).toBe("part-time");
+  });
+
+  it("experienceLevel DB→form eşlemesi sabittir (#89-2)", () => {
+    const cases: Array<[string, string]> = [
+      ["BEGINNER", "beginner"],
+      ["INTERMEDIATE", "intermediate"],
+      ["ADVANCED", "advanced"],
+    ];
+    for (const [db, form] of cases) {
+      expect(buildOnboardingDefaultValues({ experienceLevel: db }).experience.level).toBe(form);
+    }
+  });
+
+  it("derlenmemiş (serbest) goals metni knownTech'e düşmez, formatı bozmaz", () => {
+    // parseCompiledGoals derlenmemiş metinde alanları boş döndürür — prefill
+    // eski/serbest formatlı goals verisiyle patlamamalı.
+    const d = buildOnboardingDefaultValues({ goals: "sadece düz bir hedef cümlesi" });
+    expect(typeof d.experience.knownTech).toBe("string");
+    expect(typeof d.vision.futureGoal).toBe("string");
+  });
+});
+
+describe("shouldShowSurveyStep (#115)", () => {
+  it("soru VAR → adım gösterilir (survey yüklendi senaryosu)", () => {
+    expect(shouldShowSurveyStep(3, false)).toBe(true);
+  });
+
+  it("soru YOK + yükleme başarılı (gerçek boş) → adım gizlenir", () => {
+    expect(shouldShowSurveyStep(0, false)).toBe(false);
+  });
+
+  it("yükleme BAŞARISIZ → soru olmasa da adım gösterilir (uyarı görünsün)", () => {
+    expect(shouldShowSurveyStep(0, true)).toBe(true);
+  });
+});

--- a/src/features/student/models/onboardingInitial.ts
+++ b/src/features/student/models/onboardingInitial.ts
@@ -1,0 +1,59 @@
+/**
+ * #115: profile-setup prefill eşlemesi — sayfadan gelen `initial` verisinin
+ * OnboardingForm'un defaultValues şekline dönüştürülmesi.
+ *
+ * Bu mantık önceden OnboardingForm içinde inline'dı ve kombinasyonları
+ * (profil var/yok, compiled goals round-trip, experienceLevel map) test
+ * edilemiyordu. Saf fonksiyon olarak buradan hem form hem testler kullanır.
+ */
+import { parseCompiledGoals } from "./compiledGoals";
+import { experienceLevelToFormValue } from "@/lib/experience-level";
+
+export type OnboardingInitialValues = {
+  firstName?: string;
+  lastName?: string;
+  phoneNumber?: string;
+  // #55: Mevcut StudentProfile alanları — profile-setup'a dönen öğrenci için prefill.
+  birthYear?: number;
+  experienceLevel?: string;
+  interests?: string[];
+  goals?: string;
+  availability?: string;
+};
+
+export function buildOnboardingDefaultValues(initial?: OnboardingInitialValues) {
+  // #55: Mevcut StudentProfile.goals tek bir derlenmiş string — form'un üç ayrı
+  // alanına (knownTech/futureGoal/learningStyle) geri ayrıştırılır.
+  const parsedGoals = parseCompiledGoals(initial?.goals);
+
+  return {
+    personal: {
+      firstName: initial?.firstName ?? "",
+      lastName: initial?.lastName ?? "",
+      birthYear: initial?.birthYear ?? undefined,
+      phoneNumber: initial?.phoneNumber ?? "",
+    },
+    experience: {
+      level: initial?.experienceLevel ? experienceLevelToFormValue(initial.experienceLevel) : "",
+      knownTech: parsedGoals.knownTech,
+    },
+    vision: {
+      interest: initial?.interests ?? [],
+      futureGoal: parsedGoals.futureGoal,
+    },
+    workingStyle: {
+      learningStyle: parsedGoals.learningStyle,
+      availability: initial?.availability ?? "",
+    },
+  };
+}
+
+/**
+ * #83/#115: "Ek Sorular" adımı gösterilmeli mi?
+ * Gerçek boş (admin hiç soru tanımlamamış) → adım gizlenir.
+ * Yükleme başarısız → adım GÖSTERİLİR ki kullanıcı hatayı görsün
+ * (adımın "hiç soru yokmuş" gibi sessizce kaybolması yerine).
+ */
+export function shouldShowSurveyStep(questionCount: number, loadFailed: boolean): boolean {
+  return questionCount > 0 || loadFailed;
+}

--- a/src/features/student/ui/OnboardingForm.tsx
+++ b/src/features/student/ui/OnboardingForm.tsx
@@ -15,8 +15,12 @@ import {
   extractSurveyErrorMessage,
   type SurveyQuestionView,
 } from "@/features/survey/answers";
-import { compileGoals, parseCompiledGoals } from "@/features/student/models/compiledGoals";
-import { experienceLevelToFormValue } from "@/lib/experience-level";
+import { compileGoals } from "@/features/student/models/compiledGoals";
+import {
+  buildOnboardingDefaultValues,
+  shouldShowSurveyStep,
+  type OnboardingInitialValues,
+} from "@/features/student/models/onboardingInitial";
 
 import type { FieldPath } from "react-hook-form";
 
@@ -72,18 +76,6 @@ const interests = [
   { id: "Cybersecurity", label: "Siber Güvenlik", emoji: "🛡️" }
 ];
 
-type OnboardingInitialValues = {
-  firstName?: string;
-  lastName?: string;
-  phoneNumber?: string;
-  // #55: Mevcut StudentProfile alanları — profile-setup'a dönen öğrenci için prefill.
-  birthYear?: number;
-  experienceLevel?: string;
-  interests?: string[];
-  goals?: string;
-  availability?: string;
-};
-
 export default function OnboardingForm({
   initial,
   surveyQuestions = [],
@@ -99,7 +91,7 @@ export default function OnboardingForm({
   // #46: Admin anket soruları varsa forma ek bir "Ek Sorular" adımı eklenir.
   // #83: Sorular yüklenemediyse de (gerçek boş değilse) adım gösterilir — kullanıcı
   // hatayı görsün, adımın "hiç soru yokmuş" gibi sessizce kaybolması yerine.
-  const hasSurvey = surveyQuestions.length > 0 || surveyLoadFailed;
+  const hasSurvey = shouldShowSurveyStep(surveyQuestions.length, surveyLoadFailed);
   const allSteps = hasSurvey
     ? [
         ...steps,
@@ -119,33 +111,12 @@ export default function OnboardingForm({
     new Array(allSteps.length).fill(false),
   );
 
-  // #55: Mevcut StudentProfile.goals tek bir derlenmiş string — form'un üç ayrı
-  // alanına (knownTech/futureGoal/learningStyle) geri ayrıştırılır.
-  const parsedGoals = parseCompiledGoals(initial?.goals);
-
   const { register, handleSubmit, trigger, clearErrors, formState: { errors } } = useForm<EnhancedFormData>({
     resolver: zodResolver(enhancedSchema),
     mode: "onSubmit",
-    defaultValues: {
-      personal: {
-        firstName: initial?.firstName ?? "",
-        lastName: initial?.lastName ?? "",
-        birthYear: initial?.birthYear ?? undefined,
-        phoneNumber: initial?.phoneNumber ?? "",
-      },
-      experience: {
-        level: initial?.experienceLevel ? experienceLevelToFormValue(initial.experienceLevel) : "",
-        knownTech: parsedGoals.knownTech,
-      },
-      vision: {
-        interest: initial?.interests ?? [],
-        futureGoal: parsedGoals.futureGoal,
-      },
-      workingStyle: {
-        learningStyle: parsedGoals.learningStyle,
-        availability: initial?.availability ?? "",
-      },
-    },
+    // #55/#115: Prefill eşlemesi (compiled goals ayrıştırma + experienceLevel map)
+    // test edilen saf fonksiyonda — bkz. models/onboardingInitial.ts
+    defaultValues: buildOnboardingDefaultValues(initial),
   });
 
   const stepFields: FieldPath<EnhancedFormData>[][] = [


### PR DESCRIPTION
## Summary
Profile-setup prefill akışının (#55 + #46) kombinasyonları için regresyon testi yoktu (#89 madde 2). Prefill eşlemesi OnboardingForm içinde inline olduğundan test edilemiyordu — saf fonksiyonlara çıkarılıp tam test altına alındı. **Davranış birebir aynı.**

## Changes
- `models/onboardingInitial.ts` — `buildOnboardingDefaultValues(initial)` (compiled goals ayrıştırma + experienceLevel map + boş varsayılanlar) ve `shouldShowSurveyStep(count, loadFailed)` ("gerçek boş" vs "yükleme başarısız" ayrımı).
- `models/onboardingInitial.test.ts` — 8 test: profil yok, yalnızca signup verisi, profil var (tam prefill), **goals compile→parse round-trip**, **experienceLevel BEGINNER/INTERMEDIATE/ADVANCED map sabitliği**, derlenmemiş legacy goals, survey adım görünürlüğünün 3 durumu.
- `OnboardingForm.tsx` — inline mantık yerine model fonksiyonları (mevcut compiledGoals/experience-level test kalıpları yeniden kullanıldı).

## Test
- `npm test` → 126/126 (8 yeni) · lint 0 error · build ✓

## Reviewer Notes
- #89-2'nin 5 maddesi mantık düzeyinde kapsandı. "Survey load failure uyarısı görünmeli" JSX render doğrulaması component-test altyapısı gerektirir (repoda yok) — adımın gösterilme kararı (`shouldShowSurveyStep`) test edildi.

Closes #115
Refs #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)
