### PR TITLE
chore: #146 sonrasi olu test mock'lari ve kullanilmayan import temizligi

### DIFF
--- a/src/app/(admin)/admin-dashboard/page.test.tsx
+++ b/src/app/(admin)/admin-dashboard/page.test.tsx
@@ -4,10 +4,8 @@ import "@testing-library/jest-dom/vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ConfirmDialogProvider } from "@/components/ui/ConfirmDialog";
 
-// Sayfa next-auth/UnreadBadge gibi tarayıcı-dışı bağımlılıklar içeriyor; render
-// testinin odağı hata durumu olduğundan bunlar sadeleştirilir.
-vi.mock("@/features/messaging/ui/UnreadBadge", () => ({ UnreadBadge: () => null }));
-vi.mock("@/components/LogoutButton", () => ({ default: () => null }));
+// #165: LogoutButton/UnreadBadge mock'ları #146'da sayfa header'ı AppShell'e
+// taşınınca ölü kaldı (sayfa artık ikisini de import etmiyor); kaldırıldı.
 
 import AdminDashboard from "./page";
 

--- a/src/app/(student)/student-dashboard/page.tsx
+++ b/src/app/(student)/student-dashboard/page.tsx
@@ -6,7 +6,6 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth/nextauth";
 import { Clock, Briefcase, Target, Github } from "lucide-react";
 import Link from "next/link";
-import { redirect } from "next/navigation";
 import { Progress } from "@/components/ui/progress";
 import { SecurityQuestionsSetup } from "@/features/auth/ui/SecurityQuestionsSetup";
 import { MarkdownContent } from "@/components/ui/MarkdownContent";


### PR DESCRIPTION
#160 incelemesindeki iki P2 bakım maddesini kapatır.

## 1) Ölü Vitest mock'ları — admin dashboard testi
`#146`'da sayfa header'ı (LogoutButton + UnreadBadge) AppShell'e taşındı; sayfa artık ikisini de import etmiyor ama testteki mock'lar kalmıştı. Yanıltıcıydı — sanki sayfa hâlâ bağımlıymış gibi. Kaldırıldı; **test hâlâ 3/3 yeşil** (mock'lar zaten hiçbir şey yapmıyordu).

## 2) Kullanılmayan `redirect` import'u — öğrenci dashboard
`#146` sonrası boşta kalan import kaldırıldı → **lint uyarısı 9'dan 8'e** indi.

## Doğrulama
- `npm test` → 239/239 ✓
- `npm run lint` → 0 hata, 8 uyarı (biri eksildi)
- `npm run build` → ✓

## Çakışma
Açık PR'ların hiçbiri bu iki dosyaya dokunmuyor.

Closes #165
Refs #160, #126