### PR TITLE
feat: stajyer onayını profil tamamlandıktan sonraya al

### DIFF
--- a/src/app/account-status/page.tsx
+++ b/src/app/account-status/page.tsx
@@ -1,8 +1,10 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth/nextauth";
 import { redirect } from "next/navigation";
+import Link from "next/link";
 import LogoutButton from "@/components/LogoutButton";
-import { Clock, XCircle } from "lucide-react";
+import { prisma } from "@/lib/db";
+import { Clock, XCircle, UserPen } from "lucide-react";
 
 export const dynamic = "force-dynamic";
 
@@ -32,6 +34,16 @@ export default async function AccountStatusPage() {
 
   const rejected = status === "REJECTED";
 
+  // #143: Onay artık profil tamamlandıktan SONRA anlam taşıyor. Profilini henüz
+  // doldurmamış PENDING kullanıcıyı beklemeye değil, profil tamamlamaya yönlendir.
+  const profile = rejected
+    ? null
+    : await prisma.studentProfile.findUnique({
+        where: { userId: session.user.id },
+        select: { id: true },
+      });
+  const needsProfile = !rejected && !profile;
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 px-4 py-12">
       <div className="w-full max-w-md">
@@ -51,20 +63,40 @@ export default async function AccountStatusPage() {
             >
               {rejected ? (
                 <XCircle className="w-8 h-8 text-red-600" />
+              ) : needsProfile ? (
+                <UserPen className="w-8 h-8 text-amber-600" />
               ) : (
                 <Clock className="w-8 h-8 text-amber-600" />
               )}
             </div>
 
             <h1 className="text-2xl font-bold text-slate-900">
-              {rejected ? "Başvurunuz reddedildi" : "Hesabınız onay bekliyor"}
+              {rejected
+                ? "Başvurunuz reddedildi"
+                : needsProfile
+                  ? "Profilinizi tamamlayın"
+                  : "Hesabınız inceleniyor"}
             </h1>
 
             <p className="mt-3 text-sm text-slate-600 leading-relaxed">
               {rejected
                 ? "Hesabınız bir yönetici tarafından reddedildi. Bir hata olduğunu düşünüyorsanız lütfen ekiple iletişime geçin."
-                : "Kaydınız başarıyla alındı. Bir yönetici hesabınızı onayladıktan sonra panelinize erişebileceksiniz. Teşekkürler!"}
+                : needsProfile
+                  ? "Değerlendirmeye alınabilmeniz için önce profilinizi doldurmanız gerekiyor. Profiliniz, size en uygun mentörün belirlenmesinde kullanılacak."
+                  : "Profiliniz alındı ve inceleniyor. Size uygun bir mentör atandıktan sonra panelinize erişebileceksiniz. Teşekkürler!"}
             </p>
+
+            {/* #143: Profilsiz PENDING kullanıcı için doğrudan aksiyon. */}
+            {needsProfile && (
+              <div className="mt-6">
+                <Link
+                  href="/profile-setup"
+                  className="inline-flex items-center justify-center rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 px-6 py-3 text-sm font-semibold text-white shadow-md shadow-blue-200 transition-all"
+                >
+                  Profilimi Tamamla
+                </Link>
+              </div>
+            )}
 
             {session.user.email && (
               <p className="mt-4 text-xs text-slate-400">

--- a/src/app/api/student/survey-answers/route.ts
+++ b/src/app/api/student/survey-answers/route.ts
@@ -11,7 +11,9 @@ import { saveSurveyAnswersSchema } from "@/lib/validations/api";
  * Öğrencinin anket cevaplarını profile bağlı olarak kaydeder (soru başına upsert).
  */
 export async function POST(req: Request) {
-  const auth = await requireAuth("STUDENT");
+  // #143: Anket, profil tamamlama akışının parçası — PENDING stajyer de
+  // cevaplarını kaydedebilmeli (onaya dolu profille düşsün).
+  const auth = await requireAuth("STUDENT", { allowUnapprovedStudent: true });
   if (!auth.authorized) return auth.response;
 
   const userId = auth.session.user.id!;

--- a/src/features/student/ui/OnboardingForm.tsx
+++ b/src/features/student/ui/OnboardingForm.tsx
@@ -207,7 +207,10 @@ export default function OnboardingForm({
       }
 
       // Başarılı olursa yönlendirme yapılabilir.
-      window.location.href = "/student-dashboard";
+      // #143: Profil tamamlandı → durum ekranına. PENDING kullanıcı "inceleniyor /
+      // mentör atanıyor" mesajını görür; APPROVED kullanıcıyı sayfa zaten kendi
+      // paneline yönlendirir (tek hedef, iki durum da doğru çalışır).
+      window.location.href = "/account-status";
 
     } catch (err) {
       console.error("Onboarding kaydı başarısız:", err);

--- a/src/lib/auth/guard.approval.test.ts
+++ b/src/lib/auth/guard.approval.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// #143: Onay kapısının profil tamamlamadan SONRA devreye girmesi kritik bir
+// erişim kuralı — PENDING profilini doldurabilmeli, REJECTED asla.
+const { getServerSessionMock } = vi.hoisted(() => ({ getServerSessionMock: vi.fn() }));
+vi.mock("next-auth", () => ({ getServerSession: () => getServerSessionMock() }));
+vi.mock("@/lib/auth/nextauth", () => ({ authOptions: {} }));
+
+import { requireAuth } from "./guard";
+
+function session(role: string, accountStatus?: string) {
+  getServerSessionMock.mockResolvedValue({
+    user: { id: "u1", role, accountStatus },
+  });
+}
+
+describe("requireAuth — hesap onay kapısı (#143)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("APPROVED stajyer normal uçlara erişir", async () => {
+    session("STUDENT", "APPROVED");
+    const res = await requireAuth("STUDENT");
+    expect(res.authorized).toBe(true);
+  });
+
+  it("PENDING stajyer normal uçlarda 403 alır (varsayılan)", async () => {
+    session("STUDENT", "PENDING");
+    const res = await requireAuth("STUDENT");
+    expect(res.authorized).toBe(false);
+    if (!res.authorized) expect(res.response.status).toBe(403);
+  });
+
+  it("PENDING stajyer profil tamamlama ucuna (opt-in) erişebilir", async () => {
+    session("STUDENT", "PENDING");
+    const res = await requireAuth("STUDENT", { allowUnapprovedStudent: true });
+    expect(res.authorized).toBe(true);
+  });
+
+  it("REJECTED stajyer opt-in olsa DA erişemez", async () => {
+    session("STUDENT", "REJECTED");
+    const res = await requireAuth("STUDENT", { allowUnapprovedStudent: true });
+    expect(res.authorized).toBe(false);
+    if (!res.authorized) expect(res.response.status).toBe(403);
+  });
+
+  it("opt-in yalnızca STUDENT onay kuralını etkiler; rol kontrolü aynen sürer", async () => {
+    session("STUDENT", "PENDING");
+    const res = await requireAuth("ADMIN", { allowUnapprovedStudent: true });
+    expect(res.authorized).toBe(false);
+    if (!res.authorized) expect(res.response.status).toBe(403);
+  });
+
+  it("oturum yoksa 401 döner", async () => {
+    getServerSessionMock.mockResolvedValue(null);
+    const res = await requireAuth("STUDENT", { allowUnapprovedStudent: true });
+    expect(res.authorized).toBe(false);
+    if (!res.authorized) expect(res.response.status).toBe(401);
+  });
+
+  it("ADMIN/MENTOR onay kuralından etkilenmez", async () => {
+    session("ADMIN", undefined);
+    expect((await requireAuth("ADMIN")).authorized).toBe(true);
+    session("MENTOR", undefined);
+    expect((await requireAuth("MENTOR")).authorized).toBe(true);
+  });
+});

--- a/src/lib/auth/guard.ts
+++ b/src/lib/auth/guard.ts
@@ -4,12 +4,25 @@ import { authOptions } from "@/lib/auth/nextauth";
 
 type Role = "ADMIN" | "MENTOR" | "STUDENT";
 
+type RequireAuthOptions = {
+  /**
+   * #143: PENDING (henüz onaylanmamış) stajyerin de bu endpoint'i çağırmasına
+   * izin ver. Yalnızca **profil tamamlama** akışındaki uçlar için kullanılır —
+   * kullanıcı onaya düşmeden önce profilini doldurabilsin diye.
+   * REJECTED her durumda engellenir.
+   */
+  allowUnapprovedStudent?: boolean;
+};
+
 /**
  * API route'larında oturum ve rol kontrolü yapar.
  * Başarısızsa uygun HTTP yanıtı döner; başarılıysa session objesini döner.
  * Tek bir rol veya birden fazla rol (dizi) kabul eder.
  */
-export async function requireAuth(requiredRole?: Role | Role[]) {
+export async function requireAuth(
+  requiredRole?: Role | Role[],
+  options?: RequireAuthOptions,
+) {
   const session = await getServerSession(authOptions);
 
   if (!session || !session.user?.id) {
@@ -37,10 +50,18 @@ export async function requireAuth(requiredRole?: Role | Role[]) {
 
   // Onaylanmamış stajyer hesabı (PENDING/REJECTED) hiçbir student işlemi yapamaz.
   // Admin/mentor bu kontrolden etkilenmez (yalnızca STUDENT rolüne uygulanır).
+  //
+  // #143 istisnası: profil tamamlama uçları `allowUnapprovedStudent` ile PENDING'e
+  // açılabilir — kullanıcı onaya düşmeden önce profilini doldurabilsin. REJECTED
+  // bu istisnadan yararlanamaz.
+  const isPendingButAllowed =
+    options?.allowUnapprovedStudent && session.user.accountStatus === "PENDING";
+
   if (
     session.user.role === "STUDENT" &&
     session.user.accountStatus &&
-    session.user.accountStatus !== "APPROVED"
+    session.user.accountStatus !== "APPROVED" &&
+    !isPendingButAllowed
   ) {
     return {
       authorized: false as const,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -63,18 +63,25 @@ export async function middleware(request: NextRequest) {
   // Rol bazlı erişim kontrolü
   const userRole = token.role as string | undefined;
 
-  // Onaylanmamış stajyer (PENDING/REJECTED): korumalı student route'larından
-  // durum ekranına yönlendirilir. (#38 status verisi, #39 ekran)
+  // Onaylanmamış stajyer (PENDING/REJECTED) → durum ekranı. (#38 status, #39 ekran)
+  //
+  // #143: PENDING kullanıcı profilini TAMAMLAYABİLMELİ — admin boş bir profili
+  // değil, dolu profili (+ AI analizini) görerek onaylasın ve mentör atasın.
+  // Bu yüzden profil tamamlama rotaları PENDING'e açıktır; yalnızca dashboard
+  // kapalıdır. REJECTED ise hiçbirine erişemez.
   const accountStatus = token.accountStatus as string | undefined;
-  if (
-    userRole === "STUDENT" &&
-    accountStatus &&
-    accountStatus !== "APPROVED" &&
-    (pathname.startsWith("/student-dashboard") ||
-      pathname.startsWith("/student-onboarding") ||
-      pathname.startsWith("/profile-setup"))
-  ) {
-    return NextResponse.redirect(new URL("/account-status", request.url));
+  if (userRole === "STUDENT" && accountStatus && accountStatus !== "APPROVED") {
+    const isProfileCompletionRoute =
+      pathname.startsWith("/student-onboarding") || pathname.startsWith("/profile-setup");
+    const isStudentArea =
+      pathname.startsWith("/student-dashboard") || isProfileCompletionRoute;
+
+    const blocked =
+      accountStatus === "REJECTED" ? isStudentArea : isStudentArea && !isProfileCompletionRoute;
+
+    if (blocked) {
+      return NextResponse.redirect(new URL("/account-status", request.url));
+    }
   }
 
   for (const [route, requiredRole] of Object.entries(protectedRoutes)) {


### PR DESCRIPTION
## Related Issue

Closes #143

## Summary
Önceden yeni stajyer signup sonrası `PENDING` oluyor ve middleware onu **`/profile-setup` dahil** tüm stajyer sayfalarından `/account-status`'a atıyordu. Sonuç: admin **boş bir profili** onaylamak zorundaydı — deneyim seviyesini, ilgi alanlarını, AI analizini göremediği için mentör ataması körleşiyordu.

Artık stajyer **önce profilini tamamlıyor, sonra onaya düşüyor.**

## Changes
- **`middleware.ts`** — PENDING için profil tamamlama rotaları (`/profile-setup`, `/student-onboarding`) açıldı; `/student-dashboard` kapalı kaldı. **REJECTED hepsinden engellenmeye devam ediyor.**
- **`lib/auth/guard.ts`** — opt-in `requireAuth(role, { allowUnapprovedStudent: true })`. Yalnızca PENDING'i kapsar; REJECTED bu istisnadan yararlanamaz.
- **`api/student/survey-answers`** — anket profil akışının parçası olduğu için opt-in kullanıyor.
- **`OnboardingForm`** — kayıt sonrası `/account-status`'a yönlendiriyor. Tek hedef, iki durum: PENDING "inceleniyor" mesajını görür, APPROVED'ı sayfa zaten kendi paneline geçirir.
- **`account-status`** — üç duruma ayrıldı:
  - REJECTED → mevcut red mesajı (değişmedi)
  - PENDING + profil yok → *"Profilinizi tamamlayın"* + **"Profilimi Tamamla"** butonu
  - PENDING + profil var → *"Hesabınız inceleniyor — size uygun bir mentör atandıktan sonra panelinize erişebileceksiniz."*

## Test
- `npm test` → 168/168 (**7 yeni guard testi**) · lint 0 error · build ✓
- Yeni testler erişim kuralını kilitliyor: APPROVED erişir · PENDING varsayılanda 403 · PENDING opt-in ile erişir · **REJECTED opt-in olsa da erişemez** · opt-in rol kontrolünü gevşetmez · oturumsuz 401.

## Checklist
* [x] Branch adı doğru formatta
* [x] PR issue'ya bağlı
* [x] Issue etiketleri PR'a da eklendi
* [x] Gereksiz dosya değiştirilmedi
* [x] Local build/test kontrol edildi

## Reviewer Notes
- **Güvenlik açısından kritik nokta:** `allowUnapprovedStudent` bilinçli olarak yalnızca `PENDING`'i kapsıyor (`accountStatus === "PENDING"` kontrolü) — REJECTED kullanıcı hiçbir uca erişemiyor. Test bunu doğruluyor.
- `saveOnboarding` server action'ı `requireAuth` kullanmıyor (kendi `getServerSession` kontrolü var), bu yüzden değişiklik gerekmedi.
- Manuel doğrulama önerisi: PENDING kullanıcıyla `/student-dashboard` → `/account-status`'a atmalı; `/profile-setup` → açılmalı; onboarding tamamlanınca "inceleniyor" mesajı görünmeli.
