### PR TITLE
refactor: API hata mesajı ayrıştırmasını tek kaynakta birleştir

### DIFF
--- a/src/app/(mentor)/mentor-dashboard/roadmap/[roadmapId]/page.tsx
+++ b/src/app/(mentor)/mentor-dashboard/roadmap/[roadmapId]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { toast } from "sonner";
+import { extractApiErrorMessage } from "@/lib/api-error-message";
 import {
   ArrowLeft,
   Save,
@@ -79,17 +80,11 @@ function toNullableUrl(value: string): string | null {
   return trimmed === "" ? null : trimmed;
 }
 
-// #50: Zod fieldErrors ({ alan: [mesaj] }) şeklindeki hatayı okunabilir tek mesaja indirger.
+// #50: Yanıt gövdesindeki hatayı okunabilir tek mesaja indirger.
+// #126-3: Ayrıştırma (string vs zod fieldErrors) ortak helper'da — tek kaynak.
 async function extractErrorMessage(res: Response, fallback: string): Promise<string> {
   const data = await res.json().catch(() => null);
-  const fieldErrors = data?.error;
-  if (fieldErrors && typeof fieldErrors === "object") {
-    const first = Object.values(fieldErrors).flat()[0];
-    if (first) return String(first);
-  } else if (typeof fieldErrors === "string") {
-    return fieldErrors;
-  }
-  return fallback;
+  return extractApiErrorMessage(data, fallback);
 }
 
 /* ─── Sayfa ─── */

--- a/src/features/survey/answers.ts
+++ b/src/features/survey/answers.ts
@@ -1,5 +1,7 @@
 // #46: İstemci ve sunucu arasında paylaşılan saf yardımcılar (prisma/React bağımlılığı yok).
 
+import { extractApiErrorMessage } from "@/lib/api-error-message";
+
 export type SurveyQuestionView = {
   id: string;
   question: string;
@@ -26,20 +28,15 @@ export function buildSurveyAnswerPayload(
 /**
  * #83: POST /api/student/survey-answers hatasını okunabilir tek mesaja indirger.
  * Hata iki şekilde gelebilir: düz string (SurveyValidationError/500) veya zod
- * fieldErrors objesi (`{ answers: ["mesaj"] }`, 400 validation). Önceki kod
- * yalnızca string'i kontrol ediyordu; obje gelince genel/anlamsız bir mesaja
- * düşüyordu — validation hatası kullanıcıya görünmüyordu.
+ * fieldErrors objesi (`{ answers: ["mesaj"] }`, 400 validation).
+ *
+ * #126-3: Ayrıştırma mantığı ortak `extractApiErrorMessage`'a delege edilir —
+ * tek kaynak. Buradaki imza *hata alanını* alır (tüm gövdeyi değil), bu yüzden
+ * helper'ın beklediği `{ error }` şekline sarmalanır.
  */
 export function extractSurveyErrorMessage(
   errorField: unknown,
   fallback: string,
 ): string {
-  if (typeof errorField === "string" && errorField.trim().length > 0) {
-    return errorField;
-  }
-  if (errorField && typeof errorField === "object") {
-    const firstMessage = Object.values(errorField as Record<string, unknown>).flat()[0];
-    if (firstMessage) return String(firstMessage);
-  }
-  return fallback;
+  return extractApiErrorMessage({ error: errorField }, fallback);
 }


### PR DESCRIPTION
## Related Issue

Closes #137
Refs #126

## Summary
#126 madde 3. `#120` ortak `extractApiErrorMessage` helper'ını eklemişti ama `survey/answers.ts` delegasyonu (`#90` kapatıldığı için) repoya girmemişti; ayrıca mentor roadmap sayfasında inline "string vs zod fieldErrors" ayrıştırması kalmıştı.

## Changes
- `features/survey/answers.ts` → `extractSurveyErrorMessage` artık `extractApiErrorMessage`'a delege ediyor. İmza *hata alanını* aldığından helper'ın beklediği `{ error }` şekline sarmalanıyor (public API değişmedi).
- `mentor-dashboard/roadmap/[roadmapId]/page.tsx` → yerel `extractErrorMessage` içindeki inline ayrıştırma kaldırıldı, ortak helper'a bağlandı (~8 satır → 2).

## Test
- `npm test` → 161/161 (mevcut survey testleri delegasyondan sonra da geçiyor → davranış korundu)
- `npm run lint` 0 error · `npm run build` ✓

## Checklist
* [x] Branch adı doğru formatta
* [x] PR issue'ya bağlı
* [x] Issue etiketleri PR'a da eklendi
* [x] Gereksiz dosya değiştirilmedi
* [x] Local build/test kontrol edildi

## Reviewer Notes
- Tek davranış farkı iyileştirme yönünde: ortak helper, fieldErrors dizisindeki **boş string** elemanını da fallback'e düşürüyor (eski survey helper boş string döndürebiliyordu).
- Repoda başka inline ayrıştırma kalmadı (grep ile doğrulandı).
