### PR TITLE
chore: hata durumu render testlerini genişlet (admin + mesajlaşma)

### DIFF
--- a/src/app/(admin)/admin-dashboard/page.test.tsx
+++ b/src/app/(admin)/admin-dashboard/page.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ConfirmDialogProvider } from "@/components/ui/ConfirmDialog";
+
+// Sayfa next-auth/UnreadBadge gibi tarayıcı-dışı bağımlılıklar içeriyor; render
+// testinin odağı hata durumu olduğundan bunlar sadeleştirilir.
+vi.mock("@/features/messaging/ui/UnreadBadge", () => ({ UnreadBadge: () => null }));
+vi.mock("@/components/LogoutButton", () => ({ default: () => null }));
+
+import AdminDashboard from "./page";
+
+function renderPage() {
+  return render(
+    <ConfirmDialogProvider>
+      <AdminDashboard />
+    </ConfirmDialogProvider>,
+  );
+}
+
+describe("Admin dashboard — fetch fail error state (#126-6 / #89-3)", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("kullanıcı listesi isteği reddedilirse boş liste yerine error state render edilir", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    renderPage();
+
+    expect(await screen.findByText("Kullanıcılar yüklenemedi")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /tekrar dene/i })).toBeInTheDocument();
+  });
+
+  it("istek 500 dönerse de error state gösterilir (ok=false dalı)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) }),
+    );
+
+    renderPage();
+
+    expect(await screen.findByText("Kullanıcılar yüklenemedi")).toBeInTheDocument();
+  });
+
+  it("'Tekrar Dene' yeniden istek atar; başarılı olursa error state kalkar", async () => {
+    const ok = { ok: true, json: async () => [] };
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("down")) // users
+      .mockRejectedValueOnce(new Error("down")) // mentors
+      .mockResolvedValue(ok); // retry sonrası tümü
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderPage();
+
+    const retry = await screen.findByRole("button", { name: /tekrar dene/i });
+    const callsBefore = fetchMock.mock.calls.length;
+    fireEvent.click(retry);
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText("Kullanıcılar yüklenemedi")).not.toBeInTheDocument();
+    });
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+});

--- a/src/features/messaging/ui/MessagingPanel.test.tsx
+++ b/src/features/messaging/ui/MessagingPanel.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MessagingPanel } from "./MessagingPanel";
+
+// Panel görünürlük-farkında polling kullanıyor (#98); testlerde zamanlayıcı
+// tetiklenmesin diye sahte zamanlayıcıya gerek yok — sadece ilk yükleme incelenir.
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("MessagingPanel — konuşma yükleme hatası (#126-6 / #97)", () => {
+  it("konuşmalar isteği reddedilirse error UI + retry gösterilir", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    render(<MessagingPanel currentUserId="user-1" />);
+
+    expect(await screen.findByText("Konuşmalar yüklenemedi.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /tekrar dene/i })).toBeInTheDocument();
+  });
+
+  it("istek ok=false dönerse de error UI gösterilir", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) }),
+    );
+
+    render(<MessagingPanel currentUserId="user-1" />);
+
+    expect(await screen.findByText("Konuşmalar yüklenemedi.")).toBeInTheDocument();
+  });
+
+  it("'Tekrar Dene' yeniden istek atar; başarılı olursa hata kalkar", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("down"))
+      .mockResolvedValue({ ok: true, json: async () => ({ conversations: [] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<MessagingPanel currentUserId="user-1" />);
+
+    const retry = await screen.findByRole("button", { name: /tekrar dene/i });
+    fireEvent.click(retry);
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText("Konuşmalar yüklenemedi.")).not.toBeInTheDocument();
+    });
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("hata durumu 'hiç konuşma yok' boş durumundan ayrıdır", async () => {
+    // Başarılı ama boş liste → hata metni GÖRÜNMEMELİ (#89-3 ayrımı).
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ conversations: [] }) }),
+    );
+
+    render(<MessagingPanel currentUserId="user-1" />);
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText("Konuşmalar yüklenemedi.")).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Related Issue

Closes #141
Refs #126

## Summary
#126 madde 6. `#125` jsdom altyapısını kurmuştu; bu PR `#89` madde 2/3'ün **render** doğrulamasında eksik kalan parçaları tamamlar.

## Changes
- `admin-dashboard/page.test.tsx` (3 test) — kullanıcı/mentor listesi fetch fail → "Kullanıcılar yüklenemedi" + "Tekrar Dene"; hem `reject` hem `ok=false` dalı; retry sonrası error state kalkıyor.
- `messaging/MessagingPanel.test.tsx` (4 test) — konuşma yükleme hatası → error UI + retry; retry ile toparlanma; **hata durumunun "hiç konuşma yok" boş durumundan ayrı olduğu** doğrulandı (#89-3'ün asıl amacı).

## Test
- `npm test` → 168/168 (7 yeni) · lint 0 error · build ✓
- Testler dosya başında `// @vitest-environment jsdom` kullanıyor; global ortam `node` kaldı (mevcut testler etkilenmedi).

## Checklist
* [x] Branch adı doğru formatta
* [x] PR issue'ya bağlı
* [x] Issue etiketleri PR'a da eklendi
* [x] Gereksiz dosya değiştirilmedi
* [x] Local build/test kontrol edildi

## Reviewer Notes
- Yalnızca test eklendi; ürün kodu değişmedi.
- Admin sayfası testinde `UnreadBadge` ve `LogoutButton` mock'landı (tarayıcı-dışı bağımlılıklar; testin odağı hata durumu).
