### PR TITLE
chore: AppShell sonrası tekrar eden sayfa header'larını kaldır

### DIFF
--- a/src/app/(admin)/admin-dashboard/page.tsx
+++ b/src/app/(admin)/admin-dashboard/page.tsx
@@ -2,7 +2,6 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import Link from "next/link";
 import { extractApiErrorMessage } from "@/lib/api-error-message";
 import {
   Users,
@@ -12,8 +11,6 @@ import {
   Search,
   AlertCircle,
   Loader2,
-  FolderKanban,
-  MessageSquare,
   CheckCircle2,
   XCircle,
   Clock,
@@ -21,8 +18,6 @@ import {
   X,
 } from "lucide-react";
 import { toast } from "sonner";
-import LogoutButton from "@/components/LogoutButton";
-import { UnreadBadge } from "@/features/messaging/ui/UnreadBadge";
 import { useModalA11y } from "@/components/ui/useModalA11y";
 import {
   ProfileAnalysisCard,
@@ -300,32 +295,12 @@ export default function AdminDashboard() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/30 to-indigo-50/30">
       <div className="max-w-7xl mx-auto p-4 sm:p-6">
-        {/* Header */}
-        <div className="flex items-start justify-between mb-8 pt-2 gap-4 flex-wrap">
-          <div>
-            <h1 className="text-3xl font-bold text-slate-900 tracking-tight">Yönetici Paneli</h1>
-            <p className="text-slate-500 mt-1.5 text-sm">
-              Kullanıcı rollerini düzenle ve öğrencilere mentor ata
-            </p>
-          </div>
-          <div className="flex items-center gap-3 flex-wrap">
-            <Link
-              href="/admin-dashboard/messages"
-              className="relative inline-flex items-center gap-2 px-4 py-2.5 bg-white hover:bg-blue-50 text-blue-700 rounded-xl text-sm font-medium transition-colors border border-blue-100 shadow-sm"
-            >
-              <MessageSquare className="w-4 h-4" />
-              Mesajlar
-              <UnreadBadge />
-            </Link>
-            <Link
-              href="/admin-dashboard/projects"
-              className="inline-flex items-center gap-2 px-4 py-2.5 bg-white hover:bg-slate-50 text-slate-700 rounded-xl text-sm font-medium transition-colors border border-slate-200 shadow-sm"
-            >
-              <FolderKanban className="w-4 h-4" />
-              Proje Şablonları
-            </Link>
-            <LogoutButton />
-          </div>
+        {/* Sayfa başlığı — navigasyon/çıkış AppShell'de (#126-1) */}
+        <div className="mb-8 pt-2">
+          <h1 className="text-3xl font-bold text-slate-900 tracking-tight">Yönetici Paneli</h1>
+          <p className="text-slate-500 mt-1.5 text-sm">
+            Kullanıcı rollerini düzenle ve öğrencilere mentor ata
+          </p>
         </div>
 
         {/* Stats */}

--- a/src/app/(mentor)/mentor-dashboard/page.tsx
+++ b/src/app/(mentor)/mentor-dashboard/page.tsx
@@ -1,10 +1,8 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { Users, BookOpen, Clock, CheckCircle, AlertCircle, MessageSquare, UserCircle2, ChevronRight, Loader2 } from "lucide-react";
+import { Users, BookOpen, Clock, CheckCircle, AlertCircle, UserCircle2, ChevronRight, Loader2 } from "lucide-react";
 import Link from "next/link";
-import LogoutButton from "@/components/LogoutButton";
-import { UnreadBadge } from "@/features/messaging/ui/UnreadBadge";
 import { experienceLevelLabel } from "@/lib/experience-level";
 
 type StudentWithProfile = {
@@ -124,23 +122,10 @@ export default function MentorDashboardPage() {
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/30 to-indigo-50/30">
       <div className="max-w-6xl mx-auto p-6">
 
-        {/* Header */}
-        <div className="flex items-start justify-between mb-8 pt-2">
-          <div>
-            <h1 className="text-3xl font-bold text-slate-900 tracking-tight">Mentor Paneli</h1>
-            <p className="text-slate-500 mt-1.5 text-sm">Size atanmış öğrencileri yönetin ve proje atayın</p>
-          </div>
-          <div className="flex items-center gap-3">
-            <Link
-              href="/mentor-dashboard/messages"
-              className="relative inline-flex items-center gap-2 px-4 py-2.5 bg-white hover:bg-blue-50 text-blue-700 rounded-xl text-sm font-medium transition-colors border border-blue-100 shadow-sm"
-            >
-              <MessageSquare className="w-4 h-4" />
-              Mesajlar
-              <UnreadBadge />
-            </Link>
-            <LogoutButton />
-          </div>
+        {/* Sayfa başlığı — navigasyon/çıkış AppShell'de (#126-1) */}
+        <div className="mb-8 pt-2">
+          <h1 className="text-3xl font-bold text-slate-900 tracking-tight">Mentor Paneli</h1>
+          <p className="text-slate-500 mt-1.5 text-sm">Size atanmış öğrencileri yönetin ve proje atayın</p>
         </div>
 
         {/* Stats */}

--- a/src/app/(student)/student-dashboard/page.tsx
+++ b/src/app/(student)/student-dashboard/page.tsx
@@ -1,15 +1,13 @@
-import LogoutButton from "@/components/LogoutButton";
 import { getProfileSummary } from "@/features/student/server/profileSummary";
 import { ProfileSummaryCard } from "@/features/student/ui/ProfileSummaryCard";
 import { RoadmapSteps } from "@/features/student/ui/RoadmapSteps";
 import { prisma } from "@/lib/db";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth/nextauth";
-import { Clock, Briefcase, Target, MessageSquare, Github } from "lucide-react";
+import { Clock, Briefcase, Target, Github } from "lucide-react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { Progress } from "@/components/ui/progress";
-import { UnreadBadge } from "@/features/messaging/ui/UnreadBadge";
 import { SecurityQuestionsSetup } from "@/features/auth/ui/SecurityQuestionsSetup";
 import { MarkdownContent } from "@/components/ui/MarkdownContent";
 
@@ -25,10 +23,7 @@ export default async function StudentDashboardPage() {
   if (accountStatus && accountStatus !== "APPROVED") {
     const rejected = accountStatus === "REJECTED";
     return (
-      <div className="min-h-[80vh] flex flex-col items-center justify-center p-6 text-center relative">
-        <div className="absolute top-4 right-4">
-          <LogoutButton />
-        </div>
+      <div className="min-h-[80vh] flex flex-col items-center justify-center p-6 text-center">
         <div className="bg-white border border-slate-200 shadow-sm rounded-2xl p-10 max-w-lg w-full space-y-4">
           <div
             className={`w-16 h-16 rounded-full flex items-center justify-center mx-auto ${
@@ -71,10 +66,7 @@ export default async function StudentDashboardPage() {
 
   if (!profile) {
     return (
-      <div className="min-h-[80vh] flex flex-col items-center justify-center p-6 text-center relative">
-        <div className="absolute top-4 right-4">
-            <LogoutButton />
-        </div>
+      <div className="min-h-[80vh] flex flex-col items-center justify-center p-6 text-center">
         <div className="bg-white border border-slate-200 shadow-sm rounded-2xl p-10 max-w-lg w-full space-y-6">
           <div className="w-20 h-20 bg-blue-50 rounded-full flex items-center justify-center mx-auto mb-2">
             <Briefcase className="w-10 h-10 text-blue-600" />
@@ -109,29 +101,16 @@ export default async function StudentDashboardPage() {
   return (
     <div className="max-w-5xl mx-auto mt-8 p-6 space-y-8">
       
-      {/* Header */}
-      <div className="flex items-start justify-between">
-        <div>
-          <h1 className="text-3xl font-bold text-slate-900 tracking-tight">Hoş geldin, {firstName}</h1>
-          <p className="text-slate-500 mt-2 text-sm">
-            {profile.assignedProjects.length > 0 
-              ? "Çalışma masan hazır. Odaklanman gereken güncel görevler aşağıda listelenmiştir." 
-              : profile.mentorId 
-                ? "Mentörün gelişim planını hazırlıyor. Lütfen beklemede kal." 
-                : "Profilin inceleniyor. Yakında bir mentör ile eşleştirileceksin."}
-          </p>
-        </div>
-        <div className="flex items-center gap-3">
-          <Link
-            href="/student-dashboard/messages"
-            className="relative inline-flex items-center gap-2 px-4 py-2 bg-blue-50 hover:bg-blue-100 text-blue-700 rounded-lg text-sm font-medium transition-colors"
-          >
-            <MessageSquare className="w-4 h-4" />
-            Mesajlar
-            <UnreadBadge />
-          </Link>
-          <LogoutButton />
-        </div>
+      {/* Sayfa başlığı — navigasyon/çıkış AppShell'de (#126-1) */}
+      <div>
+        <h1 className="text-3xl font-bold text-slate-900 tracking-tight">Hoş geldin, {firstName}</h1>
+        <p className="text-slate-500 mt-2 text-sm">
+          {profile.assignedProjects.length > 0
+            ? "Çalışma masan hazır. Odaklanman gereken güncel görevler aşağıda listelenmiştir."
+            : profile.mentorId
+              ? "Mentörün gelişim planını hazırlıyor. Lütfen beklemede kal."
+              : "Profilin inceleniyor. Yakında bir mentör ile eşleştirileceksin."}
+        </p>
       </div>
 
       {/* Güvenlik Soruları Kurulumu */}


### PR DESCRIPTION
## Related Issue

Closes #145
Refs #126

## Summary
#126 madde 1. `#110` (AppShell) kasıtlı olarak **kademeli** merge edilmişti: üst navbar eklendi ama eski sayfa header'larına dokunulmadı. Sonuç: dashboard'larda **çift LogoutButton** ve tekrar eden "Mesajlar + UnreadBadge" bloğu.

## Changes
- **Admin dashboard** — sağdaki aksiyon bloğu (Mesajlar+UnreadBadge, Proje Şablonları, Çıkış) kaldırıldı; AppShell'de zaten var.
- **Mentor dashboard** — Mesajlar+UnreadBadge + Çıkış kaldırıldı.
- **Student dashboard** — **üç** LogoutButton'ın hepsi kaldırıldı (ana header + iki erken-return bloğu: onaysız hesap ve profilsiz durum) + Mesajlar linki.
- Ölü importlar temizlendi (`LogoutButton`, `UnreadBadge`, `MessageSquare`, admin'de ayrıca `Link`/`FolderKanban`).
- Her sayfada yalnızca kendi **içerik başlığı** kaldı.

## Test
- `npm test` → 161/161 · lint 0 error · build ✓
- **Kapsam doğrulaması:** `LogoutButton` artık yalnızca iki yerde — `AppShell.tsx` (route grupları) ve `account-status/page.tsx`.

## Checklist
* [x] Branch adı doğru formatta
* [x] PR issue'ya bağlı
* [x] Issue etiketleri PR'a da eklendi
* [x] Gereksiz dosya değiştirilmedi
* [x] Local build/test kontrol edildi

## Reviewer Notes
- **Korunanlar (bilinçli):** `account-status` route-group dışında olduğu için AppShell almıyor → kendi LogoutButton'ı kaldı. `/student-onboarding` ve `/profile-setup` tam-ekran akışlarında AppShell zaten gizli (`HIDDEN_PREFIXES`) → kendi header'ları korundu.
- Student dashboard'daki iki erken-return bloğunda yalnızca çıkış butonu kaldırıldı; blokların kendisi (savunmacı fallback) duruyor.
- Manuel doğrulama: ADMIN/MENTOR/STUDENT ile giriş → üstte tek navbar, sayfada ikinci çıkış butonu yok.
