### PR TITLE
docs: PR etiket senkron kuralını CONTRIBUTING'e ekle

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,7 @@ Varsa ekran görüntüsü ekle.
 
 * [ ] Branch adı doğru formatta
 * [ ] PR issue’ya bağlı
+* [ ] Issue etiketleri PR’a da eklendi (en az `type:` + `priority:`)
 * [ ] Gereksiz dosya değiştirilmedi
 * [ ] Sadece ilgili issue kapsamındaki değişiklikler yapıldı
 * [ ] Local build/test kontrol edildi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,6 +186,18 @@ Resolves #38
    - **Screenshots:** UI değişikliği varsa ekran görüntüsü
    - **Reviewer Notes:** Reviewer'ın özellikle bakması gereken yerler
 
+6. **Etiketler:** PR açarken bağlı issue'nun etiketlerini PR'a da ekleyin —
+   **en az `type:` ve `priority:`**, mümkünse `area:` de. Böylece PR listesi
+   issue'lar gibi filtrelenebilir ve önceliklendirme tek bakışta görünür.
+
+   ```bash
+   # PR açarken doğrudan:
+   gh pr create --label "type:fix,priority:P1,area:auth" ...
+
+   # Açtıktan sonra eklemek için:
+   gh pr edit <pr-no> --add-label "type:fix,priority:P1"
+   ```
+
 ### Issue Kapatma Standardı
 
 Issue'nun PR merge edildiğinde otomatik kapanması için PR body içinde şu ifadelerden biri bulunmalıdır:


### PR DESCRIPTION
## Related Issue

Closes #135
Refs #126

## Summary
#126 madde 7. Açık PR'lerde label çoğu zaman boştu; etiketler yalnızca issue'larda duruyordu — PR listesinde filtreleme/önceliklendirme zorlaşıyordu.

## Changes
- `CONTRIBUTING.md` → "PR Açarken" bölümüne 6. madde: bağlı issue'nun etiketlerini PR'a da ekle (en az `type:` + `priority:`), `gh pr create --label` / `gh pr edit --add-label` örnekleriyle.
- `.github/pull_request_template.md` → checklist'e "Issue etiketleri PR'a da eklendi" maddesi.

## Checklist
* [x] Branch adı doğru formatta
* [x] PR issue'ya bağlı
* [x] Issue etiketleri PR'a da eklendi (bu PR kuralı kendisi uyguluyor 🙂)
* [x] Gereksiz dosya değiştirilmedi
* [x] Local build/test kontrol edildi

## Reviewer Notes
- Yalnızca dokümantasyon; kod değişikliği yok.
- Bu PR yeni kuralı kendi üzerinde uyguluyor (etiketleri eklendi).
