### PR TITLE
fix: sifre sifirlama akisinda yetki atlatma ve hesap ifsasi

### DIFF
--- a/src/app/api/auth/forgot-password/verify/route.test.ts
+++ b/src/app/api/auth/forgot-password/verify/route.test.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { prismaMock, verifyMock, hashMock } = vi.hoisted(() => ({
+  prismaMock: {
+    user: { findUnique: vi.fn(), update: vi.fn() },
+  },
+  verifyMock: vi.fn(),
+  hashMock: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+vi.mock("@node-rs/argon2", () => ({
+  verify: (...args: unknown[]) => verifyMock(...args),
+  hash: (...args: unknown[]) => hashMock(...args),
+}));
+
+import { POST } from "./route";
+
+/** Kayıtlı 3 güvenlik cevabı olan kullanıcı. Hash'ler "hash:<cevap>" formatında. */
+function userWithAnswers() {
+  return {
+    id: "user-1",
+    securityAnswers: [
+      { questionId: 0, answer: "hash:tekir" },
+      { questionId: 1, answer: "hash:ataturk" },
+      { questionId: 2, answer: "hash:yilmaz" },
+    ],
+  };
+}
+
+/** argon2.verify taklidi: stored "hash:x" ise yalnızca "x" doğrudur. */
+function realisticVerify() {
+  verifyMock.mockImplementation(async (stored: string, candidate: string) => {
+    return stored === `hash:${candidate}`;
+  });
+}
+
+let ipCounter = 0;
+function req(body: unknown, ip?: string) {
+  // Her test kendi IP'sini kullanır — rate limiter proses-yerel ve testler arası taşar.
+  return new Request("http://test/api/auth/forgot-password/verify", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-real-ip": ip ?? `10.0.0.${++ipCounter}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+/** Her testte benzersiz e-posta — hesap bazlı limit testler arası taşmasın. */
+let emailCounter = 0;
+const freshEmail = () => `user${++emailCounter}@test.com`;
+
+describe("forgot-password/verify (#149)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hashMock.mockResolvedValue("hashed-new-password");
+  });
+
+  describe("cevap tekilleştirme — tek cevabı bilen geçemez", () => {
+    it("aynı doğru cevap 3 kez gönderilirse doğrulama BAŞARISIZ olur", async () => {
+      prismaMock.user.findUnique.mockResolvedValue(userWithAnswers());
+      realisticVerify();
+
+      const res = await POST(
+        req({
+          email: freshEmail(),
+          answers: [
+            { questionId: 0, answer: "tekir" },
+            { questionId: 0, answer: "tekir" },
+            { questionId: 0, answer: "tekir" },
+          ],
+        }),
+      );
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json).not.toHaveProperty("resetToken");
+    });
+
+    it("üç FARKLI sorunun doğru cevabı → resetToken verilir", async () => {
+      prismaMock.user.findUnique.mockResolvedValue(userWithAnswers());
+      realisticVerify();
+
+      const res = await POST(
+        req({
+          email: freshEmail(),
+          answers: [
+            { questionId: 0, answer: "tekir" },
+            { questionId: 1, answer: "ataturk" },
+            { questionId: 2, answer: "yilmaz" },
+          ],
+        }),
+      );
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json.step).toBe("verified");
+      expect(json.resetToken).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("iki doğru + bir yanlış → geçemez", async () => {
+      prismaMock.user.findUnique.mockResolvedValue(userWithAnswers());
+      realisticVerify();
+
+      const res = await POST(
+        req({
+          email: freshEmail(),
+          answers: [
+            { questionId: 0, answer: "tekir" },
+            { questionId: 1, answer: "ataturk" },
+            { questionId: 2, answer: "yanlis" },
+          ],
+        }),
+      );
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("hesap ifşası (enumeration)", () => {
+    it("kayıtsız hesap için sorular tekrarlanabilir — iki istek AYNI üçlüyü döndürür", async () => {
+      prismaMock.user.findUnique.mockResolvedValue(null);
+      const email = freshEmail();
+
+      const first = await (await POST(req({ email }))).json();
+      const second = await (await POST(req({ email }))).json();
+
+      expect(first.step).toBe("questions");
+      expect(first.questions).toHaveLength(3);
+      expect(second.questions).toEqual(first.questions);
+    });
+
+    it("farklı e-postalar farklı sahte sorular alır", async () => {
+      prismaMock.user.findUnique.mockResolvedValue(null);
+
+      const a = await (await POST(req({ email: "aaa@test.com" }))).json();
+      const b = await (await POST(req({ email: "zzz@test.com" }))).json();
+
+      expect(a.questions).not.toEqual(b.questions);
+    });
+
+    it("kayıtsız hesapta da argon2 doğrulaması çalışır (sabit zaman)", async () => {
+      prismaMock.user.findUnique.mockResolvedValue(null);
+      verifyMock.mockResolvedValue(false);
+
+      const res = await POST(
+        req({
+          email: freshEmail(),
+          answers: [
+            { questionId: 0, answer: "a" },
+            { questionId: 1, answer: "b" },
+            { questionId: 2, answer: "c" },
+          ],
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      expect(verifyMock).toHaveBeenCalledTimes(3);
+    });
+
+    it("kayıtsız hesabın hata mesajı kayıtlı hesapla aynıdır", async () => {
+      verifyMock.mockResolvedValue(false);
+      const answers = [
+        { questionId: 0, answer: "x" },
+        { questionId: 1, answer: "y" },
+        { questionId: 2, answer: "z" },
+      ];
+
+      prismaMock.user.findUnique.mockResolvedValue(null);
+      const missing = await (await POST(req({ email: freshEmail(), answers }))).json();
+
+      prismaMock.user.findUnique.mockResolvedValue(userWithAnswers());
+      const existing = await (await POST(req({ email: freshEmail(), answers }))).json();
+
+      expect(missing.error).toContain("Güvenlik sorusu cevapları yanlış");
+      expect(existing.error).toContain("Güvenlik sorusu cevapları yanlış");
+    });
+  });
+
+  describe("resetToken zorunluluğu", () => {
+    it("token olmadan yeni şifre gönderilemez", async () => {
+      prismaMock.user.findUnique.mockResolvedValue(userWithAnswers());
+      realisticVerify();
+
+      const res = await POST(
+        req({
+          email: freshEmail(),
+          answers: [
+            { questionId: 0, answer: "tekir" },
+            { questionId: 1, answer: "ataturk" },
+            { questionId: 2, answer: "yilmaz" },
+          ],
+          newPassword: "YeniSifre1!",
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      expect(prismaMock.user.update).not.toHaveBeenCalled();
+    });
+
+    it("uydurma token ile şifre değiştirilemez", async () => {
+      prismaMock.user.findUnique.mockResolvedValue(userWithAnswers());
+      realisticVerify();
+
+      const res = await POST(
+        req({
+          email: freshEmail(),
+          answers: [
+            { questionId: 0, answer: "tekir" },
+            { questionId: 1, answer: "ataturk" },
+            { questionId: 2, answer: "yilmaz" },
+          ],
+          newPassword: "YeniSifre1!",
+          resetToken: "a".repeat(64),
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      expect(prismaMock.user.update).not.toHaveBeenCalled();
+    });
+
+    it("geçerli token tek kullanımlıktır — ikinci kullanım reddedilir", async () => {
+      prismaMock.user.findUnique.mockResolvedValue(userWithAnswers());
+      realisticVerify();
+      const email = freshEmail();
+      const answers = [
+        { questionId: 0, answer: "tekir" },
+        { questionId: 1, answer: "ataturk" },
+        { questionId: 2, answer: "yilmaz" },
+      ];
+
+      const verified = await (await POST(req({ email, answers }))).json();
+      const token = verified.resetToken;
+
+      const first = await POST(
+        req({ email, answers, newPassword: "YeniSifre1!", resetToken: token }),
+      );
+      const second = await POST(
+        req({ email, answers, newPassword: "BaskaSifre1!", resetToken: token }),
+      );
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(400);
+      expect(prismaMock.user.update).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("şifre politikası", () => {
+    async function attemptPassword(newPassword: string) {
+      prismaMock.user.findUnique.mockResolvedValue(userWithAnswers());
+      realisticVerify();
+      const email = freshEmail();
+      const answers = [
+        { questionId: 0, answer: "tekir" },
+        { questionId: 1, answer: "ataturk" },
+        { questionId: 2, answer: "yilmaz" },
+      ];
+
+      const verified = await (await POST(req({ email, answers }))).json();
+      return POST(
+        req({ email, answers, newPassword, resetToken: verified.resetToken }),
+      );
+    }
+
+    it.each([
+      ["Kisa1!", "8 karakterden kısa"],
+      ["uzunsifre1!", "büyük harfsiz"],
+      ["UZUNSIFRE1!", "küçük harfsiz"],
+      ["UzunSifre!!", "rakamsız"],
+      ["UzunSifre11", "özel karaktersiz"],
+    ])("%s reddedilir (%s)", async (password) => {
+      const res = await attemptPassword(password);
+      expect(res.status).toBe(400);
+      expect(prismaMock.user.update).not.toHaveBeenCalled();
+    });
+
+    it("politikaya uyan şifre kabul edilir ve hash'lenerek yazılır", async () => {
+      const res = await attemptPassword("GucluSifre1!");
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json.step).toBe("success");
+      expect(prismaMock.user.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "user-1" },
+          data: { password: "hashed-new-password" },
+        }),
+      );
+      // Ham şifre asla yazılmaz
+      expect(hashMock).toHaveBeenCalledWith("GucluSifre1!");
+    });
+  });
+
+  describe("rate limit", () => {
+    it("meşru 3 adımlı akış tek IP'de kilitlenmeden tamamlanır", async () => {
+      prismaMock.user.findUnique.mockResolvedValue(userWithAnswers());
+      realisticVerify();
+      const ip = "10.9.9.9";
+      const email = freshEmail();
+      const answers = [
+        { questionId: 0, answer: "tekir" },
+        { questionId: 1, answer: "ataturk" },
+        { questionId: 2, answer: "yilmaz" },
+      ];
+
+      const step1 = await POST(req({ email }, ip));
+      const step2res = await POST(req({ email, answers }, ip));
+      const step2 = await step2res.json();
+      const step3 = await POST(
+        req({ email, answers, newPassword: "GucluSifre1!", resetToken: step2.resetToken }, ip),
+      );
+
+      expect(step1.status).toBe(200);
+      expect(step2res.status).toBe(200);
+      expect(step3.status).toBe(200);
+    });
+
+    it("birkaç kez yanlış hatırlayıp sonunda bilen kullanıcı kilitlenmez", async () => {
+      // Eski davranışta kota HER istekte tüketiliyordu: e-posta(1) + üç yanlış
+      // deneme(2,3,4) + doğru cevap(5) + yeni şifre(6) → son adımda 429.
+      // Yeni davranışta yalnızca 1. adım ve yanlış denemeler sayılır (4) →
+      // doğrulama ve şifre belirleme adımları kota yemez.
+      prismaMock.user.findUnique.mockResolvedValue(userWithAnswers());
+      const ip = "10.7.7.7";
+      const email = freshEmail();
+      const correct = [
+        { questionId: 0, answer: "tekir" },
+        { questionId: 1, answer: "ataturk" },
+        { questionId: 2, answer: "yilmaz" },
+      ];
+      const wrong = correct.map((a) => ({ ...a, answer: "yanlis" }));
+
+      realisticVerify();
+      await POST(req({ email }, ip)); // adım 1
+      for (let i = 0; i < 3; i++) {
+        await POST(req({ email, answers: wrong }, ip)); // yanlış denemeler
+      }
+
+      const verified = await (await POST(req({ email, answers: correct }, ip))).json();
+      const done = await POST(
+        req({ email, answers: correct, newPassword: "GucluSifre1!", resetToken: verified.resetToken }, ip),
+      );
+
+      expect(done.status).toBe(200);
+    });
+
+    it("art arda yanlış cevaplar 429'a yol açar", async () => {
+      prismaMock.user.findUnique.mockResolvedValue(userWithAnswers());
+      verifyMock.mockResolvedValue(false);
+      const ip = "10.8.8.8";
+      const answers = [
+        { questionId: 0, answer: "yanlis" },
+        { questionId: 1, answer: "yanlis" },
+        { questionId: 2, answer: "yanlis" },
+      ];
+
+      const statuses: number[] = [];
+      for (let i = 0; i < 7; i++) {
+        const res = await POST(req({ email: freshEmail(), answers }, ip));
+        statuses.push(res.status);
+      }
+
+      expect(statuses).toContain(429);
+    });
+  });
+
+  it("e-posta gönderilmezse 400", async () => {
+    const res = await POST(req({}));
+    expect(res.status).toBe(400);
+    expect(prismaMock.user.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/auth/forgot-password/verify/route.ts
+++ b/src/app/api/auth/forgot-password/verify/route.ts
@@ -5,6 +5,19 @@ import { SECURITY_QUESTIONS, REQUIRED_ANSWERS } from "@/lib/security-questions";
 import { createRateLimiter } from "@/lib/rate-limit";
 import crypto from "crypto";
 
+/**
+ * #149: Kullanıcı bulunamadığında da argon2 doğrulaması çalıştırmak için sabit
+ * bir hash. Aksi halde "hesap yok" yanıtı belirgin şekilde daha hızlı döner ve
+ * hesabın varlığı yanıt süresinden okunabilir (nextauth.ts ile aynı desen).
+ */
+let dummyHashPromise: Promise<string> | null = null;
+function getDummyHash(): Promise<string> {
+  if (!dummyHashPromise) {
+    dummyHashPromise = hash("aisigner-dummy-answer-for-constant-time-verify");
+  }
+  return dummyHashPromise;
+}
+
 const limiter = createRateLimiter("forgot-password", {
   maxRequests: 5,
   windowSeconds: 300, // 5 dakikada max 5 deneme
@@ -30,13 +43,15 @@ interface ResetToken {
 }
 const resetTokens = new Map<string, ResetToken>();
 
-// Süresi dolan tokenleri temizle (her 5 dakikada bir)
-setInterval(() => {
+// Süresi dolan tokenleri temizle (her 5 dakikada bir).
+// unref: bu zamanlayıcı tek başına prosesi ayakta tutmasın.
+const sweeper = setInterval(() => {
   const now = Date.now();
   for (const [token, data] of resetTokens) {
     if (now > data.expiresAt) resetTokens.delete(token);
   }
 }, 5 * 60 * 1000);
+sweeper.unref?.();
 
 /**
  * POST /api/auth/forgot-password/verify
@@ -50,7 +65,11 @@ export async function POST(req: Request) {
     req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
     "anonymous";
 
-  const rl = limiter.check(ip);
+  // #149: Kotayı **peek** ile yokla, tüketme. Meşru akış üç istek sürüyor
+  // (e-posta → cevaplar → yeni şifre); her istekte saymak kullanıcının kendi
+  // sıfırlamasını yarıda kilitliyordu. Kota yalnızca başarısız denemelerde ve
+  // hesap yoklamaya açık 1. adımda tüketilir.
+  const rl = limiter.peek(ip);
   if (!rl.allowed) {
     return NextResponse.json(
       { error: "Çok fazla deneme yaptınız. Lütfen 5 dakika bekleyin." },
@@ -68,6 +87,8 @@ export async function POST(req: Request) {
     };
 
     if (!email || typeof email !== "string") {
+      // Bozuk istek de kota tüketsin — aksi halde sınırsız zorlanabilir.
+      limiter.check(ip);
       return NextResponse.json(
         { error: "Geçerli bir email adresi girin." },
         { status: 400 }
@@ -76,7 +97,14 @@ export async function POST(req: Request) {
 
     // Hesap bazlı rate limiting (IP spoofing'e karşı ek koruma)
     const normalizedEmail = email.toLowerCase().trim();
-    const accountRl = accountLimiter.check(normalizedEmail);
+
+    /** Bir denemeyi iki limitte de say (başarısızlık / hesap yoklama). */
+    const consumeAttempt = () => {
+      limiter.check(ip);
+      accountLimiter.check(normalizedEmail);
+    };
+
+    const accountRl = accountLimiter.peek(normalizedEmail);
     if (!accountRl.allowed) {
       return NextResponse.json(
         { error: "Bu hesap için çok fazla deneme yapıldı. Lütfen 1 saat bekleyin." },
@@ -93,13 +121,26 @@ export async function POST(req: Request) {
 
     // Kullanıcı bulunamasa bile aynı mesajı ver (enumeration önleme)
     if (!user || user.securityAnswers.length < REQUIRED_ANSWERS) {
-      // Soruları gösterirken rastgele sorular göster (enumeration önleme)
       if (!answers) {
+        // #149: Sahte sorular e-postadan **türetilir**, rastgele seçilmez.
+        // Rastgele seçimde aynı e-posta iki kez sorulduğunda kayıtlı hesap hep
+        // aynı üçlüyü, kayıtsız hesap her seferinde farklı üçlüyü döndürüyordu;
+        // bu tek başına hesabın var olup olmadığını ele veriyordu.
+        consumeAttempt();
         return NextResponse.json({
           step: "questions",
-          questions: getRandomQuestions(),
+          questions: getDecoyQuestions(normalizedEmail),
         });
       }
+
+      // #149: Hesap yokken de argon2 çalıştır — "hesap yok" yanıtı gerçek
+      // doğrulamadan belirgin şekilde hızlı dönmesin.
+      const dummy = await getDummyHash();
+      for (let i = 0; i < REQUIRED_ANSWERS; i++) {
+        await verify(dummy, "gecersiz-cevap").catch(() => false);
+      }
+
+      consumeAttempt();
       return NextResponse.json(
         { error: "Güvenlik sorusu cevapları yanlış." },
         { status: 400 }
@@ -108,6 +149,7 @@ export async function POST(req: Request) {
 
     // ADIM 1: Sadece email geldi → Soruları döndür
     if (!answers) {
+      consumeAttempt();
       const questionIds = user.securityAnswers.map((a) => a.questionId);
       const questions = questionIds.map((qId) => ({
         questionId: qId,
@@ -122,14 +164,21 @@ export async function POST(req: Request) {
 
     // ADIM 2: Cevaplar geldi → Doğrula
     if (!Array.isArray(answers) || answers.length < REQUIRED_ANSWERS) {
+      consumeAttempt();
       return NextResponse.json(
         { error: "Tüm güvenlik sorularını cevaplayın." },
         { status: 400 }
       );
     }
 
-    let correctCount = 0;
+    // #149: Doğru cevaplar **soru bazında tekilleştirilerek** sayılır.
+    // Önceden her dizi elemanı ayrı sayıldığı için aynı doğru cevabı üç kez
+    // göndermek doğrulamayı geçiyordu — yani üç cevaptan birini bilen biri
+    // şifreyi sıfırlayabiliyordu.
+    const correctQuestionIds = new Set<number>();
     for (const ans of answers) {
+      if (correctQuestionIds.has(ans.questionId)) continue;
+
       const stored = user.securityAnswers.find(
         (sa) => sa.questionId === ans.questionId
       );
@@ -138,22 +187,25 @@ export async function POST(req: Request) {
           stored.answer,
           ans.answer.trim().toLowerCase()
         );
-        if (isCorrect) correctCount++;
+        if (isCorrect) correctQuestionIds.add(ans.questionId);
       }
     }
 
-    if (correctCount < REQUIRED_ANSWERS) {
+    if (correctQuestionIds.size < REQUIRED_ANSWERS) {
+      consumeAttempt();
       return NextResponse.json(
         { error: "Güvenlik sorusu cevapları yanlış. Lütfen tekrar deneyin." },
         { status: 400 }
       );
     }
 
-    // ADIM 3: Token + yeni şifre → doğrula ve şifreyi güncelle
-    // NOT: Artık answers tekrar doğrulanmıyor — resetToken yeterli kanıt
+    // ADIM 3: Token + yeni şifre → doğrula ve şifreyi güncelle.
+    // Buraya ulaşmak için cevaplar yukarıda **yeniden** doğrulandı; resetToken
+    // buna ek bir kanıt (step2'yi atlayıp doğrudan step3'e gidilemesin diye).
     if (newPassword) {
       // Token olmadan step 3'e geçiş engellenir
       if (!resetToken) {
+        consumeAttempt();
         return NextResponse.json(
           { error: "Geçersiz istek. Lütfen sıfırlama işlemini baştan başlatın." },
           { status: 400 }
@@ -162,6 +214,7 @@ export async function POST(req: Request) {
       const tokenData = resetTokens.get(resetToken);
       if (!tokenData || Date.now() > tokenData.expiresAt || tokenData.userId !== user.id) {
         resetTokens.delete(resetToken);
+        consumeAttempt();
         return NextResponse.json(
           { error: "Doğrulama süresi doldu veya geçersiz. Lütfen tekrar deneyin." },
           { status: 400 }
@@ -213,6 +266,11 @@ export async function POST(req: Request) {
         data: { password: hashedPassword },
       });
 
+      // #149: Sıfırlama başarıyla bittiğine göre bu kimlikler şüpheli değil;
+      // kullanıcı hemen ardından tekrar giriş akışına girerse kilitlenmesin.
+      limiter.reset(ip);
+      accountLimiter.reset(normalizedEmail);
+
       return NextResponse.json({
         step: "success",
         message: "Şifreniz başarıyla değiştirildi. Giriş yapabilirsiniz.",
@@ -241,14 +299,28 @@ export async function POST(req: Request) {
 }
 
 /**
- * Enumeration önleme: Kullanıcı bulunamadığında rastgele sorular göster
+ * Enumeration önleme: kullanıcı bulunamadığında da soru döndürülür, ama sorular
+ * e-postadan **deterministik** olarak türetilir (#149).
+ *
+ * Rastgele seçimde aynı e-posta için ikinci istek farklı sorular getiriyordu;
+ * kayıtlı hesap ise her zaman aynı üçlüyü döndürdüğü için iki istek atmak
+ * hesabın varlığını ele veriyordu. Tohum gizli anahtarla HMAC'lenir ki
+ * saldırgan "bu üçlü sahte mi" diye çevrimdışı hesaplayamasın.
  */
-function getRandomQuestions() {
+function getDecoyQuestions(email: string) {
+  const secret = process.env.NEXTAUTH_SECRET ?? "aisigner-decoy-fallback";
+  const seed = crypto.createHmac("sha256", secret).update(email).digest();
+
   const indices: number[] = [];
-  while (indices.length < REQUIRED_ANSWERS) {
-    const idx = Math.floor(Math.random() * SECURITY_QUESTIONS.length);
+  for (let i = 0; i < seed.length && indices.length < REQUIRED_ANSWERS; i++) {
+    const idx = seed[i] % SECURITY_QUESTIONS.length;
     if (!indices.includes(idx)) indices.push(idx);
   }
+  // Teorik olarak tohum yetmezse sırayla tamamla (uzunluk garantisi).
+  for (let q = 0; indices.length < REQUIRED_ANSWERS; q++) {
+    if (!indices.includes(q)) indices.push(q);
+  }
+
   return indices.map((qId) => ({
     questionId: qId,
     question: SECURITY_QUESTIONS[qId],


### PR DESCRIPTION
## Özet

`/api/auth/forgot-password/verify` akışının hiç testi yoktu. İncelemede üç sorun çıktı; üçü de düzeltildi ve **önce başarısız olan** regresyon testleriyle sabitlendi.

---

## 1) Tek cevabı bilen saldırgan doğrulamayı geçebiliyordu (kritik)

Doğru cevaplar döngüde sayılıyor ama soru bazında tekilleştirilmiyordu:

```ts
for (const ans of answers) { ...; if (isCorrect) correctCount++; }
```

`answers.length >= 3` kontrolünü geçmek için **aynı cevabı üç kez** göndermek yetiyordu:

```json
[{"questionId":0,"answer":"tekir"},{"questionId":0,"answer":"tekir"},{"questionId":0,"answer":"tekir"}]
```

`correctCount = 3` olup doğrulama geçiyordu — yani üç güvenlik cevabından **birini** bilen biri hesabın şifresini sıfırlayabiliyordu.

**Düzeltme:** doğru cevaplar `Set<number>` içinde `questionId` bazında toplanıyor; aynı soru ikinci kez sayılmıyor.

## 2) Hesap ifşası (enumeration)

Kayıtsız hesap için sahte sorular **her istekte rastgele** üretiliyordu. Aynı e-posta ile iki istek atıldığında:

| | 1. istek | 2. istek |
|---|---|---|
| kayıtlı hesap | A, B, C | A, B, C (aynı) |
| kayıtsız hesap | D, F, I | B, E, J (farklı) |

İki istekle hesabın varlığı kesin öğreniliyordu. Ayrıca kullanıcı yokken argon2 hiç çalışmadığı için **yanıt süresi** de ayrı bir ipucuydu.

**Düzeltme:** sahte sorular e-postadan `HMAC-SHA256(NEXTAUTH_SECRET, email)` ile deterministik türetiliyor — tekrar eden istekler aynı üçlüyü döndürüyor, ama saldırgan üçlünün sahte olup olmadığını çevrimdışı hesaplayamıyor. Hesap yokken de `REQUIRED_ANSWERS` kadar dummy argon2 doğrulaması çalışıyor (`nextauth.ts`'deki mevcut desen).

## 3) Meşru kullanıcı kendi akışında kilitleniyordu

Kota her istekte tüketiliyordu, meşru akış ise üç istek sürüyor. E-posta(1) + üç yanlış deneme(2,3,4) + doğru cevap(5) + yeni şifre(6) → kullanıcı **kendi sıfırlamasının son adımında** 429 alıyordu.

**Düzeltme:** kota `peek` ile yoklanıyor, yalnızca **başarısız denemelerde** ve hesap yoklamaya açık 1. adımda tüketiliyor; başarılı sıfırlamada sıfırlanıyor. Saldırgan tarafında koruma **artıyor** (her yanlış tahmin sayılıyor), meşru kullanıcı rahatlıyor.

## Ek temizlik
- `// NOT: Artık answers tekrar doğrulanmıyor` yorumu **yanlıştı** — kod cevapları 3. adımda da doğruluyor. Yorum gerçeğe göre düzeltildi (davranış değişmedi).
- Token temizleme `setInterval`'ine `unref()` eklendi; tek başına prosesi ayakta tutmasın.

---

## Testlerin anlamlı olduğu nasıl doğrulandı?

20 yeni test yazıldı. **Düzeltmeyi geri alıp** aynı testler çalıştırıldı — dördü düştü:

```
× aynı doğru cevap 3 kez gönderilirse doğrulama BAŞARISIZ olur
× kayıtsız hesap için sorular tekrarlanabilir — iki istek AYNI üçlüyü döndürür
× kayıtsız hesapta da argon2 doğrulaması çalışır (sabit zaman)
× birkaç kez yanlış hatırlayıp sonunda bilen kullanıcı kilitlenmez
Tests  4 failed | 16 passed (20)
```

Düzeltmeyle **20/20 geçiyor**. Yani testler gerçekten bu üç sorunu yakalıyor, sadece mevcut davranışı fotoğraflamıyor.

Kapsam: cevap tekilleştirme, enumeration, resetToken zorunluluğu ve tek kullanımlıklığı, şifre politikası (5 ayrı kural), rate limit.

## Doğrulama
- `npm test` → **181/181** ✓ (20'si yeni)
- `npm run lint` → 0 hata (9 uyarı, hepsi önceden var)
- `npm run build` → ✓

## Not
Bu PR yalnızca `verify/route.ts` + yeni test dosyasına dokunuyor — açık PR'ların hiçbiriyle çakışmıyor. İstemci sözleşmesi korundu (`forgot-password/page.tsx` değişmedi).

Closes #149
Refs #126