### PR TITLE
chore: modal dialoglara tam focus-trap + odak iadesi (a11y)

### DIFF
--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -10,6 +10,7 @@
 
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
 import { AlertTriangle } from "lucide-react";
+import { handleTabKey } from "./focus-trap";
 
 export type ConfirmOptions = {
   title: string;
@@ -40,6 +41,10 @@ type PendingState = {
 export function ConfirmDialogProvider({ children }: { children: React.ReactNode }) {
   const [pending, setPending] = useState<PendingState | null>(null);
   const confirmBtnRef = useRef<HTMLButtonElement>(null);
+  const cancelBtnRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  // Dialog'u açan eleman — kapanışta odak buraya geri verilir.
+  const triggerRef = useRef<HTMLElement | null>(null);
 
   const confirm = useCallback<ConfirmFn>((options) => {
     return new Promise<boolean>((resolve) => {
@@ -57,15 +62,27 @@ export function ConfirmDialogProvider({ children }: { children: React.ReactNode 
     [],
   );
 
-  // Açılışta onay butonuna odaklan + Escape ile iptal.
+  // Açılışta odak + Escape ile iptal + Tab-trap + kapanışta odak iadesi.
   useEffect(() => {
     if (!pending) return;
-    confirmBtnRef.current?.focus();
+
+    triggerRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    // #126-5: Tehlikeli (danger) onaylarda varsayılan odak İptal'de (güvenli varsayılan);
+    // aksi halde onay butonunda.
+    const initial = pending.options.danger ? cancelBtnRef.current : confirmBtnRef.current;
+    initial?.focus();
+
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") close(false);
+      handleTabKey(dialogRef.current, e);
     };
     document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      triggerRef.current?.focus({ preventScroll: true });
+    };
   }, [pending, close]);
 
   return (
@@ -78,6 +95,7 @@ export function ConfirmDialogProvider({ children }: { children: React.ReactNode 
           role="presentation"
         >
           <div
+            ref={dialogRef}
             role="alertdialog"
             aria-modal="true"
             aria-labelledby="confirm-title"
@@ -105,6 +123,7 @@ export function ConfirmDialogProvider({ children }: { children: React.ReactNode 
             </div>
             <div className="flex items-center justify-end gap-2 px-6 py-4 bg-slate-50 border-t border-slate-100">
               <button
+                ref={cancelBtnRef}
                 type="button"
                 onClick={() => close(false)}
                 className="px-4 py-2 rounded-xl text-sm font-medium text-slate-700 bg-white border border-slate-200 hover:bg-slate-100 transition-colors"

--- a/src/components/ui/focus-trap.test.tsx
+++ b/src/components/ui/focus-trap.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { getFocusable, handleTabKey } from "./focus-trap";
+
+let container: HTMLDivElement;
+let first: HTMLButtonElement;
+let last: HTMLButtonElement;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  first = document.createElement("button");
+  first.textContent = "İlk";
+  const middle = document.createElement("input");
+  last = document.createElement("button");
+  last.textContent = "Son";
+  const disabled = document.createElement("button");
+  disabled.textContent = "Pasif";
+  disabled.setAttribute("disabled", "");
+  container.append(first, middle, last, disabled);
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+function tab(shift = false): KeyboardEvent {
+  return new KeyboardEvent("keydown", { key: "Tab", shiftKey: shift, cancelable: true });
+}
+
+describe("getFocusable (#126-5)", () => {
+  it("odaklanabilir elemanları döner, disabled'ı hariç tutar", () => {
+    const items = getFocusable(container);
+    expect(items).toHaveLength(3); // button, input, button (disabled hariç)
+    expect(items[0]).toBe(first);
+    expect(items[items.length - 1]).toBe(last);
+  });
+
+  it("null container'da boş dizi döner", () => {
+    expect(getFocusable(null)).toEqual([]);
+  });
+});
+
+describe("handleTabKey (#126-5)", () => {
+  it("son elemanda Tab → ilk elemana sarar (preventDefault)", () => {
+    last.focus();
+    const e = tab();
+    const prevent = vi.spyOn(e, "preventDefault");
+    handleTabKey(container, e);
+    expect(prevent).toHaveBeenCalled();
+    expect(document.activeElement).toBe(first);
+  });
+
+  it("ilk elemanda Shift+Tab → son elemana sarar", () => {
+    first.focus();
+    const e = tab(true);
+    const prevent = vi.spyOn(e, "preventDefault");
+    handleTabKey(container, e);
+    expect(prevent).toHaveBeenCalled();
+    expect(document.activeElement).toBe(last);
+  });
+
+  it("ortadaki elemanda Tab → müdahale etmez (tarayıcı doğal akışı)", () => {
+    first.focus();
+    const e = tab();
+    const prevent = vi.spyOn(e, "preventDefault");
+    handleTabKey(container, e);
+    expect(prevent).not.toHaveBeenCalled();
+  });
+
+  it("Tab dışındaki tuşlarda hiçbir şey yapmaz", () => {
+    const e = new KeyboardEvent("keydown", { key: "Enter", cancelable: true });
+    const prevent = vi.spyOn(e, "preventDefault");
+    handleTabKey(container, e);
+    expect(prevent).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/focus-trap.ts
+++ b/src/components/ui/focus-trap.ts
@@ -1,0 +1,42 @@
+// #126 madde 5: Modal/dialog için paylaşılan focus-trap yardımcıları.
+// useModalA11y (projects modal vb.) ve ConfirmDialog aynı mantığı kullanır.
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+/** Container içindeki odaklanabilir elemanları döner. */
+export function getFocusable(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return [];
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+}
+
+/**
+ * Tab / Shift+Tab olayında odağı `container` içinde döngüye sokar
+ * (son elemanda Tab → ilk; ilk elemanda Shift+Tab → son).
+ * Tab dışındaki tuşlarda hiçbir şey yapmaz.
+ */
+export function handleTabKey(container: HTMLElement | null, e: KeyboardEvent): void {
+  if (e.key !== "Tab" || !container) return;
+  const focusable = getFocusable(container);
+  if (focusable.length === 0) return;
+
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active = document.activeElement;
+
+  if (e.shiftKey) {
+    if (active === first || !container.contains(active)) {
+      e.preventDefault();
+      last.focus();
+    }
+  } else if (active === last || !container.contains(active)) {
+    e.preventDefault();
+    first.focus();
+  }
+}

--- a/src/components/ui/useModalA11y.ts
+++ b/src/components/ui/useModalA11y.ts
@@ -1,13 +1,15 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { handleTabKey } from "./focus-trap";
 
 /**
- * Modal/dialog için minimal a11y davranışı (#6):
+ * Modal/dialog için a11y davranışı (#6 / #126-5):
  * - Escape tuşuyla kapatma
  * - Açılışta dialog panele odak (klavye kullanıcısı modal içinde başlar)
+ * - Tab / Shift+Tab odağını modal içinde tutar (focus-trap)
+ * - Kapanışta odağı, dialog'u açan tetikleyici elemana geri verir
  *
- * Tam bir focus-trap değildir; hafif ve bağımsız bir iyileştirmedir.
  * Dönen ref dialog paneline bağlanmalı; panele ayrıca
  * `role="dialog" aria-modal="true" tabIndex={-1}` verilmelidir.
  *
@@ -18,18 +20,28 @@ export function useModalA11y(isOpen: boolean, onClose: () => void) {
   const ref = useRef<HTMLDivElement>(null);
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
+  // Modal'ı açan eleman — kapanışta odak buraya geri verilir.
+  const triggerRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     if (!isOpen) return;
 
+    triggerRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") onCloseRef.current();
+      handleTabKey(ref.current, e);
     };
     document.addEventListener("keydown", onKeyDown);
     // Açılışta odak panele — sayfa kaymasını tetiklemeden.
     ref.current?.focus({ preventScroll: true });
 
-    return () => document.removeEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      // Kapanışta odağı tetikleyiciye iade et (klavye kullanıcısı kaybolmasın).
+      triggerRef.current?.focus({ preventScroll: true });
+    };
   }, [isOpen]);
 
   return ref;


### PR DESCRIPTION
## Summary
#126 madde 5. `useModalA11y` / `ConfirmDialog` Escape + aria-modal + açılışta odak sağlıyordu ama Tab döngüsü modal içinde hapsolmuyor ve kapanışta odak tetikleyiciye dönmüyordu.

## Changes
- `focus-trap.ts` — paylaşılan `getFocusable` + `handleTabKey` (Tab/Shift+Tab wrap). Harici bağımlılık yok.
- `useModalA11y` — Tab-trap + kapanışta odak iadesi (projects modal vb.).
- `ConfirmDialog` — Tab-trap + odak iadesi + **danger onaylarda varsayılan odak İptal'de** (WCAG güvenli varsayılan).
- `focus-trap.test.tsx` — 6 jsdom unit test (wrap yönleri, disabled hariç tutma, Tab-dışı no-op).

## Test
- `npm test` (yeni 6 test) · lint 0 error · build ✓

## Reviewer Notes
- Klavye manuel kontrol: aç → Tab döngüsü içeride kalıyor → Escape → odak tetikleyiciye dönüyor.
- ⚠️ CI'daki mevcut test hatası develop-#129 kaynaklı (bu PR'la ilgisiz); hotfix #130 merge olunca düzelir.

Closes #133
Refs #126
