### PR TITLE
chore: 'Şifremi Unuttum' linkini şifre alanının altına taşı

### DIFF
--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -117,12 +117,7 @@ function SigninForm() {
 
               {/* Şifre */}
               <div>
-                <div className="flex items-center justify-between mb-1.5">
-                  <label htmlFor="signin-password" className="text-sm font-medium text-slate-700">Şifre</label>
-                  <Link href="/forgot-password" className="text-xs font-medium text-amber-600 hover:text-amber-700">
-                    Şifremi Unuttum
-                  </Link>
-                </div>
+                <label htmlFor="signin-password" className="mb-1.5 block text-sm font-medium text-slate-700">Şifre</label>
                 <div className="relative">
                   <input
                     id="signin-password"
@@ -145,6 +140,11 @@ function SigninForm() {
                 {state.error?.password && (
                   <p className="mt-1 text-xs text-red-500">{state.error.password[0]}</p>
                 )}
+                <div className="mt-1.5 text-right">
+                  <Link href="/forgot-password" className="text-xs font-medium text-amber-600 hover:text-amber-700">
+                    Şifremi Unuttum
+                  </Link>
+                </div>
               </div>
 
               {/* Genel hata */}


### PR DESCRIPTION
## Summary
Kullanıcı geri bildirimi: signin'de "Şifremi Unuttum" linki şifre etiketinin sağında (üstte) duruyordu; daha yaygın olan **şifre alanının altına** taşındı.

## Changes
- `src/app/(auth)/signin/page.tsx` — link label satırından çıkarıldı; şifre input'unun (ve hata mesajının) altına, sağa hizalı olarak eklendi. Şifre etiketi tek başına kaldı.

## Test
- `npm run lint` 0 error · `npm test` geçti · `npm run build` ✓
- Davranış: link `/forgot-password`'a gidiyor; göster/gizle ve hata mesajı etkilenmedi.

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)
