### PR TITLE
feat: ogrenci -> admin 'Oneri & Istek' modulu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ src/
 │   ├── ai/server/                        — profile-analysis(+store), recommendations, roadmap
 │   ├── ai/ui/                            — AIChatBot (Posilog), ProfileAnalysisCard
 │   ├── student/models/                   — onboarding, compiledGoals, onboardingInitial
+│   ├── suggestions/                      — öneri/istek: labels + server (#147)
 │   ├── survey/                           — answers + server/survey (#45/#46)
 │   └── mentors|messaging|projects|files|auth/...
 └── lib/
@@ -73,6 +74,7 @@ src/
 | `Roadmap` / `RoadmapStep` | DRAFT/PUBLISHED; step'te githubIssueUrl (#50); öğrenci DRAFT'a etkileşemez (#52) |
 | `SurveyQuestion` / `SurveyAnswer` | admin anket havuzu + stajyer cevapları (#45/#46) |
 | `ProfileAnalysis` | AI profil analizinin kalıcı hali, profile 1-1 (#47) |
+| `Suggestion` | Stajyer→admin öneri/istek; type + status + adminNote (#147) |
 | `Message` / `StepComment` / `StepFile` / `SecurityAnswer` | mesajlaşma, yorum, dosya, güvenlik soruları |
 
 ## Kritik Mimari Notlar

--- a/prisma/migrations/20260721104852_add_suggestion_module/migration.sql
+++ b/prisma/migrations/20260721104852_add_suggestion_module/migration.sql
@@ -1,0 +1,34 @@
+-- CreateEnum
+CREATE TYPE "SuggestionType" AS ENUM ('SUGGESTION', 'REQUEST');
+
+-- CreateEnum
+CREATE TYPE "SuggestionStatus" AS ENUM ('OPEN', 'IN_REVIEW', 'RESOLVED');
+
+-- CreateTable
+CREATE TABLE "Suggestion" (
+    "id" TEXT NOT NULL,
+    "authorId" TEXT NOT NULL,
+    "type" "SuggestionType" NOT NULL DEFAULT 'SUGGESTION',
+    "title" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "status" "SuggestionStatus" NOT NULL DEFAULT 'OPEN',
+    "adminNote" TEXT,
+    "reviewedById" TEXT,
+    "reviewedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Suggestion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Suggestion_authorId_createdAt_idx" ON "Suggestion"("authorId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Suggestion_status_createdAt_idx" ON "Suggestion"("status", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "Suggestion" ADD CONSTRAINT "Suggestion_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Suggestion" ADD CONSTRAINT "Suggestion_reviewedById_fkey" FOREIGN KEY ("reviewedById") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,27 +8,29 @@ datasource db {
 }
 
 model User {
-  id            String    @id @default(cuid())
-  email         String    @unique
+  id            String        @id @default(cuid())
+  email         String        @unique
   name          String?
   lastName      String?
   password      String
   phone         String?
-  role          Role      @default(STUDENT)
+  role          Role          @default(STUDENT)
   accountStatus AccountStatus @default(APPROVED)
   emailVerified DateTime?
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
+  createdAt     DateTime      @default(now())
+  updatedAt     DateTime      @updatedAt
 
   // Relations
-  sessions        Session[]
-  studentProfile  StudentProfile? @relation("StudentProfile_userIdToUser")
-  mentoredStudents StudentProfile[] @relation("StudentProfile_mentorIdToUser")
-  sentMessages    Message[]       @relation("Message_senderIdToUser")
-  receivedMessages Message[]      @relation("Message_receiverIdToUser")
-  stepComments    StepComment[]
-  stepFiles       StepFile[]
-  securityAnswers SecurityAnswer[]
+  sessions            Session[]
+  studentProfile      StudentProfile?  @relation("StudentProfile_userIdToUser")
+  mentoredStudents    StudentProfile[] @relation("StudentProfile_mentorIdToUser")
+  sentMessages        Message[]        @relation("Message_senderIdToUser")
+  receivedMessages    Message[]        @relation("Message_receiverIdToUser")
+  stepComments        StepComment[]
+  stepFiles           StepFile[]
+  securityAnswers     SecurityAnswer[]
+  suggestions         Suggestion[]     @relation("Suggestion_authorIdToUser")
+  reviewedSuggestions Suggestion[]     @relation("Suggestion_reviewedByIdToUser")
 }
 
 model Session {
@@ -60,27 +62,27 @@ model StudentProfile {
 }
 
 model ProjectTemplate {
-  id            String   @id @default(cuid())
+  id            String     @id @default(cuid())
   // #112: Seed idempotency title lookup'ına dayanır; DB seviyesinde de benzersiz olmalı.
-  title         String   @unique
+  title         String     @unique
   description   String
   track         String[]
   difficulty    Difficulty
   // #49: Projenin GitHub repository URL'i (opsiyonel, public repo).
   githubRepoUrl String?
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  createdAt     DateTime   @default(now())
+  updatedAt     DateTime   @updatedAt
 
   assignedProjects AssignedProject[]
 }
 
 model AssignedProject {
-  id               String           @id @default(cuid())
-  studentProfileId String
+  id                String           @id @default(cuid())
+  studentProfileId  String
   projectTemplateId String
-  status           AssignmentStatus @default(PENDING)
-  createdAt        DateTime         @default(now())
-  updatedAt        DateTime         @updatedAt
+  status            AssignmentStatus @default(PENDING)
+  createdAt         DateTime         @default(now())
+  updatedAt         DateTime         @updatedAt
 
   studentProfile  StudentProfile  @relation(fields: [studentProfileId], references: [id])
   projectTemplate ProjectTemplate @relation(fields: [projectTemplateId], references: [id])
@@ -116,9 +118,9 @@ model RoadmapStep {
   createdAt      DateTime   @default(now())
   updatedAt      DateTime   @updatedAt
 
-  roadmap   Roadmap       @relation(fields: [roadmapId], references: [id], onDelete: Cascade)
-  comments  StepComment[]
-  files     StepFile[]
+  roadmap  Roadmap       @relation(fields: [roadmapId], references: [id], onDelete: Cascade)
+  comments StepComment[]
+  files    StepFile[]
 }
 
 model Message {
@@ -226,6 +228,42 @@ model SurveyAnswer {
 
   @@unique([questionId, studentProfileId])
   @@index([studentProfileId])
+}
+
+/// #147: Stajyerin yöneticiye ilettiği öneri/istek kaydı.
+model Suggestion {
+  id       String           @id @default(cuid())
+  authorId String
+  type     SuggestionType   @default(SUGGESTION)
+  title    String
+  content  String
+  status   SuggestionStatus @default(OPEN)
+
+  /// Yöneticinin kayda düştüğü yanıt/not (öğrenciye de gösterilir).
+  adminNote String?
+
+  reviewedById String?
+  reviewedAt   DateTime?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  author     User  @relation("Suggestion_authorIdToUser", fields: [authorId], references: [id], onDelete: Cascade)
+  reviewedBy User? @relation("Suggestion_reviewedByIdToUser", fields: [reviewedById], references: [id], onDelete: SetNull)
+
+  @@index([authorId, createdAt])
+  @@index([status, createdAt])
+}
+
+enum SuggestionType {
+  SUGGESTION
+  REQUEST
+}
+
+enum SuggestionStatus {
+  OPEN
+  IN_REVIEW
+  RESOLVED
 }
 
 enum Role {

--- a/src/app/(admin)/admin-dashboard/suggestions/page.tsx
+++ b/src/app/(admin)/admin-dashboard/suggestions/page.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Loader2, AlertCircle, Inbox, Save } from "lucide-react";
+import { toast } from "sonner";
+import { extractApiErrorMessage } from "@/lib/api-error-message";
+import {
+  authorDisplayName,
+  statusLabels,
+  statusOrder,
+  statusStyles,
+  typeLabels,
+  typeStyles,
+  type SuggestionStatus,
+  type SuggestionType,
+} from "@/features/suggestions/labels";
+
+type AdminSuggestion = {
+  id: string;
+  type: SuggestionType;
+  title: string;
+  content: string;
+  status: SuggestionStatus;
+  adminNote: string | null;
+  createdAt: string;
+  author: { id: string; name: string | null; lastName: string | null; email: string };
+};
+
+type Filter = "ALL" | SuggestionStatus;
+
+export default function AdminSuggestionsPage() {
+  const [items, setItems] = useState<AdminSuggestion[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [filter, setFilter] = useState<Filter>("ALL");
+  const [savingId, setSavingId] = useState<string | null>(null);
+  // Kaydedilmemiş not taslakları — kayıt id'sine göre tutulur.
+  const [noteDrafts, setNoteDrafts] = useState<Record<string, string>>({});
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      setLoadError(false);
+      const res = await fetch("/api/admin/suggestions");
+      if (!res.ok) throw new Error("failed");
+      setItems(await res.json());
+    } catch {
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function patch(id: string, data: { status?: SuggestionStatus; adminNote?: string }) {
+    setSavingId(id);
+    try {
+      const res = await fetch(`/api/admin/suggestions/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        toast.error(extractApiErrorMessage(body, "Güncellenemedi. Lütfen tekrar deneyin."));
+        return;
+      }
+
+      const updated: AdminSuggestion = await res.json();
+      setItems((prev) => prev.map((i) => (i.id === id ? updated : i)));
+      setNoteDrafts((prev) => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+      toast.success("Güncellendi.");
+    } catch {
+      toast.error("Bağlantı hatası. Lütfen tekrar deneyin.");
+    } finally {
+      setSavingId(null);
+    }
+  }
+
+  const visible = filter === "ALL" ? items : items.filter((i) => i.status === filter);
+  const openCount = items.filter((i) => i.status === "OPEN").length;
+
+  return (
+    <div className="max-w-5xl mx-auto p-6 space-y-6">
+      <div className="pt-2">
+        <h1 className="text-3xl font-bold text-slate-900 tracking-tight">Öneri & İstek</h1>
+        <p className="text-slate-500 mt-1.5 text-sm">
+          Stajyerlerden gelen öneri ve talepleri inceleyin, durumlarını güncelleyin.
+          {openCount > 0 && (
+            <span className="ml-1 font-medium text-amber-600">
+              {openCount} açık kayıt var.
+            </span>
+          )}
+        </p>
+      </div>
+
+      {/* Durum filtresi */}
+      <div className="flex flex-wrap gap-2">
+        {(["ALL", ...statusOrder] as Filter[]).map((f) => (
+          <button
+            key={f}
+            onClick={() => setFilter(f)}
+            aria-pressed={filter === f}
+            className={`px-4 py-2 rounded-xl text-sm font-medium border transition-colors ${
+              filter === f
+                ? "bg-slate-900 text-white border-slate-900"
+                : "bg-white text-slate-600 border-slate-200 hover:bg-slate-50"
+            }`}
+          >
+            {f === "ALL" ? "Tümü" : statusLabels[f]}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-16 text-slate-500">
+          <Loader2 className="w-5 h-5 animate-spin mr-2" />
+          Yükleniyor...
+        </div>
+      ) : loadError ? (
+        <div className="bg-white rounded-2xl border border-slate-200 p-10 text-center">
+          <AlertCircle className="w-8 h-8 text-red-500 mx-auto mb-3" />
+          <p className="text-slate-900 font-semibold">Kayıtlar yüklenemedi</p>
+          <button
+            onClick={load}
+            className="mt-4 rounded-xl bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-5 py-2.5 transition-colors"
+          >
+            Tekrar Dene
+          </button>
+        </div>
+      ) : visible.length === 0 ? (
+        <div className="bg-slate-50 border border-slate-200 rounded-xl p-12 text-center">
+          <Inbox className="w-9 h-9 text-slate-400 mx-auto mb-3" />
+          <p className="text-slate-500 text-sm">
+            {filter === "ALL"
+              ? "Henüz bir öneri veya istek gelmedi."
+              : "Bu durumda kayıt bulunmuyor."}
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-4">
+          {visible.map((item) => {
+            const draft = noteDrafts[item.id] ?? item.adminNote ?? "";
+            const noteChanged = draft !== (item.adminNote ?? "");
+            const busy = savingId === item.id;
+
+            return (
+              <li
+                key={item.id}
+                className="bg-white rounded-2xl border border-slate-200/80 shadow-sm p-5"
+              >
+                <div className="flex flex-wrap items-center gap-2 mb-2">
+                  <span className={`px-2.5 py-0.5 rounded-md text-xs font-semibold border ${typeStyles[item.type]}`}>
+                    {typeLabels[item.type]}
+                  </span>
+                  <span className={`px-2.5 py-0.5 rounded-md text-xs font-semibold border ${statusStyles[item.status]}`}>
+                    {statusLabels[item.status]}
+                  </span>
+                  <span className="text-xs text-slate-500">
+                    {authorDisplayName(item.author)}
+                  </span>
+                  <span className="text-xs text-slate-400 ml-auto">
+                    {new Date(item.createdAt).toLocaleDateString("tr-TR")}
+                  </span>
+                </div>
+
+                <h3 className="font-semibold text-slate-900">{item.title}</h3>
+                <p className="text-sm text-slate-600 mt-1 whitespace-pre-wrap">{item.content}</p>
+
+                {/* Durum değiştirme */}
+                <div className="flex flex-wrap items-center gap-2 mt-4 pt-4 border-t border-slate-100">
+                  <span className="text-xs font-medium text-slate-500 mr-1">Durum:</span>
+                  {statusOrder.map((s) => (
+                    <button
+                      key={s}
+                      onClick={() => patch(item.id, { status: s })}
+                      disabled={busy || item.status === s}
+                      className={`px-3 py-1.5 rounded-lg text-xs font-medium border transition-colors disabled:opacity-60 disabled:cursor-not-allowed ${
+                        item.status === s
+                          ? statusStyles[s]
+                          : "bg-white text-slate-600 border-slate-200 hover:bg-slate-50"
+                      }`}
+                    >
+                      {statusLabels[s]}
+                    </button>
+                  ))}
+                </div>
+
+                {/* Yönetici notu */}
+                <div className="mt-4">
+                  <label
+                    htmlFor={`note-${item.id}`}
+                    className="block text-xs font-medium text-slate-500 mb-1.5"
+                  >
+                    Yönetici yanıtı (öğrenciye gösterilir)
+                  </label>
+                  <textarea
+                    id={`note-${item.id}`}
+                    value={draft}
+                    onChange={(e) =>
+                      setNoteDrafts((prev) => ({ ...prev, [item.id]: e.target.value }))
+                    }
+                    maxLength={2000}
+                    rows={2}
+                    className="w-full px-3 py-2 rounded-xl border border-slate-200 text-sm resize-y focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-500"
+                  />
+                  <button
+                    onClick={() => patch(item.id, { adminNote: draft })}
+                    disabled={busy || !noteChanged}
+                    className="mt-2 inline-flex items-center gap-1.5 px-4 py-2 rounded-xl bg-slate-900 hover:bg-slate-800 disabled:bg-slate-300 disabled:cursor-not-allowed text-white text-xs font-medium transition-colors"
+                  >
+                    {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Save className="w-3.5 h-3.5" />}
+                    Notu Kaydet
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/(student)/student-dashboard/suggestions/page.tsx
+++ b/src/app/(student)/student-dashboard/suggestions/page.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Loader2, AlertCircle, Send, Inbox, MessageSquareQuote } from "lucide-react";
+import { toast } from "sonner";
+import { extractApiErrorMessage } from "@/lib/api-error-message";
+import {
+  typeLabels,
+  typeStyles,
+  statusLabels,
+  statusStyles,
+  type SuggestionStatus,
+  type SuggestionType,
+} from "@/features/suggestions/labels";
+
+type Suggestion = {
+  id: string;
+  type: SuggestionType;
+  title: string;
+  content: string;
+  status: SuggestionStatus;
+  adminNote: string | null;
+  createdAt: string;
+};
+
+const MAX_TITLE = 120;
+const MAX_CONTENT = 2000;
+
+export default function StudentSuggestionsPage() {
+  const [items, setItems] = useState<Suggestion[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+
+  const [type, setType] = useState<SuggestionType>("SUGGESTION");
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      setLoadError(false);
+      const res = await fetch("/api/suggestions");
+      if (!res.ok) throw new Error("failed");
+      setItems(await res.json());
+    } catch {
+      setLoadError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (submitting) return;
+
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/suggestions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type, title, content }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => null);
+        toast.error(extractApiErrorMessage(data, "Gönderilemedi. Lütfen tekrar deneyin."));
+        return;
+      }
+
+      const created: Suggestion = await res.json();
+      setItems((prev) => [created, ...prev]);
+      setTitle("");
+      setContent("");
+      toast.success("Mesajınız yöneticiye iletildi.");
+    } catch {
+      toast.error("Bağlantı hatası. Lütfen tekrar deneyin.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const canSubmit =
+    title.trim().length >= 3 && content.trim().length >= 10 && !submitting;
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 space-y-8">
+      <div className="pt-2">
+        <h1 className="text-3xl font-bold text-slate-900 tracking-tight">Öneri & İstek</h1>
+        <p className="text-slate-500 mt-1.5 text-sm">
+          Platformla ilgili bir öneriniz veya talebiniz mi var? Doğrudan yöneticiye iletin.
+        </p>
+      </div>
+
+      {/* Gönderim formu */}
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white rounded-2xl border border-slate-200/80 shadow-sm p-6 space-y-5"
+      >
+        <div className="flex gap-2">
+          {(Object.keys(typeLabels) as SuggestionType[]).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setType(t)}
+              aria-pressed={type === t}
+              className={`px-4 py-2 rounded-xl text-sm font-medium border transition-colors ${
+                type === t
+                  ? "bg-blue-600 text-white border-blue-600"
+                  : "bg-white text-slate-600 border-slate-200 hover:bg-slate-50"
+              }`}
+            >
+              {typeLabels[t]}
+            </button>
+          ))}
+        </div>
+
+        <div>
+          <label htmlFor="suggestion-title" className="block text-sm font-medium text-slate-700 mb-1.5">
+            Başlık
+          </label>
+          <input
+            id="suggestion-title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            maxLength={MAX_TITLE}
+            placeholder="Kısa ve net bir başlık"
+            className="w-full h-11 px-4 rounded-xl border border-slate-200 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-500"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="suggestion-content" className="block text-sm font-medium text-slate-700 mb-1.5">
+            Açıklama
+          </label>
+          <textarea
+            id="suggestion-content"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            maxLength={MAX_CONTENT}
+            rows={5}
+            placeholder="Önerinizi veya talebinizi ayrıntılı anlatın (en az 10 karakter)."
+            className="w-full px-4 py-3 rounded-xl border border-slate-200 text-sm resize-y focus:outline-none focus:ring-2 focus:ring-blue-500/40 focus:border-blue-500"
+          />
+          <p className="text-xs text-slate-400 mt-1.5 text-right">
+            {content.length}/{MAX_CONTENT}
+          </p>
+        </div>
+
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="inline-flex items-center gap-2 h-11 px-6 rounded-xl bg-blue-600 hover:bg-blue-700 disabled:bg-slate-300 disabled:cursor-not-allowed text-white text-sm font-medium transition-colors"
+        >
+          {submitting ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : (
+            <Send className="w-4 h-4" />
+          )}
+          Gönder
+        </button>
+      </form>
+
+      {/* Geçmiş */}
+      <section>
+        <h2 className="text-xl font-bold text-slate-900 border-b border-slate-200 pb-3 mb-5 flex items-center gap-2">
+          <MessageSquareQuote className="w-5 h-5 text-slate-700" />
+          Gönderdiklerim
+        </h2>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-14 text-slate-500">
+            <Loader2 className="w-5 h-5 animate-spin mr-2" />
+            Yükleniyor...
+          </div>
+        ) : loadError ? (
+          <div className="bg-white rounded-2xl border border-slate-200 p-10 text-center">
+            <AlertCircle className="w-8 h-8 text-red-500 mx-auto mb-3" />
+            <p className="text-slate-900 font-semibold">Kayıtlar yüklenemedi</p>
+            <button
+              onClick={load}
+              className="mt-4 rounded-xl bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-5 py-2.5 transition-colors"
+            >
+              Tekrar Dene
+            </button>
+          </div>
+        ) : items.length === 0 ? (
+          <div className="bg-slate-50 border border-slate-200 rounded-xl p-10 text-center">
+            <Inbox className="w-9 h-9 text-slate-400 mx-auto mb-3" />
+            <p className="text-slate-500 text-sm">
+              Henüz bir öneri veya istek göndermediniz.
+            </p>
+          </div>
+        ) : (
+          <ul className="space-y-4">
+            {items.map((item) => (
+              <li
+                key={item.id}
+                className="bg-white rounded-2xl border border-slate-200/80 shadow-sm p-5"
+              >
+                <div className="flex flex-wrap items-center gap-2 mb-2">
+                  <span className={`px-2.5 py-0.5 rounded-md text-xs font-semibold border ${typeStyles[item.type]}`}>
+                    {typeLabels[item.type]}
+                  </span>
+                  <span className={`px-2.5 py-0.5 rounded-md text-xs font-semibold border ${statusStyles[item.status]}`}>
+                    {statusLabels[item.status]}
+                  </span>
+                  <span className="text-xs text-slate-400 ml-auto">
+                    {new Date(item.createdAt).toLocaleDateString("tr-TR")}
+                  </span>
+                </div>
+                <h3 className="font-semibold text-slate-900">{item.title}</h3>
+                <p className="text-sm text-slate-600 mt-1 whitespace-pre-wrap">{item.content}</p>
+
+                {item.adminNote && (
+                  <div className="mt-4 rounded-xl bg-slate-50 border border-slate-200 p-3">
+                    <p className="text-xs font-semibold text-slate-500 mb-1">Yönetici yanıtı</p>
+                    <p className="text-sm text-slate-700 whitespace-pre-wrap">{item.adminNote}</p>
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/api/admin/suggestions/[id]/route.test.ts
+++ b/src/app/api/admin/suggestions/[id]/route.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, prismaMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  prismaMock: {
+    suggestion: { findUnique: vi.fn(), update: vi.fn() },
+  },
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+
+import { PATCH } from "./route";
+
+function authAsAdmin() {
+  requireAuthMock.mockResolvedValue({
+    authorized: true,
+    session: { user: { id: "admin-1", role: "ADMIN" } },
+  });
+}
+function patchReq(body: unknown) {
+  return new Request("http://test/api/admin/suggestions/s1", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+const params = Promise.resolve({ id: "s1" });
+
+describe("admin/suggestions/[id] PATCH (#147)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("durum günceller ve inceleyen yöneticiyi damgalar", async () => {
+    authAsAdmin();
+    prismaMock.suggestion.findUnique.mockResolvedValue({ id: "s1" });
+    prismaMock.suggestion.update.mockResolvedValue({ id: "s1", status: "RESOLVED" });
+
+    const res = await PATCH(patchReq({ status: "RESOLVED" }), { params });
+
+    expect(res.status).toBe(200);
+    const arg = prismaMock.suggestion.update.mock.calls[0][0];
+    expect(arg.data.status).toBe("RESOLVED");
+    expect(arg.data.reviewedById).toBe("admin-1");
+    expect(arg.data.reviewedAt).toBeInstanceOf(Date);
+  });
+
+  it("kayıt yoksa → 404, update çağrılmaz", async () => {
+    authAsAdmin();
+    prismaMock.suggestion.findUnique.mockResolvedValue(null);
+
+    const res = await PATCH(patchReq({ status: "OPEN" }), { params });
+
+    expect(res.status).toBe(404);
+    expect(prismaMock.suggestion.update).not.toHaveBeenCalled();
+  });
+
+  it("boş gövde → 400 (en az bir alan gerekli)", async () => {
+    authAsAdmin();
+
+    const res = await PATCH(patchReq({}), { params });
+
+    expect(res.status).toBe(400);
+    expect(prismaMock.suggestion.update).not.toHaveBeenCalled();
+  });
+
+  it("geçersiz durum → 400", async () => {
+    authAsAdmin();
+
+    const res = await PATCH(patchReq({ status: "ARSIVLENDI" }), { params });
+
+    expect(res.status).toBe(400);
+    expect(prismaMock.suggestion.update).not.toHaveBeenCalled();
+  });
+
+  it("admin değil → 403, DB'ye hiç gidilmez", async () => {
+    requireAuthMock.mockResolvedValue({
+      authorized: false,
+      response: new Response(JSON.stringify({ error: "yetkisiz" }), { status: 403 }),
+    });
+
+    const res = await PATCH(patchReq({ status: "RESOLVED" }), { params });
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.suggestion.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/admin/suggestions/[id]/route.ts
+++ b/src/app/api/admin/suggestions/[id]/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { updateSuggestion } from "@/features/suggestions/server/suggestions";
+import { requireAuth } from "@/lib/auth/guard";
+import { updateSuggestionSchema } from "@/lib/validations/api";
+
+/**
+ * PATCH /api/admin/suggestions/[id]
+ * Öneri/isteğin durumunu veya yönetici notunu günceller (#147).
+ */
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAuth("ADMIN");
+  if (!auth.authorized) return auth.response;
+
+  try {
+    const { id } = await params;
+    const body = await req.json();
+    const parsed = updateSuggestionSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      );
+    }
+
+    // guard `session.user.id` varlığını doğruladı.
+    const updated = await updateSuggestion(id, parsed.data, auth.session.user.id!);
+    if (!updated) {
+      return NextResponse.json({ error: "Kayıt bulunamadı." }, { status: 404 });
+    }
+
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error("PATCH /api/admin/suggestions/[id] error:", error);
+    return NextResponse.json(
+      { error: "Kayıt güncellenirken hata oluştu." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/admin/suggestions/route.test.ts
+++ b/src/app/api/admin/suggestions/route.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, prismaMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  prismaMock: {
+    suggestion: { findMany: vi.fn() },
+  },
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+
+import { GET } from "./route";
+
+function authAsAdmin() {
+  requireAuthMock.mockResolvedValue({
+    authorized: true,
+    session: { user: { id: "admin-1", role: "ADMIN" } },
+  });
+}
+function req(query = "") {
+  return new Request(`http://test/api/admin/suggestions${query}`);
+}
+
+describe("admin/suggestions route (#147)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("GET admin → 200, filtresiz tüm kayıtlar", async () => {
+    authAsAdmin();
+    prismaMock.suggestion.findMany.mockResolvedValue([{ id: "s1" }]);
+
+    const res = await GET(req());
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.suggestion.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: undefined }),
+    );
+  });
+
+  it("GET ADMIN rolü zorunlu — guard'a 'ADMIN' geçilir", async () => {
+    authAsAdmin();
+    prismaMock.suggestion.findMany.mockResolvedValue([]);
+
+    await GET(req());
+
+    expect(requireAuthMock).toHaveBeenCalledWith("ADMIN");
+  });
+
+  it("GET admin değil → guard yanıtı aynen döner (403)", async () => {
+    requireAuthMock.mockResolvedValue({
+      authorized: false,
+      response: new Response(JSON.stringify({ error: "yetkisiz" }), { status: 403 }),
+    });
+
+    const res = await GET(req());
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.suggestion.findMany).not.toHaveBeenCalled();
+  });
+
+  it("GET geçerli status filtresi sorguya yansır", async () => {
+    authAsAdmin();
+    prismaMock.suggestion.findMany.mockResolvedValue([]);
+
+    await GET(req("?status=IN_REVIEW"));
+
+    expect(prismaMock.suggestion.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { status: "IN_REVIEW" } }),
+    );
+  });
+
+  it("GET geçersiz status → 400", async () => {
+    authAsAdmin();
+
+    const res = await GET(req("?status=BILINMEYEN"));
+
+    expect(res.status).toBe(400);
+    expect(prismaMock.suggestion.findMany).not.toHaveBeenCalled();
+  });
+
+  it("GET yanıtı yazarın parola alanını seçmez", async () => {
+    authAsAdmin();
+    prismaMock.suggestion.findMany.mockResolvedValue([]);
+
+    await GET(req());
+
+    const select = prismaMock.suggestion.findMany.mock.calls[0][0].select;
+    expect(select.author.select).not.toHaveProperty("password");
+    expect(select.author.select).toMatchObject({ id: true, email: true });
+  });
+});

--- a/src/app/api/admin/suggestions/route.ts
+++ b/src/app/api/admin/suggestions/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { listAllSuggestions } from "@/features/suggestions/server/suggestions";
+import { requireAuth } from "@/lib/auth/guard";
+import { suggestionStatusEnum } from "@/lib/validations/api";
+
+/**
+ * GET /api/admin/suggestions?status=OPEN
+ * Tüm öneri/istekleri listeler (admin) — #147.
+ */
+export async function GET(req: Request) {
+  const auth = await requireAuth("ADMIN");
+  if (!auth.authorized) return auth.response;
+
+  try {
+    const raw = new URL(req.url).searchParams.get("status");
+    const parsed = raw ? suggestionStatusEnum.safeParse(raw) : null;
+    if (parsed && !parsed.success) {
+      return NextResponse.json(
+        { error: "Geçersiz durum filtresi." },
+        { status: 400 },
+      );
+    }
+
+    const items = await listAllSuggestions(parsed?.data);
+    return NextResponse.json(items);
+  } catch (error) {
+    console.error("GET /api/admin/suggestions error:", error);
+    return NextResponse.json(
+      { error: "Öneriler yüklenirken hata oluştu." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/suggestions/route.test.ts
+++ b/src/app/api/suggestions/route.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, prismaMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  prismaMock: {
+    suggestion: { findMany: vi.fn(), create: vi.fn() },
+  },
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+
+import { GET, POST } from "./route";
+
+function authAs(id: string) {
+  requireAuthMock.mockResolvedValue({
+    authorized: true,
+    session: { user: { id, role: "STUDENT" } },
+  });
+}
+function unauthorized(status = 401) {
+  requireAuthMock.mockResolvedValue({
+    authorized: false,
+    response: new Response(JSON.stringify({ error: "yetkisiz" }), { status }),
+  });
+}
+function postReq(body: unknown) {
+  return new Request("http://test/api/suggestions", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("suggestions route (#147)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("GET → yalnızca oturum sahibinin kayıtlarını sorgular", async () => {
+    authAs("student-1");
+    prismaMock.suggestion.findMany.mockResolvedValue([{ id: "s1" }]);
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.suggestion.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { authorId: "student-1" } }),
+    );
+  });
+
+  it("GET oturum yok → 401", async () => {
+    unauthorized();
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("POST geçerli → 201 ve authorId oturumdan alınır", async () => {
+    authAs("student-1");
+    prismaMock.suggestion.create.mockResolvedValue({ id: "s1" });
+
+    const res = await POST(
+      postReq({
+        type: "REQUEST",
+        title: "Ek kaynak talebi",
+        content: "React konusunda ek kaynak paylaşabilir misiniz?",
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(prismaMock.suggestion.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ authorId: "student-1", type: "REQUEST" }),
+      }),
+    );
+  });
+
+  it("POST gövdedeki authorId yok sayılır — başkası adına kayıt açılamaz", async () => {
+    authAs("student-1");
+    prismaMock.suggestion.create.mockResolvedValue({ id: "s1" });
+
+    await POST(
+      postReq({
+        authorId: "baskasi",
+        type: "SUGGESTION",
+        title: "Karanlık mod",
+        content: "Panelde karanlık mod seçeneği olsa çok iyi olur.",
+      }),
+    );
+
+    const arg = prismaMock.suggestion.create.mock.calls[0][0];
+    expect(arg.data.authorId).toBe("student-1");
+  });
+
+  it("POST kısa açıklama → 400, create çağrılmaz", async () => {
+    authAs("student-1");
+
+    const res = await POST(
+      postReq({ type: "SUGGESTION", title: "Başlık", content: "kısa" }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(prismaMock.suggestion.create).not.toHaveBeenCalled();
+  });
+
+  it("POST geçersiz tip → 400", async () => {
+    authAs("student-1");
+
+    const res = await POST(
+      postReq({
+        type: "SIKAYET",
+        title: "Başlık",
+        content: "Yeterince uzun bir açıklama metni.",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(prismaMock.suggestion.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/suggestions/route.ts
+++ b/src/app/api/suggestions/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import {
+  createSuggestion,
+  listOwnSuggestions,
+} from "@/features/suggestions/server/suggestions";
+import { requireAuth } from "@/lib/auth/guard";
+import { createSuggestionSchema } from "@/lib/validations/api";
+
+/**
+ * GET /api/suggestions
+ * Oturum sahibinin kendi öneri/istek geçmişi (#147).
+ */
+export async function GET() {
+  const auth = await requireAuth();
+  if (!auth.authorized) return auth.response;
+
+  try {
+    // guard `session.user.id` varlığını doğruladı.
+    const items = await listOwnSuggestions(auth.session.user.id!);
+    return NextResponse.json(items);
+  } catch (error) {
+    console.error("GET /api/suggestions error:", error);
+    return NextResponse.json(
+      { error: "Öneriler yüklenirken hata oluştu." },
+      { status: 500 },
+    );
+  }
+}
+
+/**
+ * POST /api/suggestions
+ * Yeni öneri/istek oluşturur. Yazar her zaman oturumdan alınır — istemci
+ * başkası adına kayıt açamaz (#147).
+ */
+export async function POST(req: Request) {
+  const auth = await requireAuth();
+  if (!auth.authorized) return auth.response;
+
+  try {
+    const body = await req.json();
+    const parsed = createSuggestionSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      );
+    }
+
+    const created = await createSuggestion({
+      authorId: auth.session.user.id!,
+      ...parsed.data,
+    });
+    return NextResponse.json(created, { status: 201 });
+  } catch (error) {
+    console.error("POST /api/suggestions error:", error);
+    return NextResponse.json(
+      { error: "Öneri gönderilirken hata oluştu." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -17,6 +17,7 @@ const navByRole: Record<Role, { home: string; links: NavLink[] }> = {
       { href: "/admin-dashboard", label: "Panel" },
       { href: "/admin-dashboard/projects", label: "Projeler" },
       { href: "/admin-dashboard/messages", label: "Mesajlar" },
+      { href: "/admin-dashboard/suggestions", label: "Öneri & İstek" },
     ],
   },
   MENTOR: {
@@ -31,6 +32,7 @@ const navByRole: Record<Role, { home: string; links: NavLink[] }> = {
     links: [
       { href: "/student-dashboard", label: "Panel" },
       { href: "/student-dashboard/messages", label: "Mesajlar" },
+      { href: "/student-dashboard/suggestions", label: "Öneri & İstek" },
     ],
   },
 };

--- a/src/features/suggestions/labels.test.ts
+++ b/src/features/suggestions/labels.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { authorDisplayName, statusLabels, typeLabels } from "./labels";
+
+describe("suggestions labels (#147)", () => {
+  it("ad ve soyadı birleştirir", () => {
+    expect(
+      authorDisplayName({ name: "Ayşe", lastName: "Yılmaz", email: "a@x.com" }),
+    ).toBe("Ayşe Yılmaz");
+  });
+
+  it("yalnızca ad varsa soyadsız döner", () => {
+    expect(authorDisplayName({ name: "Ayşe", lastName: null, email: "a@x.com" })).toBe(
+      "Ayşe",
+    );
+  });
+
+  it("ad/soyad yoksa e-postaya düşer", () => {
+    expect(authorDisplayName({ name: null, lastName: null, email: "a@x.com" })).toBe(
+      "a@x.com",
+    );
+  });
+
+  it("boşluktan ibaret ad e-postaya düşer", () => {
+    expect(authorDisplayName({ name: "  ", lastName: null, email: "a@x.com" })).toBe(
+      "a@x.com",
+    );
+  });
+
+  it("tüm tip ve durumların Türkçe etiketi vardır", () => {
+    expect(Object.values(typeLabels).every(Boolean)).toBe(true);
+    expect(Object.values(statusLabels).every(Boolean)).toBe(true);
+  });
+});

--- a/src/features/suggestions/labels.ts
+++ b/src/features/suggestions/labels.ts
@@ -1,0 +1,41 @@
+/**
+ * #147: Öneri & İstek modülünün ortak etiket/renk tanımları.
+ * Öğrenci ve yönetici arayüzü aynı sözlüğü kullanır ki metinler ayrışmasın.
+ */
+
+export type SuggestionType = "SUGGESTION" | "REQUEST";
+export type SuggestionStatus = "OPEN" | "IN_REVIEW" | "RESOLVED";
+
+export const typeLabels: Record<SuggestionType, string> = {
+  SUGGESTION: "Öneri",
+  REQUEST: "İstek",
+};
+
+export const typeStyles: Record<SuggestionType, string> = {
+  SUGGESTION: "bg-indigo-50 text-indigo-700 border-indigo-200",
+  REQUEST: "bg-blue-50 text-blue-700 border-blue-200",
+};
+
+export const statusLabels: Record<SuggestionStatus, string> = {
+  OPEN: "Açık",
+  IN_REVIEW: "İnceleniyor",
+  RESOLVED: "Çözüldü",
+};
+
+export const statusStyles: Record<SuggestionStatus, string> = {
+  OPEN: "bg-amber-50 text-amber-700 border-amber-200",
+  IN_REVIEW: "bg-blue-50 text-blue-700 border-blue-200",
+  RESOLVED: "bg-emerald-50 text-emerald-700 border-emerald-200",
+};
+
+export const statusOrder: SuggestionStatus[] = ["OPEN", "IN_REVIEW", "RESOLVED"];
+
+/** Yazarın görünen adı — ad/soyad boşsa e-postaya düşer. */
+export function authorDisplayName(author: {
+  name: string | null;
+  lastName: string | null;
+  email: string;
+}): string {
+  const full = [author.name, author.lastName].filter(Boolean).join(" ").trim();
+  return full || author.email;
+}

--- a/src/features/suggestions/server/suggestions.ts
+++ b/src/features/suggestions/server/suggestions.ts
@@ -1,0 +1,89 @@
+import { prisma } from "@/lib/db";
+import type { SuggestionStatus, SuggestionType } from "@prisma/client";
+
+/**
+ * #147: Öneri & İstek modülünün veri katmanı.
+ *
+ * Kural: öğrenci yalnızca **kendi** kayıtlarını görür (author scope'u sorguya
+ * gömülüdür, route seviyesinde filtre unutulamaz). Admin tümünü görür.
+ */
+
+/** Öğrenciye de gösterilen alanlar — yazar bilgisi hariç. */
+const ownSelect = {
+  id: true,
+  type: true,
+  title: true,
+  content: true,
+  status: true,
+  adminNote: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
+/** Admin listesi — yazarın kimliği de gerekir (hash asla seçilmez). */
+const adminSelect = {
+  ...ownSelect,
+  reviewedAt: true,
+  author: {
+    select: { id: true, name: true, lastName: true, email: true },
+  },
+  reviewedBy: {
+    select: { id: true, name: true, lastName: true },
+  },
+} as const;
+
+export async function createSuggestion(input: {
+  authorId: string;
+  type: SuggestionType;
+  title: string;
+  content: string;
+}) {
+  return prisma.suggestion.create({
+    data: input,
+    select: ownSelect,
+  });
+}
+
+/** Bir kullanıcının kendi gönderdiği öneri/istekler (en yeni önce). */
+export async function listOwnSuggestions(authorId: string) {
+  return prisma.suggestion.findMany({
+    where: { authorId },
+    orderBy: { createdAt: "desc" },
+    select: ownSelect,
+  });
+}
+
+/** Tüm kayıtlar (admin). Açık olanlar önce gelsin diye status'e göre de sıralanır. */
+export async function listAllSuggestions(status?: SuggestionStatus) {
+  return prisma.suggestion.findMany({
+    where: status ? { status } : undefined,
+    orderBy: [{ status: "asc" }, { createdAt: "desc" }],
+    select: adminSelect,
+  });
+}
+
+/**
+ * Admin durum/not günceller. `status` verildiyse inceleme bilgisi de damgalanır.
+ * Kayıt yoksa `null` döner (route 404'e çevirir).
+ */
+export async function updateSuggestion(
+  id: string,
+  data: { status?: SuggestionStatus; adminNote?: string },
+  reviewedById: string,
+) {
+  const exists = await prisma.suggestion.findUnique({
+    where: { id },
+    select: { id: true },
+  });
+  if (!exists) return null;
+
+  return prisma.suggestion.update({
+    where: { id },
+    data: {
+      ...data,
+      reviewedById,
+      reviewedAt: new Date(),
+    },
+    select: adminSelect,
+  });
+}

--- a/src/lib/validations/api.ts
+++ b/src/lib/validations/api.ts
@@ -205,3 +205,39 @@ export const updateStepCommentSchema = z.object({
     .max(1000, "Yorum en fazla 1000 karakter olabilir")
     .transform((val) => val.trim()),
 });
+
+// ==========================================
+// 📮 Öneri & İstek Şemaları (#147)
+// ==========================================
+
+export const suggestionTypeEnum = z.enum(["SUGGESTION", "REQUEST"]);
+export const suggestionStatusEnum = z.enum(["OPEN", "IN_REVIEW", "RESOLVED"]);
+
+// Stajyer yeni öneri/istek gönderir
+export const createSuggestionSchema = z.object({
+  type: suggestionTypeEnum,
+  title: z
+    .string()
+    .min(3, "Başlık en az 3 karakter olmalı")
+    .max(120, "Başlık en fazla 120 karakter olabilir")
+    .transform((val) => val.trim()),
+  content: z
+    .string()
+    .min(10, "Açıklama en az 10 karakter olmalı")
+    .max(2000, "Açıklama en fazla 2000 karakter olabilir")
+    .transform((val) => val.trim()),
+});
+
+// Yönetici durum / not günceller — en az bir alan gönderilmeli
+export const updateSuggestionSchema = z
+  .object({
+    status: suggestionStatusEnum.optional(),
+    adminNote: z
+      .string()
+      .max(2000, "Not en fazla 2000 karakter olabilir")
+      .transform((val) => val.trim())
+      .optional(),
+  })
+  .refine((data) => data.status !== undefined || data.adminNote !== undefined, {
+    message: "Güncellenecek en az bir alan gönderilmeli",
+  });


### PR DESCRIPTION
## Ne yapıldı?

Stajyerlerin platformla ilgili **öneri** ve **istek**lerini doğrudan yöneticiye iletebileceği modül. Bugüne kadar öğrencinin admin ile iletişim kurabileceği bir kanal yoktu — mesajlaşma yalnızca mentör ile çalışıyor.

### Veri katmanı
- `Suggestion` modeli + migration: `type` (SUGGESTION/REQUEST), `status` (OPEN/IN_REVIEW/RESOLVED), `adminNote`, `author` & `reviewedBy` FK, `(authorId, createdAt)` ve `(status, createdAt)` indeksleri.
- Yazar kapsamı (`where: { authorId }`) **veri katmanına gömülü** — route seviyesinde filtre unutulamaz.
- Admin select'i yazarın yalnızca `id/name/lastName/email` alanlarını çeker; parola hash'i hiçbir yolda seçilmez.

### API
| Uç | Yetki | İş |
|---|---|---|
| `GET /api/suggestions` | oturum | kendi geçmişi |
| `POST /api/suggestions` | oturum | yeni kayıt — `authorId` **her zaman** oturumdan |
| `GET /api/admin/suggestions?status=` | ADMIN | tüm kayıtlar + durum filtresi |
| `PATCH /api/admin/suggestions/[id]` | ADMIN | durum / yönetici notu |

### Arayüz
- `/student-dashboard/suggestions` — tip seçimi, form, kendi geçmişi ve yöneticinin yanıtı.
- `/admin-dashboard/suggestions` — durum filtresi, tek tıkla durum değiştirme, öğrenciye görünen yanıt notu.
- `AppShell`'e rol bazlı "Öneri & İstek" bağlantısı (öğrenci + yönetici).
- Mevcut desenlere uyuldu: `loadError` + "Tekrar Dene", `sonner` toast, `extractApiErrorMessage`.

## Test
22 yeni test (toplam **183/183 yeşil**):
- Yazar kapsamı: `GET` yalnızca kendi `authorId`'sini sorguluyor; `POST` gövdesindeki `authorId` yok sayılıyor (**başkası adına kayıt açılamıyor**).
- Yetki: admin olmayan `403` alıyor ve **DB'ye hiç gidilmiyor**.
- Şema: kısa açıklama / geçersiz tip / geçersiz durum / boş PATCH gövdesi → `400`, DB yazımı yok.
- Olmayan kayıt PATCH → `404`.
- Admin select'inde `password` alanı bulunmadığı testle sabitlendi.

## Doğrulama
- `npm test` → 183/183 ✓
- `npm run lint` → 0 hata (9 uyarı, hepsi önceden var)
- `npm run build` → ✓, 5 route kayıtlı
- Migration lokal DB'ye uygulandı ✓

## Not
`package-lock.json` değişmedi — yeni bağımlılık yok.

Closes #147
Refs #126