### PR TITLE
refactor: markdown yolunu tekilleştir — AIChatBot ortak MarkdownContent'e geçti

### DIFF
--- a/src/components/ui/MarkdownContent.test.tsx
+++ b/src/components/ui/MarkdownContent.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { MarkdownContent } from "./MarkdownContent";
+
+describe("MarkdownContent — biçimlendirme (#126-2)", () => {
+  it("kalın ve satır içi kodu render eder", () => {
+    const { container } = render(<MarkdownContent>{"**kalın** ve `kod`"}</MarkdownContent>);
+    expect(container.querySelector("strong")).toHaveTextContent("kalın");
+    expect(container.querySelector("code")).toHaveTextContent("kod");
+  });
+
+  it("sıralı listeyi render eder (eski chat renderer'ı bunu düz metin bırakıyordu)", () => {
+    const { container } = render(<MarkdownContent>{"1. bir\n2. iki"}</MarkdownContent>);
+    expect(container.querySelector("ol")).toBeInTheDocument();
+    expect(container.querySelectorAll("li")).toHaveLength(2);
+  });
+
+  it("bağlantıyı güvenli özniteliklerle render eder", () => {
+    render(<MarkdownContent>{"[site](https://example.com)"}</MarkdownContent>);
+    const link = screen.getByRole("link", { name: "site" });
+    expect(link).toHaveAttribute("href", "https://example.com");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+
+  it("madde işaretli listeyi ve başlığı render eder", () => {
+    const { container } = render(<MarkdownContent>{"## Başlık\n\n- a\n- b"}</MarkdownContent>);
+    expect(container.querySelector("h2")).toHaveTextContent("Başlık");
+    expect(container.querySelectorAll("ul li")).toHaveLength(2);
+  });
+});
+
+describe("MarkdownContent — XSS güvenliği (#126-2)", () => {
+  it("ham HTML'i element olarak render ETMEZ (script enjeksiyonu yok)", () => {
+    const { container } = render(
+      <MarkdownContent>{'<script>alert(1)</script><img src=x onerror="alert(1)">'}</MarkdownContent>,
+    );
+    // react-markdown varsayılan olarak ham HTML'i çalıştırmaz (rehype-raw yok).
+    expect(container.querySelector("script")).toBeNull();
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("javascript: şemalı bağlantıyı href olarak geçirmez", () => {
+    const { container } = render(
+      <MarkdownContent>{"[tıkla](javascript:alert(1))"}</MarkdownContent>,
+    );
+    const link = container.querySelector("a");
+    // react-markdown güvensiz şemaları temizler; link ya yok ya da href zararsız.
+    expect(link?.getAttribute("href") ?? "").not.toContain("javascript:");
+  });
+});

--- a/src/features/ai/ui/AIChatBot.tsx
+++ b/src/features/ai/ui/AIChatBot.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useRef, useEffect, type ReactNode } from "react";
+import { useState, useRef, useEffect } from "react";
+import { MarkdownContent } from "@/components/ui/MarkdownContent";
 import { X, Send, Loader2, GraduationCap, Minus } from "lucide-react";
 
 type ChatMessage = {
@@ -174,7 +175,9 @@ export function AIChatBot() {
               }`}
             >
               {msg.role === "assistant" ? (
-                <div className="space-y-1">{renderMessage(msg.content)}</div>
+                // #126-2: Ortak markdown yolu — sıralı liste, link, blockquote,
+                // tablo gibi yapılar da doğru render edilir (react-markdown + gfm).
+                <MarkdownContent>{msg.content}</MarkdownContent>
               ) : (
                 <p className="whitespace-pre-wrap">{msg.content}</p>
               )}
@@ -228,96 +231,3 @@ export function AIChatBot() {
   );
 }
 
-/**
- * Satır içi markdown → React node'ları.
- * Desteklenen: **kalın** ve `kod`. XSS-güvenli (HTML enjeksiyonu yok, sadece
- * React elemanları üretir).
- */
-function renderInline(text: string, keyPrefix: string): ReactNode[] {
-  const nodes: ReactNode[] = [];
-  const regex = /(\*\*[^*]+\*\*|`[^`]+`)/g;
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
-  let i = 0;
-
-  while ((match = regex.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      nodes.push(text.slice(lastIndex, match.index));
-    }
-    const token = match[0];
-    if (token.startsWith("**")) {
-      nodes.push(
-        <strong key={`${keyPrefix}-b-${i}`} className="font-semibold">
-          {token.slice(2, -2)}
-        </strong>,
-      );
-    } else {
-      nodes.push(
-        <code
-          key={`${keyPrefix}-c-${i}`}
-          className="px-1 py-0.5 rounded bg-gray-100 text-purple-700 text-[13px] font-mono"
-        >
-          {token.slice(1, -1)}
-        </code>,
-      );
-    }
-    lastIndex = match.index + token.length;
-    i++;
-  }
-  if (lastIndex < text.length) {
-    nodes.push(text.slice(lastIndex));
-  }
-  return nodes;
-}
-
-/**
- * Blok seviyesinde hafif markdown render'ı (bağımlılıksız, XSS-güvenli).
- * Desteklenen: başlıklar, madde listeleri, paragraflar ve satır içi
- * kalın/kod. Gemini yanıtlarındaki ham işaretleri temizler.
- */
-function renderMessage(text: string): ReactNode {
-  const lines = text.split("\n");
-  const blocks: ReactNode[] = [];
-  let listItems: string[] = [];
-  let key = 0;
-
-  const flushList = () => {
-    if (listItems.length === 0) return;
-    const items = listItems;
-    const k = key++;
-    blocks.push(
-      <ul key={`ul-${k}`} className="list-disc pl-5 space-y-0.5">
-        {items.map((it, idx) => (
-          <li key={idx}>{renderInline(it, `li-${k}-${idx}`)}</li>
-        ))}
-      </ul>,
-    );
-    listItems = [];
-  };
-
-  for (const line of lines) {
-    const bullet = line.match(/^\s*[-*]\s+(.*)$/);
-    const heading = line.match(/^\s*#{1,6}\s+(.*)$/);
-    if (bullet) {
-      listItems.push(bullet[1]);
-      continue;
-    }
-    flushList();
-    if (heading) {
-      const k = key++;
-      blocks.push(
-        <p key={`h-${k}`} className="font-semibold">
-          {renderInline(heading[1], `h-${k}`)}
-        </p>,
-      );
-    } else if (line.trim() === "") {
-      blocks.push(<div key={`sp-${key++}`} className="h-1" />);
-    } else {
-      const k = key++;
-      blocks.push(<p key={`p-${k}`}>{renderInline(line, `p-${k}`)}</p>);
-    }
-  }
-  flushList();
-
-  return blocks;
-}


### PR DESCRIPTION
## Related Issue

Closes #139
Refs #126

## Summary
#126 madde 2. İki ayrı markdown yolu vardı: `MarkdownContent` (react-markdown, `#94`) ve AIChatBot içindeki elle yazılmış hafif renderer (`#106`). Özel renderer yalnızca `**kalın**`, `` `kod` ``, bullet ve başlık destekliyordu — AI yanıtlarında sık geçen **sıralı liste, link, blockquote, tablo** düz metin kalıyordu.

## Changes
- `AIChatBot.tsx` → asistan balonu artık `<MarkdownContent>` kullanıyor; `renderInline` + `renderMessage` (~93 satır) silindi, `ReactNode` importu kalktı. Kullanıcı mesajları (düz metin, `whitespace-pre-wrap`) değişmedi.
- `MarkdownContent.test.tsx` → 6 yeni jsdom testi: biçimlendirme (kalın/kod/sıralı liste/başlık/link) + **XSS güvenliği**.

## Test
- `npm test` → 167/167 (6 yeni) · lint 0 error · build ✓
- **XSS doğrulaması** (issue'nun istediği): ham `<script>` ve `<img onerror>` element olarak render edilmiyor (react-markdown varsayılanı, `rehype-raw` yok); `javascript:` şemalı link href'e geçmiyor.

## Checklist
* [x] Branch adı doğru formatta
* [x] PR issue'ya bağlı
* [x] Issue etiketleri PR'a da eklendi
* [x] Gereksiz dosya değiştirilmedi
* [x] Local build/test kontrol edildi

## Reviewer Notes
- Bundle etkisi yok sayılır: `react-markdown` zaten bağımlılık (proje açıklamaları için kullanılıyordu).
- Görsel: asistan balonu beyaz zeminli (`bg-white text-gray-800`), MarkdownContent'in slate paleti uyumlu. Boşluk yönetimi bileşenin kendi `my-2/first:mt-0/last:mb-0` kurallarına bırakıldı (eski `space-y-1` sarmalayıcı kaldırıldı).
