### PR TITLE
fix: projects page testini ConfirmDialogProvider ile sarmala (develop CI hotfix)

### DIFF
--- a/src/app/(admin)/admin-dashboard/projects/page.test.tsx
+++ b/src/app/(admin)/admin-dashboard/projects/page.test.tsx
@@ -2,8 +2,18 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import { ConfirmDialogProvider } from "@/components/ui/ConfirmDialog";
 
 import ProjectsPage from "./page";
+
+// #129: Sayfa artık useConfirm() kullanıyor (#95); provider olmadan render hata verir.
+function renderPage() {
+  return render(
+    <ConfirmDialogProvider>
+      <ProjectsPage />
+    </ConfirmDialogProvider>,
+  );
+}
 
 describe("Admin projects — fetch fail error state (#123 / #89-3)", () => {
   beforeEach(() => {
@@ -13,7 +23,7 @@ describe("Admin projects — fetch fail error state (#123 / #89-3)", () => {
   it("fetch reddedilirse boş liste yerine error state render edilir", async () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
 
-    render(<ProjectsPage />);
+    renderPage();
 
     expect(await screen.findByText("Şablonlar yüklenemedi")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /tekrar dene/i })).toBeInTheDocument();
@@ -31,7 +41,7 @@ describe("Admin projects — fetch fail error state (#123 / #89-3)", () => {
       });
     vi.stubGlobal("fetch", fetchMock);
 
-    render(<ProjectsPage />);
+    renderPage();
 
     const retry = await screen.findByRole("button", { name: /tekrar dene/i });
     fireEvent.click(retry);


### PR DESCRIPTION
## Summary
⚠️ **Develop CI hotfix** — `src/app/(admin)/admin-dashboard/projects/page.test.tsx` develop'ta fail ediyordu ve **tüm yeni PR'ları bloklıyordu**.

Sebep merge sırası: test (#125) eski projects sayfasına göre yazılmıştı; sayfa sonradan (#95) `useConfirm()` kullanmaya başladı. `useConfirm` `<ConfirmDialogProvider>` gerektirdiğinden provider'sız render `useConfirm, <ConfirmDialogProvider> içinde kullanılmalıdır.` hatasıyla düşüyordu.

## Changes
- `projects/page.test.tsx` — `renderPage()` helper'ı: `<ProjectsPage />` artık `<ConfirmDialogProvider>` ile sarılıyor. İki mevcut senaryo (fetch-fail error state + Tekrar Dene) aynen korundu.

## Test
- `npm test` → 161/161 (önceden 2 fail) · lint 0 error · build ✓

## Reviewer Notes
- Öncelikli merge önerilir; bu düzelmeden diğer açık PR'ların (128 vb.) CI'ı yeşile dönemez.

Closes #129
