### PR TITLE
docs: PENDING profil-tamamlama auth sozlesmesini CLAUDE.md'ye yaz

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,19 @@ src/
 3. `requireAuth`: rol kontrolü + APPROVED olmayan STUDENT'a 403.
 4. Middleware: onaysız stajyeri `/account-status`'a yönlendirir; `/forgot-password` public.
 
+#### ⚠️ PENDING profil-tamamlama sözleşmesi (#143 — bozmayın)
+Stajyer **PENDING iken profilini tamamlar**; onay bu adımdan *sonra* gelir. Bu yüzden
+profil-tamamlama yolları, "onaysız STUDENT'ı engelle" kuralının **bilinçli istisnasıdır**:
+- `requireAuth(role, { allowUnapprovedStudent: true })` → PENDING geçer, **REJECTED yine 403**.
+  Yalnızca profil-tamamlama uçlarında kullanılır (ör. `api/student/survey-answers`).
+- `saveOnboarding` bilerek `requireAuth` **kullanmaz**; doğrudan `getServerSession` ile yalnız
+  oturum kontrol eder (requireAuth'a çevirmek akışı kırar — dosyada açıklayıcı yorum var).
+- Middleware: PENDING → yalnız `/profile-setup` + `/student-onboarding`; `/student-dashboard`
+  engelli. REJECTED → tüm student alanı engelli.
+
+"Güvenlik sıkılaştırması" niyetiyle bu uçlara `requireAuth` eklemeden önce buranın istisna
+olduğunu hatırlayın; aksi halde onboarding tamamen çöker.
+
 ### AI Entegrasyonu
 - `gcp-credentials.json` (gitignore'da) + `GOOGLE_CLOUD_PROJECT` env gerekir; yoksa
   analiz/özet fonksiyonları **mock'a düşer** (graceful degradation), chat hata döner.

--- a/src/features/student/server/onboarding.ts
+++ b/src/features/student/server/onboarding.ts
@@ -20,6 +20,11 @@ const onboardingSchema = z.object({
 
 export async function saveOnboarding(rawData: unknown) {
   // 1. Kullanıcı doğrulama
+  // #143 SÖZLEŞME: Burada bilerek `requireAuth` KULLANILMAZ. requireAuth,
+  // APPROVED olmayan STUDENT'ı 403 ile engeller; oysa profil tamamlama tam da
+  // hesap PENDING iken yapılır (onay bu adımdan SONRA gelir). Doğrudan
+  // getServerSession ile yalnızca oturum kontrol edilir. Bunu `requireAuth`e
+  // çevirmek onboarding akışını kırar — detay: guard.ts `allowUnapprovedStudent`.
   const session = await getServerSession(authOptions)
   if (!session?.user?.id) {
     throw new Error("Oturum bulunamadı")


### PR DESCRIPTION
#160 incelemesindeki P2 dokümantasyon maddesini kapatır.

## Sorun
`#143`/`#144`'te eklenen auth istisnası **bilinçliydi ama yazılı değildi**:
- `requireAuth(role, { allowUnapprovedStudent: true })` → PENDING geçer, **REJECTED yine engel**
- `saveOnboarding` bilerek `requireAuth` **kullanmaz** (stajyer PENDING iken profilini doldurur)

Yusuf'un notu: *"must be documented to prevent 'security fixes' that break onboarding."* Biri iyi niyetle "bu uçta auth eksik" deyip `requireAuth` eklerse **onboarding tamamen çöker.**

## Ne yapıldı
- **CLAUDE.md** Auth bölümüne "⚠️ PENDING profil-tamamlama sözleşmesi" başlığı: opt-in kuralı, `saveOnboarding` istisnası, middleware davranışı (PENDING → yalnız profil yolları; REJECTED → tümü engel).
- **`saveOnboarding`**'e niyet yorumu: neden `requireAuth` kullanılmadığı, #143 referanslı.

## Neden test yok?
Sözleşme **guard seviyesinde zaten 7 testle kilitli** (`guard.approval.test.ts`): PENDING opt-in ile geçer, **REJECTED opt-in olsa da geçemez**, opt-in rol kontrolünü gevşetmez. Bu PR davranış değiştirmiyor, yalnızca mevcut sözleşmeyi görünür kılıyor.

## Doğrulama
- `npm test` → 239/239 ✓
- `npm run lint` → 0 hata
- `npm run build` → ✓

Closes #167
Refs #160, #126