### PR TITLE
fix: sifre sifirlama ekraninda odak yonetimi ve tekrar eden kod

### DIFF
--- a/src/app/(auth)/forgot-password/page.test.tsx
+++ b/src/app/(auth)/forgot-password/page.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import ForgotPasswordPage from "./page";
+
+/** fetch yanıtı taklidi. */
+function jsonResponse(body: unknown, ok = true) {
+  return { ok, json: async () => body } as Response;
+}
+
+const fetchMock = vi.fn();
+vi.stubGlobal("fetch", fetchMock);
+
+const questions = [
+  { questionId: 0, question: "İlk evcil hayvanınızın adı neydi?" },
+  { questionId: 1, question: "İlk okulunuzun adı neydi?" },
+];
+
+/** 1. adımı geçip soru ekranına ulaş. */
+async function reachQuestions() {
+  fetchMock.mockResolvedValueOnce(jsonResponse({ step: "questions", questions }));
+
+  fireEvent.change(screen.getByLabelText("E-posta Adresi"), {
+    target: { value: "user@test.com" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Devam Et" }));
+
+  await screen.findByText("Güvenlik Soruları");
+}
+
+/** 2. adımı geçip yeni şifre ekranına ulaş. */
+async function reachNewPassword() {
+  await reachQuestions();
+
+  fetchMock.mockResolvedValueOnce(
+    jsonResponse({ step: "verified", resetToken: "t".repeat(64) }),
+  );
+
+  questions.forEach((q, i) => {
+    fireEvent.change(screen.getByLabelText(`${i + 1}. ${q.question}`), {
+      target: { value: "cevap" },
+    });
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Cevapları Doğrula" }));
+
+  await screen.findByText("Yeni Şifre Belirle");
+}
+
+describe("Şifre sıfırlama akışı (#156)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    render(<ForgotPasswordPage />);
+  });
+
+  it("e-posta gönderilince sorular ekranına geçilir", async () => {
+    await reachQuestions();
+
+    expect(screen.getByLabelText(/İlk evcil hayvanınızın adı/)).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/auth/forgot-password/verify",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("e-posta küçük harfe çevrilerek gönderilir", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ step: "questions", questions }));
+
+    fireEvent.change(screen.getByLabelText("E-posta Adresi"), {
+      target: { value: "  USER@Test.COM  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Devam Et" }));
+
+    await screen.findByText("Güvenlik Soruları");
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.email).toBe("user@test.com");
+  });
+
+  it("adım değişince odak başlığa taşınır", async () => {
+    await reachQuestions();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { level: 1 })).toHaveFocus();
+    });
+  });
+
+  it("ilk açılışta odak çalınmaz", () => {
+    expect(screen.getByRole("heading", { level: 1 })).not.toHaveFocus();
+  });
+
+  it("adım göstergesi ekran okuyucuya hangi adımda olunduğunu söyler", async () => {
+    expect(screen.getByText("3 adımdan 1. adımdasınız.")).toBeInTheDocument();
+
+    await reachQuestions();
+    expect(screen.getByText("3 adımdan 2. adımdasınız.")).toBeInTheDocument();
+  });
+
+  it("sunucu hatası role='alert' ile duyurulur", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ error: "Çok fazla deneme yaptınız." }, false),
+    );
+
+    fireEvent.change(screen.getByLabelText("E-posta Adresi"), {
+      target: { value: "user@test.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Devam Et" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Çok fazla deneme yaptınız.");
+  });
+
+  it("ağ hatası kullanıcıya bildirilir", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("network"));
+
+    fireEvent.change(screen.getByLabelText("E-posta Adresi"), {
+      target: { value: "user@test.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Devam Et" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Bağlantı hatası");
+  });
+
+  it("'Geri dön' e-posta adımına döndürür", async () => {
+    await reachQuestions();
+
+    fireEvent.click(screen.getByRole("button", { name: /Geri dön/ }));
+
+    expect(await screen.findByText("Şifremi Unuttum")).toBeInTheDocument();
+  });
+
+  it("cevaplar doğrulanınca yeni şifre adımına geçilir", async () => {
+    await reachNewPassword();
+
+    expect(screen.getByLabelText("Yeni Şifre")).toBeInTheDocument();
+    expect(screen.getByLabelText("Şifreyi Tekrar Gir")).toBeInTheDocument();
+  });
+
+  it("şifreler eşleşmezse uyarı alan hatası olarak bağlanır", async () => {
+    await reachNewPassword();
+
+    fireEvent.change(screen.getByLabelText("Yeni Şifre"), {
+      target: { value: "GucluSifre1!" },
+    });
+    fireEvent.change(screen.getByLabelText("Şifreyi Tekrar Gir"), {
+      target: { value: "BaskaSifre1!" },
+    });
+
+    const confirm = screen.getByLabelText("Şifreyi Tekrar Gir");
+    const warning = screen.getByText("Şifreler eşleşmiyor");
+
+    expect(confirm).toHaveAttribute("aria-invalid", "true");
+    expect(confirm.getAttribute("aria-describedby")).toBe(warning.id);
+  });
+
+  it("şifre kuralları ilerlemesi ekran okuyucuya özetlenir", async () => {
+    await reachNewPassword();
+
+    fireEvent.change(screen.getByLabelText("Yeni Şifre"), {
+      target: { value: "abc" },
+    });
+    expect(screen.getByText(/kurallarından 1 \/ 5/)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Yeni Şifre"), {
+      target: { value: "GucluSifre1!" },
+    });
+    expect(screen.getByText(/kurallarından 5 \/ 5/)).toBeInTheDocument();
+  });
+
+  it("3. adımda resetToken sunucuya gönderilir", async () => {
+    await reachNewPassword();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ step: "success" }));
+
+    fireEvent.change(screen.getByLabelText("Yeni Şifre"), {
+      target: { value: "GucluSifre1!" },
+    });
+    fireEvent.change(screen.getByLabelText("Şifreyi Tekrar Gir"), {
+      target: { value: "GucluSifre1!" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Şifreyi Değiştir" }));
+
+    await screen.findByText("Şifre Değiştirildi");
+    const body = JSON.parse(fetchMock.mock.calls[2][1].body);
+    expect(body.resetToken).toBe("t".repeat(64));
+    expect(body.newPassword).toBe("GucluSifre1!");
+    // Sunucu 3. adımda cevapları yeniden doğruluyor — sözleşme korunmalı
+    expect(body.answers).toHaveLength(2);
+  });
+
+  it("başarı ekranında adım göstergesi gizlenir", async () => {
+    await reachNewPassword();
+    fetchMock.mockResolvedValueOnce(jsonResponse({ step: "success" }));
+
+    fireEvent.change(screen.getByLabelText("Yeni Şifre"), {
+      target: { value: "GucluSifre1!" },
+    });
+    fireEvent.change(screen.getByLabelText("Şifreyi Tekrar Gir"), {
+      target: { value: "GucluSifre1!" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Şifreyi Değiştir" }));
+
+    await screen.findByText("Şifre Değiştirildi");
+    expect(screen.queryByText(/adımdasınız/)).not.toBeInTheDocument();
+  });
+});

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,62 +1,117 @@
 "use client";
 
-import { useState } from "react";
-import { KeyRound, ArrowLeft, ShieldCheck, Eye, EyeOff, CheckCircle2, Loader2 } from "lucide-react";
-import Link from "next/link";
-
-type Question = {
-  questionId: number;
-  question: string;
-};
+import { useEffect, useRef, useState } from "react";
+import { KeyRound, ShieldCheck, CheckCircle2 } from "lucide-react";
+import { AuthCard } from "@/features/auth/ui/AuthCard";
+import { FormAlert } from "@/features/auth/ui/FormAlert";
+import { StepIndicator } from "@/features/auth/ui/StepIndicator";
+import {
+  EmailStep,
+  QuestionsStep,
+  NewPasswordStep,
+  SuccessStep,
+  type Question,
+} from "@/features/auth/ui/forgot-password/steps";
 
 type Step = "email" | "questions" | "newPassword" | "success";
 
-const passwordRules = [
-  { test: (p: string) => p.length >= 8, label: "En az 8 karakter" },
-  { test: (p: string) => /[A-Z]/.test(p), label: "En az bir büyük harf" },
-  { test: (p: string) => /[a-z]/.test(p), label: "En az bir küçük harf" },
-  { test: (p: string) => /[0-9]/.test(p), label: "En az bir rakam" },
-  { test: (p: string) => /[^A-Za-z0-9]/.test(p), label: "En az bir özel karakter" },
-];
+const VERIFY_URL = "/api/auth/forgot-password/verify";
+
+/** Adım başına başlık/ikon — render içinde dağılmasın diye tek yerde. */
+const stepMeta: Record<Step, { icon: typeof KeyRound; title: string; subtitle: string }> = {
+  email: {
+    icon: KeyRound,
+    title: "Şifremi Unuttum",
+    subtitle: "Kayıtlı e-posta adresini gir",
+  },
+  questions: {
+    icon: ShieldCheck,
+    title: "Güvenlik Soruları",
+    subtitle: "Kimliğini doğrulamak için soruları cevapla",
+  },
+  newPassword: {
+    icon: KeyRound,
+    title: "Yeni Şifre Belirle",
+    subtitle: "Yeni şifreni belirle",
+  },
+  success: {
+    icon: CheckCircle2,
+    title: "Şifre Değiştirildi",
+    subtitle: "Artık yeni şifrenle giriş yapabilirsin",
+  },
+};
+
+const stepNumber: Record<Step, number> = {
+  email: 1,
+  questions: 2,
+  newPassword: 3,
+  success: 3,
+};
 
 export default function ForgotPasswordPage() {
   const [step, setStep] = useState<Step>("email");
   const [email, setEmail] = useState("");
   const [questions, setQuestions] = useState<Question[]>([]);
   const [answers, setAnswers] = useState<Record<number, string>>({});
-  const [resetToken, setResetToken] = useState<string>("");
+  const [resetToken, setResetToken] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
-  // ADIM 1: Email gönder → Güvenlik sorularını al
+  // #156: Adım değişince odağı başlığa taşı. Önceden basılan düğme DOM'dan
+  // silindiği için odak <body>'ye düşüyordu: klavyeyle gezen kullanıcı yeni
+  // alanlara ulaşmak için baştan tab'lamak zorunda kalıyor, ekran okuyucu
+  // kullanan ise sayfanın değiştiğini hiç fark etmiyordu.
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      // İlk açılışta odağı çalmayalım — kullanıcı henüz bir şey yapmadı.
+      isFirstRender.current = false;
+      return;
+    }
+    titleRef.current?.focus();
+  }, [step]);
+
+  /** Üç adım da aynı uca POST atıyor; ortak sarmalayıcı. */
+  async function postVerify(body: Record<string, unknown>) {
+    const res = await fetch(VERIFY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: email.toLowerCase().trim(), ...body }),
+    });
+    return { res, data: await res.json().catch(() => null) };
+  }
+
+  /** Sunucunun beklediği cevap dizisi — 2. ve 3. adımda aynı şekilde gidiyor. */
+  function answerPayload() {
+    return questions.map((q) => ({
+      questionId: q.questionId,
+      answer: answers[q.questionId] || "",
+    }));
+  }
+
   async function handleEmailSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
     setLoading(true);
 
     try {
-      const res = await fetch("/api/auth/forgot-password/verify", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: email.toLowerCase().trim() }),
-      });
-
-      const data = await res.json();
+      const { res, data } = await postVerify({});
       if (!res.ok) {
-        setError(data.error || "Bir hata oluştu.");
+        setError(data?.error || "Bir hata oluştu.");
         return;
       }
 
-      if (data.step === "questions" && data.questions) {
+      if (data?.step === "questions" && data.questions) {
         setQuestions(data.questions);
-        const emptyAnswers: Record<number, string> = {};
+        const empty: Record<number, string> = {};
         data.questions.forEach((q: Question) => {
-          emptyAnswers[q.questionId] = "";
+          empty[q.questionId] = "";
         });
-        setAnswers(emptyAnswers);
+        setAnswers(empty);
         setStep("questions");
       }
     } catch {
@@ -66,31 +121,19 @@ export default function ForgotPasswordPage() {
     }
   }
 
-  // ADIM 2: Güvenlik sorularını doğrula → resetToken al
   async function handleAnswersSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
     setLoading(true);
 
-    const answerPayload = questions.map((q) => ({
-      questionId: q.questionId,
-      answer: answers[q.questionId] || "",
-    }));
-
     try {
-      const res = await fetch("/api/auth/forgot-password/verify", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email: email.toLowerCase().trim(), answers: answerPayload }),
-      });
-
-      const data = await res.json();
+      const { res, data } = await postVerify({ answers: answerPayload() });
       if (!res.ok) {
-        setError(data.error || "Cevaplar yanlış.");
+        setError(data?.error || "Cevaplar yanlış.");
         return;
       }
 
-      if (data.step === "verified" && data.resetToken) {
+      if (data?.step === "verified" && data.resetToken) {
         setResetToken(data.resetToken);
         setStep("newPassword");
       } else {
@@ -103,7 +146,6 @@ export default function ForgotPasswordPage() {
     }
   }
 
-  // ADIM 3: Yeni şifre belirle (resetToken ile)
   async function handlePasswordSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
@@ -112,7 +154,6 @@ export default function ForgotPasswordPage() {
       setError("Şifreler eşleşmiyor.");
       return;
     }
-
     if (!resetToken) {
       setError("Doğrulama tokenı eksik. Sıfırlamayı baştan başlat.");
       return;
@@ -121,29 +162,18 @@ export default function ForgotPasswordPage() {
     setLoading(true);
 
     try {
-      const res = await fetch("/api/auth/forgot-password/verify", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          email: email.toLowerCase().trim(),
-          // Backend step3'te answers'ı yine bekliyor (kontrolden geçmesi için),
-          // ama asıl yetki resetToken ile veriliyor.
-          answers: questions.map((q) => ({
-            questionId: q.questionId,
-            answer: answers[q.questionId] || "",
-          })),
-          resetToken,
-          newPassword,
-        }),
+      // Sunucu 3. adımda cevapları yeniden doğruluyor; resetToken ek kanıt.
+      const { res, data } = await postVerify({
+        answers: answerPayload(),
+        resetToken,
+        newPassword,
       });
 
-      const data = await res.json();
       if (!res.ok) {
-        setError(data.error || "Şifre değiştirilemedi.");
+        setError(data?.error || "Şifre değiştirilemedi.");
         return;
       }
-
-      if (data.step === "success") {
+      if (data?.step === "success") {
         setStep("success");
       }
     } catch {
@@ -153,259 +183,60 @@ export default function ForgotPasswordPage() {
     }
   }
 
-  // Adım göstergesi (1-2-3)
-  const stepNumber =
-    step === "email" ? 1 : step === "questions" ? 2 : step === "newPassword" ? 3 : 3;
+  const meta = stepMeta[step];
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 px-4 py-12">
-      <div className="w-full max-w-md">
-        <div className="bg-white rounded-3xl shadow-2xl ring-1 ring-slate-200/60 overflow-hidden">
-          {/* Üst şerit */}
-          <div className="h-1.5 bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500" />
+    <AuthCard
+      icon={meta.icon}
+      title={meta.title}
+      subtitle={meta.subtitle}
+      titleRef={titleRef}
+    >
+      {step !== "success" && <StepIndicator current={stepNumber[step]} total={3} />}
 
-          <div className="p-8 sm:p-10">
-            {/* Başlık */}
-            <div className="mb-6 text-center">
-              <div className="mx-auto mb-4 h-14 w-14 rounded-2xl bg-gradient-to-br from-blue-600 to-indigo-600 flex items-center justify-center shadow-lg shadow-blue-200">
-                {step === "success" ? (
-                  <CheckCircle2 className="w-6 h-6 text-white" />
-                ) : step === "questions" ? (
-                  <ShieldCheck className="w-6 h-6 text-white" />
-                ) : (
-                  <KeyRound className="w-6 h-6 text-white" />
-                )}
-              </div>
-              <h1 className="text-2xl font-bold text-slate-900">
-                {step === "email" && "Şifremi Unuttum"}
-                {step === "questions" && "Güvenlik Soruları"}
-                {step === "newPassword" && "Yeni Şifre Belirle"}
-                {step === "success" && "Şifre Değiştirildi"}
-              </h1>
-              <p className="mt-1.5 text-sm text-slate-500">
-                {step === "email" && "Kayıtlı e-posta adresini gir"}
-                {step === "questions" && "Kimliğini doğrulamak için soruları cevapla"}
-                {step === "newPassword" && "Yeni şifreni belirle"}
-                {step === "success" && "Artık yeni şifrenle giriş yapabilirsin"}
-              </p>
-            </div>
-
-            {/* Adım göstergesi */}
-            {step !== "success" && (
-              <div className="flex items-center justify-center gap-2 mb-6">
-                {[1, 2, 3].map((n) => (
-                  <div
-                    key={n}
-                    className={`h-1.5 rounded-full transition-all ${
-                      n <= stepNumber
-                        ? "w-10 bg-gradient-to-r from-blue-500 to-indigo-500"
-                        : "w-6 bg-slate-200"
-                    }`}
-                  />
-                ))}
-              </div>
-            )}
-
-            {/* Hata mesajı */}
-            {error && (
-              <div className="mb-4 rounded-xl bg-red-50 border border-red-100 px-4 py-3 text-sm text-red-600">
-                {error}
-              </div>
-            )}
-
-            {/* ADIM 1: Email */}
-            {step === "email" && (
-              <form onSubmit={handleEmailSubmit} className="space-y-5">
-                <div>
-                  <label htmlFor="fp-email" className="mb-1.5 block text-sm font-medium text-slate-700">
-                    E-posta Adresi
-                  </label>
-                  <input
-                    id="fp-email"
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-slate-800 text-sm shadow-sm focus:border-blue-500 focus:bg-white focus:ring-3 focus:ring-blue-100 outline-none transition"
-                    placeholder="ornek@email.com"
-                    required
-                    autoComplete="email"
-                  />
-                </div>
-
-                <button
-                  type="submit"
-                  disabled={loading}
-                  className="w-full rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 px-4 py-3 font-semibold text-white shadow-md shadow-blue-200 transition-all focus:outline-none focus:ring-3 focus:ring-blue-300 disabled:opacity-60 flex items-center justify-center gap-2"
-                >
-                  {loading && <Loader2 className="w-4 h-4 animate-spin" />}
-                  {loading ? "Kontrol Ediliyor..." : "Devam Et"}
-                </button>
-
-                <div className="text-center">
-                  <Link
-                    href="/signin"
-                    className="inline-flex items-center text-sm text-slate-500 hover:text-slate-700 transition-colors"
-                  >
-                    <ArrowLeft className="w-4 h-4 mr-1" />
-                    Giriş sayfasına dön
-                  </Link>
-                </div>
-              </form>
-            )}
-
-            {/* ADIM 2: Güvenlik Soruları */}
-            {step === "questions" && (
-              <form onSubmit={handleAnswersSubmit} className="space-y-5">
-                {questions.map((q, index) => (
-                  <div key={q.questionId}>
-                    <label htmlFor={`fp-q-${q.questionId}`} className="mb-1.5 block text-sm font-medium text-slate-700">
-                      {index + 1}. {q.question}
-                    </label>
-                    <input
-                      id={`fp-q-${q.questionId}`}
-                      type="text"
-                      value={answers[q.questionId] || ""}
-                      onChange={(e) =>
-                        setAnswers((prev) => ({
-                          ...prev,
-                          [q.questionId]: e.target.value,
-                        }))
-                      }
-                      className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-slate-800 text-sm shadow-sm focus:border-blue-500 focus:bg-white focus:ring-3 focus:ring-blue-100 outline-none transition"
-                      placeholder="Cevabın..."
-                      required
-                    />
-                  </div>
-                ))}
-
-                <button
-                  type="submit"
-                  disabled={loading}
-                  className="w-full rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 px-4 py-3 font-semibold text-white shadow-md shadow-blue-200 transition-all focus:outline-none focus:ring-3 focus:ring-blue-300 disabled:opacity-60 flex items-center justify-center gap-2"
-                >
-                  {loading && <Loader2 className="w-4 h-4 animate-spin" />}
-                  {loading ? "Doğrulanıyor..." : "Cevapları Doğrula"}
-                </button>
-
-                <div className="text-center">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setStep("email");
-                      setError("");
-                    }}
-                    className="inline-flex items-center text-sm text-slate-500 hover:text-slate-700 transition-colors"
-                  >
-                    <ArrowLeft className="w-4 h-4 mr-1" />
-                    Geri dön
-                  </button>
-                </div>
-              </form>
-            )}
-
-            {/* ADIM 3: Yeni Şifre */}
-            {step === "newPassword" && (
-              <form onSubmit={handlePasswordSubmit} className="space-y-5">
-                <div>
-                  <label htmlFor="fp-new-password" className="mb-1.5 block text-sm font-medium text-slate-700">
-                    Yeni Şifre
-                  </label>
-                  <div className="relative">
-                    <input
-                      id="fp-new-password"
-                      type={showPassword ? "text" : "password"}
-                      value={newPassword}
-                      onChange={(e) => setNewPassword(e.target.value)}
-                      className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 pr-11 text-slate-800 text-sm shadow-sm focus:border-blue-500 focus:bg-white focus:ring-3 focus:ring-blue-100 outline-none transition"
-                      placeholder="En az 8 karakter"
-                      required
-                      minLength={8}
-                      autoComplete="new-password"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setShowPassword(!showPassword)}
-                      aria-label={showPassword ? "Şifreyi gizle" : "Şifreyi göster"}
-                      className="absolute inset-y-0 right-3 flex items-center text-slate-400 hover:text-slate-600 transition-colors"
-                    >
-                      {showPassword ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
-                    </button>
-                  </div>
-
-                  {newPassword.length > 0 && (
-                    <div className="mt-2.5 grid grid-cols-2 gap-x-4 gap-y-1">
-                      {passwordRules.map((rule) => {
-                        const ok = rule.test(newPassword);
-                        return (
-                          <p
-                            key={rule.label}
-                            className={`flex items-center text-[11px] gap-1 ${
-                              ok ? "text-emerald-600" : "text-slate-400"
-                            }`}
-                          >
-                            <CheckCircle2
-                              className={`w-3 h-3 shrink-0 ${
-                                ok ? "text-emerald-500" : "text-slate-300"
-                              }`}
-                            />
-                            {rule.label}
-                          </p>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-
-                <div>
-                  <label htmlFor="fp-confirm-password" className="mb-1.5 block text-sm font-medium text-slate-700">
-                    Şifreyi Tekrar Gir
-                  </label>
-                  <input
-                    id="fp-confirm-password"
-                    type={showPassword ? "text" : "password"}
-                    value={confirmPassword}
-                    onChange={(e) => setConfirmPassword(e.target.value)}
-                    className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-slate-800 text-sm shadow-sm focus:border-blue-500 focus:bg-white focus:ring-3 focus:ring-blue-100 outline-none transition"
-                    placeholder="Şifreni tekrar gir"
-                    required
-                    autoComplete="new-password"
-                  />
-                  {confirmPassword && newPassword !== confirmPassword && (
-                    <p className="mt-1 text-xs text-red-500">Şifreler eşleşmiyor</p>
-                  )}
-                </div>
-
-                <button
-                  type="submit"
-                  disabled={loading || newPassword !== confirmPassword}
-                  className="w-full rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 px-4 py-3 font-semibold text-white shadow-md shadow-blue-200 transition-all focus:outline-none focus:ring-3 focus:ring-blue-300 disabled:opacity-60 flex items-center justify-center gap-2"
-                >
-                  {loading && <Loader2 className="w-4 h-4 animate-spin" />}
-                  {loading ? "Kaydediliyor..." : "Şifreyi Değiştir"}
-                </button>
-              </form>
-            )}
-
-            {/* ADIM 4: Başarılı */}
-            {step === "success" && (
-              <div className="text-center space-y-5">
-                <div className="mx-auto h-16 w-16 rounded-2xl bg-emerald-100 flex items-center justify-center">
-                  <CheckCircle2 className="w-8 h-8 text-emerald-600" />
-                </div>
-                <p className="text-slate-600 text-sm">
-                  Şifren başarıyla güncellendi. Artık yeni şifrenle giriş yapabilirsin.
-                </p>
-                <Link
-                  href="/signin"
-                  className="block w-full rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 px-4 py-3 font-semibold text-white shadow-md shadow-blue-200 transition-all text-center"
-                >
-                  Giriş Yap
-                </Link>
-              </div>
-            )}
-          </div>
+      {error && (
+        <div className="mb-4">
+          <FormAlert variant="error">{error}</FormAlert>
         </div>
-      </div>
-    </div>
+      )}
+
+      {step === "email" && (
+        <EmailStep
+          email={email}
+          onEmailChange={setEmail}
+          onSubmit={handleEmailSubmit}
+          loading={loading}
+        />
+      )}
+
+      {step === "questions" && (
+        <QuestionsStep
+          questions={questions}
+          answers={answers}
+          onAnswerChange={(questionId, value) =>
+            setAnswers((prev) => ({ ...prev, [questionId]: value }))
+          }
+          onSubmit={handleAnswersSubmit}
+          onBack={() => {
+            setStep("email");
+            setError("");
+          }}
+          loading={loading}
+        />
+      )}
+
+      {step === "newPassword" && (
+        <NewPasswordStep
+          newPassword={newPassword}
+          confirmPassword={confirmPassword}
+          onNewPasswordChange={setNewPassword}
+          onConfirmPasswordChange={setConfirmPassword}
+          onSubmit={handlePasswordSubmit}
+          loading={loading}
+        />
+      )}
+
+      {step === "success" && <SuccessStep />}
+    </AuthCard>
   );
 }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -3,28 +3,19 @@
 import { useState } from "react"
 import { useActionState } from "react"
 import { signupAction } from "./actions"
-import { UserPlus, CheckCircle2 } from "lucide-react"
+import { UserPlus } from "lucide-react"
 import Link from "next/link"
 import { AuthCard } from "@/features/auth/ui/AuthCard"
 import { AuthField } from "@/features/auth/ui/AuthField"
 import { FormAlert } from "@/features/auth/ui/FormAlert"
 import { AuthSubmitButton } from "@/features/auth/ui/AuthSubmitButton"
+import { PasswordRules } from "@/features/auth/ui/PasswordRules"
 
 const initialState = { error: {} as Record<string, string[]> }
-
-const passwordRules = [
-  { test: (p: string) => p.length >= 8, label: "En az 8 karakter" },
-  { test: (p: string) => /[A-Z]/.test(p), label: "En az bir büyük harf" },
-  { test: (p: string) => /[a-z]/.test(p), label: "En az bir küçük harf" },
-  { test: (p: string) => /[0-9]/.test(p), label: "En az bir rakam" },
-  { test: (p: string) => /[^A-Za-z0-9]/.test(p), label: "En az bir özel karakter" },
-]
 
 export default function SignupPage() {
   const [state, formAction, isPending] = useActionState(signupAction, initialState)
   const [password, setPassword] = useState("")
-
-  const metCount = passwordRules.filter((r) => r.test(password)).length
 
   return (
     <AuthCard
@@ -103,34 +94,7 @@ export default function SignupPage() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           errors={state.error?.password}
-          belowField={
-            password.length > 0 && (
-              <>
-                {/* #153: Kurallar görsel olarak işaretleniyordu ama ekran okuyucuya
-                    hiç ulaşmıyordu. Sayaç aria-live ile özetleniyor; listenin
-                    kendisi görsel destek olarak kalıyor. */}
-                <p className="sr-only" aria-live="polite">
-                  Şifre kurallarından {metCount} / {passwordRules.length} tanesi sağlandı.
-                </p>
-                <div className="mt-2.5 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1" aria-hidden="true">
-                  {passwordRules.map((rule) => {
-                    const ok = rule.test(password)
-                    return (
-                      <p
-                        key={rule.label}
-                        className={`flex items-center text-[11px] gap-1 ${ok ? "text-emerald-600" : "text-slate-400"}`}
-                      >
-                        <CheckCircle2
-                          className={`w-3 h-3 shrink-0 ${ok ? "text-emerald-500" : "text-slate-300"}`}
-                        />
-                        {rule.label}
-                      </p>
-                    )
-                  })}
-                </div>
-              </>
-            )
-          }
+          belowField={<PasswordRules password={password} />}
         />
 
         {state.error?.general && (

--- a/src/features/auth/password-rules.ts
+++ b/src/features/auth/password-rules.ts
@@ -1,0 +1,20 @@
+/**
+ * #156: Şifre politikası kuralları — kayıt ve şifre sıfırlama ekranları
+ * aynı listeyi ayrı ayrı tanımlıyordu. Sunucudaki politika değişirse tek
+ * yerden güncellenebilsin diye ortaklaştırıldı.
+ *
+ * Sunucu tarafı karşılığı: `api/auth/forgot-password/verify/route.ts` ve
+ * `lib/validations/api.ts` içindeki signup şeması.
+ */
+export const passwordRules = [
+  { test: (p: string) => p.length >= 8, label: "En az 8 karakter" },
+  { test: (p: string) => /[A-Z]/.test(p), label: "En az bir büyük harf" },
+  { test: (p: string) => /[a-z]/.test(p), label: "En az bir küçük harf" },
+  { test: (p: string) => /[0-9]/.test(p), label: "En az bir rakam" },
+  { test: (p: string) => /[^A-Za-z0-9]/.test(p), label: "En az bir özel karakter" },
+] as const;
+
+/** Sağlanan kural sayısı — ilerleme özetini seslendirmek için. */
+export function countMetRules(password: string): number {
+  return passwordRules.filter((r) => r.test(password)).length;
+}

--- a/src/features/auth/ui/AuthCard.tsx
+++ b/src/features/auth/ui/AuthCard.tsx
@@ -1,5 +1,5 @@
 import type { LucideIcon } from "lucide-react";
-import type { ReactNode } from "react";
+import type { ReactNode, Ref } from "react";
 
 /**
  * #153: Giriş/kayıt/şifre sıfırlama ekranlarının ortak kart kabuğu.
@@ -15,6 +15,7 @@ export function AuthCard({
   width = "md",
   children,
   footer,
+  titleRef,
 }: {
   icon: LucideIcon;
   title: string;
@@ -23,6 +24,11 @@ export function AuthCard({
   width?: "md" | "lg";
   children: ReactNode;
   footer?: ReactNode;
+  /**
+   * #156: Çok adımlı akışlarda adım değişince odağın başlığa taşınabilmesi için.
+   * Odaklanabilir olması gerektiğinden başlık `tabIndex={-1}` alır.
+   */
+  titleRef?: Ref<HTMLHeadingElement>;
 }) {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-50 via-blue-50 to-indigo-100 px-4 py-12">
@@ -35,7 +41,13 @@ export function AuthCard({
               <div className="mx-auto mb-4 h-14 w-14 rounded-2xl bg-gradient-to-br from-blue-600 to-indigo-600 flex items-center justify-center shadow-lg shadow-blue-200">
                 <Icon className="w-6 h-6 text-white" aria-hidden="true" />
               </div>
-              <h1 className="text-2xl font-bold text-slate-900">{title}</h1>
+              <h1
+                ref={titleRef}
+                tabIndex={titleRef ? -1 : undefined}
+                className="text-2xl font-bold text-slate-900 outline-none"
+              >
+                {title}
+              </h1>
               {subtitle && <p className="mt-1.5 text-sm text-slate-500">{subtitle}</p>}
             </div>
 

--- a/src/features/auth/ui/PasswordRules.tsx
+++ b/src/features/auth/ui/PasswordRules.tsx
@@ -1,0 +1,45 @@
+import { CheckCircle2 } from "lucide-react";
+import { passwordRules, countMetRules } from "@/features/auth/password-rules";
+
+/**
+ * #156: Şifre kuralları göstergesi (kayıt + şifre sıfırlama ortak).
+ *
+ * Liste görsel bir yardımcı; renk/ikon değişimi ekran okuyucuya bir şey
+ * anlatmadığı için `aria-hidden`. Onun yerine sağlanan kural sayısı
+ * `aria-live` ile özetlenir — kullanıcı yazdıkça ilerlemeyi duyar.
+ */
+export function PasswordRules({ password }: { password: string }) {
+  if (password.length === 0) return null;
+
+  const met = countMetRules(password);
+
+  return (
+    <>
+      <p className="sr-only" aria-live="polite">
+        Şifre kurallarından {met} / {passwordRules.length} tanesi sağlandı.
+      </p>
+
+      <div
+        className="mt-2.5 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1"
+        aria-hidden="true"
+      >
+        {passwordRules.map((rule) => {
+          const ok = rule.test(password);
+          return (
+            <p
+              key={rule.label}
+              className={`flex items-center text-[11px] gap-1 ${
+                ok ? "text-emerald-600" : "text-slate-400"
+              }`}
+            >
+              <CheckCircle2
+                className={`w-3 h-3 shrink-0 ${ok ? "text-emerald-500" : "text-slate-300"}`}
+              />
+              {rule.label}
+            </p>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/src/features/auth/ui/StepIndicator.tsx
+++ b/src/features/auth/ui/StepIndicator.tsx
@@ -1,0 +1,35 @@
+/**
+ * #156: Çok adımlı akış göstergesi.
+ *
+ * Görsel çubuklar `aria-hidden`; ilerleme bilgisi ekran okuyucuya
+ * "3 adımdan 2." şeklinde metin olarak verilir. Önceden gösterge yalnızca
+ * üç süslü div'den ibaretti ve hangi adımda olunduğu hiç iletilmiyordu.
+ */
+export function StepIndicator({
+  current,
+  total,
+}: {
+  current: number;
+  total: number;
+}) {
+  return (
+    <div className="mb-6">
+      <p className="sr-only">
+        {total} adımdan {current}. adımdasınız.
+      </p>
+
+      <div className="flex items-center justify-center gap-2" aria-hidden="true">
+        {Array.from({ length: total }, (_, i) => i + 1).map((n) => (
+          <div
+            key={n}
+            className={`h-1.5 rounded-full transition-all ${
+              n <= current
+                ? "w-10 bg-gradient-to-r from-blue-500 to-indigo-500"
+                : "w-6 bg-slate-200"
+            }`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/auth/ui/forgot-password/steps.tsx
+++ b/src/features/auth/ui/forgot-password/steps.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft, CheckCircle2 } from "lucide-react";
+import { AuthField } from "@/features/auth/ui/AuthField";
+import { AuthSubmitButton } from "@/features/auth/ui/AuthSubmitButton";
+import { PasswordRules } from "@/features/auth/ui/PasswordRules";
+
+export type Question = { questionId: number; question: string };
+
+/** Adımlar arasında paylaşılan "geri dön" bağlantısı görünümü. */
+const backLinkClass =
+  "inline-flex items-center text-sm text-slate-500 hover:text-slate-700 transition-colors";
+
+/** ADIM 1 — e-posta ile güvenlik sorularını iste. */
+export function EmailStep({
+  email,
+  onEmailChange,
+  onSubmit,
+  loading,
+}: {
+  email: string;
+  onEmailChange: (value: string) => void;
+  onSubmit: (e: React.FormEvent) => void;
+  loading: boolean;
+}) {
+  return (
+    <form onSubmit={onSubmit} className="space-y-5">
+      <AuthField
+        id="fp-email"
+        name="email"
+        label="E-posta Adresi"
+        type="email"
+        value={email}
+        onChange={(e) => onEmailChange(e.target.value)}
+        placeholder="ornek@email.com"
+        required
+        autoComplete="email"
+      />
+
+      <AuthSubmitButton pending={loading} label="Devam Et" pendingLabel="Kontrol Ediliyor..." />
+
+      <div className="text-center">
+        <Link href="/signin" className={backLinkClass}>
+          <ArrowLeft className="w-4 h-4 mr-1" aria-hidden="true" />
+          Giriş sayfasına dön
+        </Link>
+      </div>
+    </form>
+  );
+}
+
+/** ADIM 2 — güvenlik sorularını cevapla. */
+export function QuestionsStep({
+  questions,
+  answers,
+  onAnswerChange,
+  onSubmit,
+  onBack,
+  loading,
+}: {
+  questions: Question[];
+  answers: Record<number, string>;
+  onAnswerChange: (questionId: number, value: string) => void;
+  onSubmit: (e: React.FormEvent) => void;
+  onBack: () => void;
+  loading: boolean;
+}) {
+  return (
+    <form onSubmit={onSubmit} className="space-y-5">
+      {questions.map((q, index) => (
+        <AuthField
+          key={q.questionId}
+          id={`fp-q-${q.questionId}`}
+          name={`answer-${q.questionId}`}
+          label={`${index + 1}. ${q.question}`}
+          value={answers[q.questionId] || ""}
+          onChange={(e) => onAnswerChange(q.questionId, e.target.value)}
+          placeholder="Cevabın..."
+          required
+          autoComplete="off"
+        />
+      ))}
+
+      <AuthSubmitButton
+        pending={loading}
+        label="Cevapları Doğrula"
+        pendingLabel="Doğrulanıyor..."
+      />
+
+      <div className="text-center">
+        <button type="button" onClick={onBack} className={backLinkClass}>
+          <ArrowLeft className="w-4 h-4 mr-1" aria-hidden="true" />
+          Geri dön
+        </button>
+      </div>
+    </form>
+  );
+}
+
+/** ADIM 3 — yeni şifreyi belirle. */
+export function NewPasswordStep({
+  newPassword,
+  confirmPassword,
+  onNewPasswordChange,
+  onConfirmPasswordChange,
+  onSubmit,
+  loading,
+}: {
+  newPassword: string;
+  confirmPassword: string;
+  onNewPasswordChange: (value: string) => void;
+  onConfirmPasswordChange: (value: string) => void;
+  onSubmit: (e: React.FormEvent) => void;
+  loading: boolean;
+}) {
+  const mismatch = confirmPassword.length > 0 && newPassword !== confirmPassword;
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-5">
+      <AuthField
+        id="fp-new-password"
+        name="newPassword"
+        label="Yeni Şifre"
+        revealable
+        value={newPassword}
+        onChange={(e) => onNewPasswordChange(e.target.value)}
+        placeholder="En az 8 karakter"
+        required
+        minLength={8}
+        autoComplete="new-password"
+        belowField={<PasswordRules password={newPassword} />}
+      />
+
+      <AuthField
+        id="fp-confirm-password"
+        name="confirmPassword"
+        label="Şifreyi Tekrar Gir"
+        revealable
+        value={confirmPassword}
+        onChange={(e) => onConfirmPasswordChange(e.target.value)}
+        placeholder="Şifreni tekrar gir"
+        required
+        autoComplete="new-password"
+        // #156: Eşleşmeme uyarısı artık alanın kendi hatası — aria-describedby
+        // ile input'a bağlanıyor ve role="alert" ile duyuruluyor.
+        errors={mismatch ? ["Şifreler eşleşmiyor"] : undefined}
+      />
+
+      <AuthSubmitButton
+        pending={loading}
+        label="Şifreyi Değiştir"
+        pendingLabel="Kaydediliyor..."
+      />
+    </form>
+  );
+}
+
+/** ADIM 4 — başarı ekranı. */
+export function SuccessStep() {
+  return (
+    <div className="text-center space-y-5">
+      <div className="mx-auto h-16 w-16 rounded-2xl bg-emerald-100 flex items-center justify-center">
+        <CheckCircle2 className="w-8 h-8 text-emerald-600" aria-hidden="true" />
+      </div>
+      <p className="text-slate-600 text-sm">
+        Şifren başarıyla güncellendi. Artık yeni şifrenle giriş yapabilirsin.
+      </p>
+      <Link
+        href="/signin"
+        className="block w-full rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 px-4 py-3 font-semibold text-white shadow-md shadow-blue-200 transition-all text-center"
+      >
+        Giriş Yap
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
> ℹ️ Bu PR başta #155'in (giriş/kayıt a11y) üzerine kuruluydu. **#155 merge edildi**, bu dal güncel `develop` üzerine rebase edildi; artık diff **yalnızca şifre sıfırlama işini** içeriyor ve çakışma yok.

## Özet

411 satırlık tek bileşen adım bileşenlerine bölündü ve #155'te develop'a giren ortak auth bileşenlerine (`AuthCard`/`AuthField`/`FormAlert`/`AuthSubmitButton`) geçirildi. Bu arada üç erişilebilirlik sorunu düzeltildi.

## 1) Adım değişince odak kayboluyordu
"Devam Et"e basınca basılan düğme DOM'dan siliniyor ve odak `<body>`'ye düşüyordu: klavyeyle gezen kullanıcı yeni alanlara ulaşmak için baştan tab'lamak zorunda, ekran okuyucu kullanan sayfanın değiştiğini hiç fark etmiyordu. Artık odak yeni adımın başlığına taşınıyor (ilk açılışta çalınmıyor).

## 2) Adım göstergesi ekran okuyucuya görünmezdi
Üç süslü `<div>`'den ibaretti. `StepIndicator` artık "3 adımdan 2. adımdasınız" metnini veriyor; görsel çubuklar `aria-hidden`.

## 3) Uyarılar duyurulmuyordu
Sunucu hataları `role="alert"`; "Şifreler eşleşmiyor" uyarısı artık alanın kendi hatası olarak `aria-describedby` ile input'a bağlı.

## 4) Şifre kuralları listesi kayıt ekranıyla ortaklaştırıldı
Aynı 5 kural iki dosyada ayrıydı → `password-rules.ts` + `PasswordRules`; kayıt ekranı da ona geçirildi.

## Doğrulama (rebase sonrası)
- `npm test` → 252/252 ✓
- `npm run lint` → 0 hata
- `npm run build` → ✓
- Odak testinin anlamlı olduğu, odak taşıma kapatılarak doğrulandı (1 test düşüyor).

Closes #156
Refs #126