### PR TITLE
fix: oneri modulu — POST hiz siniri (P1) + liste sayfalama (P2)

### DIFF
--- a/src/app/(admin)/admin-dashboard/suggestions/page.tsx
+++ b/src/app/(admin)/admin-dashboard/suggestions/page.tsx
@@ -36,14 +36,28 @@ export default function AdminSuggestionsPage() {
   const [savingId, setSavingId] = useState<string | null>(null);
   // Kaydedilmemiş not taslakları — kayıt id'sine göre tutulur.
   const [noteDrafts, setNoteDrafts] = useState<Record<string, string>>({});
+  // #163: Filtre artık sunucuda uygulanıyor (sayfalamayla tutarlı olsun diye).
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
 
-  const load = useCallback(async () => {
+  // Filtreye göre sorgu string'i — "ALL"da status parametresi gitmez.
+  const queryFor = (f: Filter, cursor?: string) => {
+    const params = new URLSearchParams();
+    if (f !== "ALL") params.set("status", f);
+    if (cursor) params.set("cursor", cursor);
+    const qs = params.toString();
+    return `/api/admin/suggestions${qs ? `?${qs}` : ""}`;
+  };
+
+  const load = useCallback(async (f: Filter) => {
     try {
       setLoading(true);
       setLoadError(false);
-      const res = await fetch("/api/admin/suggestions");
+      const res = await fetch(queryFor(f));
       if (!res.ok) throw new Error("failed");
-      setItems(await res.json());
+      const page = await res.json();
+      setItems(page.items);
+      setNextCursor(page.nextCursor);
     } catch {
       setLoadError(true);
     } finally {
@@ -51,9 +65,26 @@ export default function AdminSuggestionsPage() {
     }
   }, []);
 
+  const loadMore = useCallback(async () => {
+    if (!nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const res = await fetch(queryFor(filter, nextCursor));
+      if (!res.ok) throw new Error("failed");
+      const page = await res.json();
+      setItems((prev) => [...prev, ...page.items]);
+      setNextCursor(page.nextCursor);
+    } catch {
+      toast.error("Daha fazlası yüklenemedi. Lütfen tekrar deneyin.");
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [filter, nextCursor, loadingMore]);
+
+  // Filtre değişince baştan yükle (cursor sıfırlanır).
   useEffect(() => {
-    load();
-  }, [load]);
+    load(filter);
+  }, [filter, load]);
 
   async function patch(id: string, data: { status?: SuggestionStatus; adminNote?: string }) {
     setSavingId(id);
@@ -85,8 +116,8 @@ export default function AdminSuggestionsPage() {
     }
   }
 
-  const visible = filter === "ALL" ? items : items.filter((i) => i.status === filter);
-  const openCount = items.filter((i) => i.status === "OPEN").length;
+  // #163: Filtreleme sunucuda yapıldığı için gelen liste zaten filtrelenmiş.
+  const visible = items;
 
   return (
     <div className="max-w-5xl mx-auto p-6 space-y-6">
@@ -94,11 +125,7 @@ export default function AdminSuggestionsPage() {
         <h1 className="text-3xl font-bold text-slate-900 tracking-tight">Öneri & İstek</h1>
         <p className="text-slate-500 mt-1.5 text-sm">
           Stajyerlerden gelen öneri ve talepleri inceleyin, durumlarını güncelleyin.
-          {openCount > 0 && (
-            <span className="ml-1 font-medium text-amber-600">
-              {openCount} açık kayıt var.
-            </span>
-          )}
+          Açık kayıtları görmek için <span className="font-medium">Açık</span> filtresini kullanın.
         </p>
       </div>
 
@@ -130,7 +157,7 @@ export default function AdminSuggestionsPage() {
           <AlertCircle className="w-8 h-8 text-red-500 mx-auto mb-3" />
           <p className="text-slate-900 font-semibold">Kayıtlar yüklenemedi</p>
           <button
-            onClick={load}
+            onClick={() => load(filter)}
             className="mt-4 rounded-xl bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium px-5 py-2.5 transition-colors"
           >
             Tekrar Dene
@@ -225,6 +252,19 @@ export default function AdminSuggestionsPage() {
             );
           })}
         </ul>
+      )}
+
+      {!loading && !loadError && nextCursor && (
+        <div className="text-center">
+          <button
+            onClick={loadMore}
+            disabled={loadingMore}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl border border-slate-200 bg-white text-slate-700 text-sm font-medium hover:bg-slate-50 disabled:opacity-60 transition-colors"
+          >
+            {loadingMore && <Loader2 className="w-4 h-4 animate-spin" />}
+            Daha fazla yükle
+          </button>
+        </div>
       )}
     </div>
   );

--- a/src/app/(student)/student-dashboard/suggestions/page.tsx
+++ b/src/app/(student)/student-dashboard/suggestions/page.tsx
@@ -30,6 +30,9 @@ export default function StudentSuggestionsPage() {
   const [items, setItems] = useState<Suggestion[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState(false);
+  // #163: Sayfalama — nextCursor null ise son sayfadayız.
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
 
   const [type, setType] = useState<SuggestionType>("SUGGESTION");
   const [title, setTitle] = useState("");
@@ -42,13 +45,31 @@ export default function StudentSuggestionsPage() {
       setLoadError(false);
       const res = await fetch("/api/suggestions");
       if (!res.ok) throw new Error("failed");
-      setItems(await res.json());
+      const page = await res.json();
+      setItems(page.items);
+      setNextCursor(page.nextCursor);
     } catch {
       setLoadError(true);
     } finally {
       setLoading(false);
     }
   }, []);
+
+  const loadMore = useCallback(async () => {
+    if (!nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const res = await fetch(`/api/suggestions?cursor=${encodeURIComponent(nextCursor)}`);
+      if (!res.ok) throw new Error("failed");
+      const page = await res.json();
+      setItems((prev) => [...prev, ...page.items]);
+      setNextCursor(page.nextCursor);
+    } catch {
+      toast.error("Daha fazlası yüklenemedi. Lütfen tekrar deneyin.");
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [nextCursor, loadingMore]);
 
   useEffect(() => {
     load();
@@ -225,6 +246,19 @@ export default function StudentSuggestionsPage() {
               </li>
             ))}
           </ul>
+        )}
+
+        {nextCursor && (
+          <div className="mt-5 text-center">
+            <button
+              onClick={loadMore}
+              disabled={loadingMore}
+              className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl border border-slate-200 bg-white text-slate-700 text-sm font-medium hover:bg-slate-50 disabled:opacity-60 transition-colors"
+            >
+              {loadingMore && <Loader2 className="w-4 h-4 animate-spin" />}
+              Daha fazla yükle
+            </button>
+          </div>
         )}
       </section>
     </div>

--- a/src/app/api/admin/suggestions/route.test.ts
+++ b/src/app/api/admin/suggestions/route.test.ts
@@ -89,4 +89,37 @@ describe("admin/suggestions route (#147)", () => {
     expect(select.author.select).not.toHaveProperty("password");
     expect(select.author.select).toMatchObject({ id: true, email: true });
   });
+
+  it("GET yanıtı sayfalama zarfı döner (#163)", async () => {
+    authAsAdmin();
+    prismaMock.suggestion.findMany.mockResolvedValue([{ id: "s1" }]);
+
+    const json = await (await GET(req())).json();
+
+    expect(json).toHaveProperty("items");
+    expect(json).toHaveProperty("nextCursor");
+  });
+
+  it("GET limit+1 kayıtta nextCursor üretilir (#163)", async () => {
+    authAsAdmin();
+    prismaMock.suggestion.findMany.mockResolvedValue([
+      { id: "a" },
+      { id: "b" },
+      { id: "c" },
+    ]);
+
+    const json = await (await GET(req("?limit=2"))).json();
+
+    expect(json.items).toHaveLength(2);
+    expect(json.nextCursor).toBe("b");
+  });
+
+  it("GET geçersiz limit → 400 (#163)", async () => {
+    authAsAdmin();
+
+    const res = await GET(req("?limit=999"));
+
+    expect(res.status).toBe(400);
+    expect(prismaMock.suggestion.findMany).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/api/admin/suggestions/route.ts
+++ b/src/app/api/admin/suggestions/route.ts
@@ -1,28 +1,32 @@
 import { NextResponse } from "next/server";
 import { listAllSuggestions } from "@/features/suggestions/server/suggestions";
 import { requireAuth } from "@/lib/auth/guard";
-import { suggestionStatusEnum } from "@/lib/validations/api";
+import { listSuggestionsQuerySchema } from "@/lib/validations/api";
 
 /**
- * GET /api/admin/suggestions?status=OPEN
- * Tüm öneri/istekleri listeler (admin) — #147.
+ * GET /api/admin/suggestions?status=OPEN&cursor=<id>&limit=<n>
+ * Tüm öneri/istekleri sayfalanmış listeler (admin) — #147, #163.
  */
 export async function GET(req: Request) {
   const auth = await requireAuth("ADMIN");
   if (!auth.authorized) return auth.response;
 
-  try {
-    const raw = new URL(req.url).searchParams.get("status");
-    const parsed = raw ? suggestionStatusEnum.safeParse(raw) : null;
-    if (parsed && !parsed.success) {
-      return NextResponse.json(
-        { error: "Geçersiz durum filtresi." },
-        { status: 400 },
-      );
-    }
+  const { searchParams } = new URL(req.url);
+  const parsed = listSuggestionsQuerySchema.safeParse({
+    status: searchParams.get("status") ?? undefined,
+    cursor: searchParams.get("cursor") ?? undefined,
+    limit: searchParams.get("limit") ?? undefined,
+  });
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten().fieldErrors },
+      { status: 400 },
+    );
+  }
 
-    const items = await listAllSuggestions(parsed?.data);
-    return NextResponse.json(items);
+  try {
+    const page = await listAllSuggestions(parsed.data);
+    return NextResponse.json(page);
   } catch (error) {
     console.error("GET /api/admin/suggestions error:", error);
     return NextResponse.json(

--- a/src/app/api/suggestions/route.test.ts
+++ b/src/app/api/suggestions/route.test.ts
@@ -25,6 +25,9 @@ function unauthorized(status = 401) {
     response: new Response(JSON.stringify({ error: "yetkisiz" }), { status }),
   });
 }
+function getReq(query = "") {
+  return new Request(`http://test/api/suggestions${query}`);
+}
 function postReq(body: unknown) {
   return new Request("http://test/api/suggestions", {
     method: "POST",
@@ -32,15 +35,27 @@ function postReq(body: unknown) {
     body: JSON.stringify(body),
   });
 }
+const validBody = {
+  type: "SUGGESTION",
+  title: "Karanlık mod",
+  content: "Panelde karanlık mod seçeneği olsa çok iyi olur.",
+};
 
-describe("suggestions route (#147)", () => {
-  beforeEach(() => vi.clearAllMocks());
+// Rate limiter proses-yerel ve testler arası taşar; her testte benzersiz kullanıcı.
+let userSeq = 0;
+const freshUser = () => `student-${++userSeq}`;
+
+describe("suggestions route (#147/#163)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.suggestion.findMany.mockResolvedValue([]);
+  });
 
   it("GET → yalnızca oturum sahibinin kayıtlarını sorgular", async () => {
     authAs("student-1");
     prismaMock.suggestion.findMany.mockResolvedValue([{ id: "s1" }]);
 
-    const res = await GET();
+    const res = await GET(getReq());
 
     expect(res.status).toBe(200);
     expect(prismaMock.suggestion.findMany).toHaveBeenCalledWith(
@@ -48,14 +63,60 @@ describe("suggestions route (#147)", () => {
     );
   });
 
+  it("GET yanıtı sayfalama zarfı döner ({items, nextCursor})", async () => {
+    authAs("student-1");
+    prismaMock.suggestion.findMany.mockResolvedValue([{ id: "s1" }, { id: "s2" }]);
+
+    const json = await (await GET(getReq())).json();
+
+    expect(json).toHaveProperty("items");
+    expect(json).toHaveProperty("nextCursor");
+    expect(json.items).toHaveLength(2);
+  });
+
+  it("GET limit+1 kayıt gelirse nextCursor son görünen kaydın id'si olur", async () => {
+    authAs("student-1");
+    // limit=2 istenirse server take:3 sorgular; 3 kayıt gelirse "daha var" demektir.
+    prismaMock.suggestion.findMany.mockResolvedValue([
+      { id: "a" },
+      { id: "b" },
+      { id: "c" },
+    ]);
+
+    const json = await (await GET(getReq("?limit=2"))).json();
+
+    expect(json.items.map((i: { id: string }) => i.id)).toEqual(["a", "b"]);
+    expect(json.nextCursor).toBe("b");
+    expect(prismaMock.suggestion.findMany.mock.calls[0][0].take).toBe(3);
+  });
+
+  it("GET cursor verilirse sayfalama parametreleri eklenir", async () => {
+    authAs("student-1");
+
+    await GET(getReq("?cursor=s9"));
+
+    const args = prismaMock.suggestion.findMany.mock.calls[0][0];
+    expect(args.cursor).toEqual({ id: "s9" });
+    expect(args.skip).toBe(1);
+  });
+
+  it("GET geçersiz limit → 400", async () => {
+    authAs("student-1");
+
+    const res = await GET(getReq("?limit=-5"));
+
+    expect(res.status).toBe(400);
+    expect(prismaMock.suggestion.findMany).not.toHaveBeenCalled();
+  });
+
   it("GET oturum yok → 401", async () => {
     unauthorized();
-    const res = await GET();
+    const res = await GET(getReq());
     expect(res.status).toBe(401);
   });
 
   it("POST geçerli → 201 ve authorId oturumdan alınır", async () => {
-    authAs("student-1");
+    authAs(freshUser());
     prismaMock.suggestion.create.mockResolvedValue({ id: "s1" });
 
     const res = await POST(
@@ -69,30 +130,23 @@ describe("suggestions route (#147)", () => {
     expect(res.status).toBe(201);
     expect(prismaMock.suggestion.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ authorId: "student-1", type: "REQUEST" }),
+        data: expect.objectContaining({ type: "REQUEST" }),
       }),
     );
   });
 
   it("POST gövdedeki authorId yok sayılır — başkası adına kayıt açılamaz", async () => {
-    authAs("student-1");
+    const id = freshUser();
+    authAs(id);
     prismaMock.suggestion.create.mockResolvedValue({ id: "s1" });
 
-    await POST(
-      postReq({
-        authorId: "baskasi",
-        type: "SUGGESTION",
-        title: "Karanlık mod",
-        content: "Panelde karanlık mod seçeneği olsa çok iyi olur.",
-      }),
-    );
+    await POST(postReq({ ...validBody, authorId: "baskasi" }));
 
-    const arg = prismaMock.suggestion.create.mock.calls[0][0];
-    expect(arg.data.authorId).toBe("student-1");
+    expect(prismaMock.suggestion.create.mock.calls[0][0].data.authorId).toBe(id);
   });
 
   it("POST kısa açıklama → 400, create çağrılmaz", async () => {
-    authAs("student-1");
+    authAs(freshUser());
 
     const res = await POST(
       postReq({ type: "SUGGESTION", title: "Başlık", content: "kısa" }),
@@ -103,17 +157,40 @@ describe("suggestions route (#147)", () => {
   });
 
   it("POST geçersiz tip → 400", async () => {
-    authAs("student-1");
+    authAs(freshUser());
 
     const res = await POST(
-      postReq({
-        type: "SIKAYET",
-        title: "Başlık",
-        content: "Yeterince uzun bir açıklama metni.",
-      }),
+      postReq({ type: "SIKAYET", title: "Başlık", content: "Yeterince uzun bir açıklama." }),
     );
 
     expect(res.status).toBe(400);
     expect(prismaMock.suggestion.create).not.toHaveBeenCalled();
+  });
+
+  it("POST hız sınırı: 10 kayıt geçer, 11. istek → 429 (#163 P1)", async () => {
+    const id = freshUser();
+    authAs(id);
+    prismaMock.suggestion.create.mockResolvedValue({ id: "s1" });
+
+    const statuses: number[] = [];
+    for (let i = 0; i < 11; i++) {
+      const res = await POST(postReq(validBody));
+      statuses.push(res.status);
+    }
+
+    expect(statuses.slice(0, 10).every((s) => s === 201)).toBe(true);
+    expect(statuses[10]).toBe(429);
+  });
+
+  it("POST 429 yanıtında Retry-After başlığı bulunur", async () => {
+    const id = freshUser();
+    authAs(id);
+    prismaMock.suggestion.create.mockResolvedValue({ id: "s1" });
+
+    for (let i = 0; i < 10; i++) await POST(postReq(validBody));
+    const res = await POST(postReq(validBody));
+
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBeTruthy();
   });
 });

--- a/src/app/api/suggestions/route.ts
+++ b/src/app/api/suggestions/route.ts
@@ -4,20 +4,43 @@ import {
   listOwnSuggestions,
 } from "@/features/suggestions/server/suggestions";
 import { requireAuth } from "@/lib/auth/guard";
-import { createSuggestionSchema } from "@/lib/validations/api";
+import {
+  createSuggestionSchema,
+  listSuggestionsQuerySchema,
+} from "@/lib/validations/api";
+import { createRateLimiter } from "@/lib/rate-limit";
+
+// #163 (P1): Kimliği doğrulanmış öğrenci sınırsız öneri gönderip yönetici gelen
+// kutusunu spam'leyebiliyordu. ai-chat/forgot-password ile aynı desen.
+const createLimiter = createRateLimiter("suggestions-create", {
+  maxRequests: 10,
+  windowSeconds: 3600, // saatte 10 öneri/istek
+});
 
 /**
- * GET /api/suggestions
- * Oturum sahibinin kendi öneri/istek geçmişi (#147).
+ * GET /api/suggestions?cursor=<id>&limit=<n>
+ * Oturum sahibinin kendi öneri/istek geçmişi, sayfalanmış (#147, #163).
  */
-export async function GET() {
+export async function GET(req: Request) {
   const auth = await requireAuth();
   if (!auth.authorized) return auth.response;
 
+  const { searchParams } = new URL(req.url);
+  const parsedQuery = listSuggestionsQuerySchema.safeParse({
+    cursor: searchParams.get("cursor") ?? undefined,
+    limit: searchParams.get("limit") ?? undefined,
+  });
+  if (!parsedQuery.success) {
+    return NextResponse.json(
+      { error: parsedQuery.error.flatten().fieldErrors },
+      { status: 400 },
+    );
+  }
+
   try {
     // guard `session.user.id` varlığını doğruladı.
-    const items = await listOwnSuggestions(auth.session.user.id!);
-    return NextResponse.json(items);
+    const page = await listOwnSuggestions(auth.session.user.id!, parsedQuery.data);
+    return NextResponse.json(page);
   } catch (error) {
     console.error("GET /api/suggestions error:", error);
     return NextResponse.json(
@@ -35,6 +58,15 @@ export async function GET() {
 export async function POST(req: Request) {
   const auth = await requireAuth();
   if (!auth.authorized) return auth.response;
+
+  // #163 (P1): Kötüye kullanım/spam koruması — kullanıcı bazlı.
+  const rl = createLimiter.check(auth.session.user.id!);
+  if (!rl.allowed) {
+    return NextResponse.json(
+      { error: "Çok fazla öneri gönderdiniz. Lütfen bir süre sonra tekrar deneyin." },
+      { status: 429, headers: { "Retry-After": String(rl.retryAfterSeconds) } },
+    );
+  }
 
   try {
     const body = await req.json();

--- a/src/features/suggestions/server/suggestions.ts
+++ b/src/features/suggestions/server/suggestions.ts
@@ -44,22 +44,54 @@ export async function createSuggestion(input: {
   });
 }
 
-/** Bir kullanıcının kendi gönderdiği öneri/istekler (en yeni önce). */
-export async function listOwnSuggestions(authorId: string) {
-  return prisma.suggestion.findMany({
-    where: { authorId },
-    orderBy: { createdAt: "desc" },
-    select: ownSelect,
-  });
+/**
+ * #163: Cursor tabanlı sayfalama sonucu. `nextCursor` null ise son sayfadayız.
+ * `take: limit + 1` hilesiyle "daha fazlası var mı" fazladan sorgu atmadan bulunur.
+ */
+export type SuggestionPage<T> = { items: T[]; nextCursor: string | null };
+
+type PageParams = { cursor?: string; limit?: number };
+
+function paginate<T extends { id: string }>(
+  rows: T[],
+  limit: number,
+): SuggestionPage<T> {
+  const hasMore = rows.length > limit;
+  const items = hasMore ? rows.slice(0, limit) : rows;
+  return {
+    items,
+    nextCursor: hasMore ? items[items.length - 1].id : null,
+  };
 }
 
-/** Tüm kayıtlar (admin). Açık olanlar önce gelsin diye status'e göre de sıralanır. */
-export async function listAllSuggestions(status?: SuggestionStatus) {
-  return prisma.suggestion.findMany({
+/** Bir kullanıcının kendi gönderdiği öneri/istekler (en yeni önce), sayfalanmış. */
+export async function listOwnSuggestions(
+  authorId: string,
+  { cursor, limit = 20 }: PageParams = {},
+) {
+  const rows = await prisma.suggestion.findMany({
+    where: { authorId },
+    orderBy: { createdAt: "desc" },
+    take: limit + 1,
+    // cursor verilmişse "o kayıttan sonrasını getir".
+    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    select: ownSelect,
+  });
+  return paginate(rows, limit);
+}
+
+/** Tüm kayıtlar (admin), sayfalanmış. Açık olanlar önce gelsin diye status'e göre de sıralanır. */
+export async function listAllSuggestions(
+  { status, cursor, limit = 20 }: PageParams & { status?: SuggestionStatus } = {},
+) {
+  const rows = await prisma.suggestion.findMany({
     where: status ? { status } : undefined,
     orderBy: [{ status: "asc" }, { createdAt: "desc" }],
+    take: limit + 1,
+    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
     select: adminSelect,
   });
+  return paginate(rows, limit);
 }
 
 /**

--- a/src/lib/validations/api.ts
+++ b/src/lib/validations/api.ts
@@ -228,6 +228,15 @@ export const createSuggestionSchema = z.object({
     .transform((val) => val.trim()),
 });
 
+// #163: Öneri listelerinde cursor tabanlı sayfalama. Query string'den geldiği
+// için limit coerce edilir (mesajlaşmadaki getMessagesSchema ile aynı desen).
+export const listSuggestionsQuerySchema = z.object({
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  // Yalnızca admin listesinde kullanılır; öğrenci ucunda yok sayılır.
+  status: suggestionStatusEnum.optional(),
+});
+
 // Yönetici durum / not günceller — en az bir alan gönderilmeli
 export const updateSuggestionSchema = z
   .object({


### PR DESCRIPTION
#160 post-merge incelemesindeki iki öneri-modülü (#147/#148) maddesini kapatır.

## 🔴 P1 — `POST /api/suggestions` hız sınırı yoktu
Kimliği doğrulanmış öğrenci **sınırsız** öneri gönderip yönetici gelen kutusunu spam'leyebiliyordu (Yusuf'un tek P1'i).

`createRateLimiter` ile **kullanıcı bazlı saatte 10** sınır; aşılınca **429 + `Retry-After`**. `ai-chat` / `forgot-password` ile birebir aynı desen.

## 🟡 P2 — Öneri listeleri sayfalanmıyordu
`listOwnSuggestions` / `listAllSuggestions` sınırsız `findMany` yapıyordu — hacim büyüdükçe yavaşlardı.

- Cursor tabanlı sayfalama (`take: limit + 1` ile fazladan sorgu atmadan "daha var mı" tespiti — mesajlaşmadaki desen)
- `listSuggestionsQuerySchema` (limit `coerce`, üst sınır 50)
- İki uç da artık `{ items, nextCursor }` dönüyor
- Öğrenci ve admin sayfalarına **"Daha fazla yükle"**
- **Admin filtresi artık sunucuda** uygulanıyor — sayfalamayla tutarlı olması için istemci-tarafı filtre kaldırıldı

## Testler
26 test (11'i yeni/değişen). Kanıt için ilgili kod geçici kaldırıldı:
- Rate-limit kapatılınca 2 test düşüyor (429 eşiği + Retry-After)
- Kapsam: 10 geçer/11. reddedilir, `nextCursor` üretimi, cursor parametreleri, geçersiz limit → 400

## Davranış notu
Admin başlığındaki "N açık kayıt var" ipucu kaldırıldı — sayfalamayla birlikte yüklenen sayfadan doğru toplam çıkarılamıyordu. Yerine "Açık filtresini kullanın" yönlendirmesi kondu. (Doğru sayaç istenirse ayrı bir count sorgusu gerekir — kapsamı büyütmemek için eklenmedi.)

## Doğrulama
- `npm test` → 248/248 ✓
- `npm run lint` → 0 hata
- `npm run build` → ✓
- `package-lock.json` değişmedi

## Çakışma
Açık PR'ların hiçbiri bu dosyalara dokunmuyor.

Closes #163
Refs #160, #126