### PR TITLE
fix: kayit formu ad/soyad required + AuthField revealable sozlesmesi

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -58,6 +58,7 @@ export default function SignupPage() {
             label="Ad"
             autoComplete="given-name"
             placeholder="Adınız"
+            required
             errors={state.error?.name}
           />
           <AuthField
@@ -66,6 +67,7 @@ export default function SignupPage() {
             label="Soyad"
             autoComplete="family-name"
             placeholder="Soyadınız"
+            required
             errors={state.error?.lastName}
           />
         </div>

--- a/src/features/auth/ui/AuthField.test.tsx
+++ b/src/features/auth/ui/AuthField.test.tsx
@@ -64,4 +64,24 @@ describe("AuthField erişilebilirlik (#153)", () => {
 
     expect(screen.getByText(/opsiyonel/)).toBeInTheDocument();
   });
+
+  it("revealable, dışarıdan geçilen type'ı yok sayar — password ile başlar (#169)", () => {
+    // Belgelenmiş sözleşme: revealable + type birlikte anlamlı değil.
+    // type="email" verilse bile revealable kazanır ve password olarak başlar.
+    render(<AuthField id="p" name="password" label="Şifre" revealable type="email" />);
+
+    expect(screen.getByLabelText("Şifre")).toHaveAttribute("type", "password");
+  });
+
+  it("revealable olmayan alan verilen type'ı kullanır", () => {
+    render(<AuthField id="e" name="email" label="E-posta" type="email" />);
+
+    expect(screen.getByLabelText("E-posta")).toHaveAttribute("type", "email");
+  });
+
+  it("required prop input'a geçer (#169 — signup ad/soyad)", () => {
+    render(<AuthField id="n" name="name" label="Ad" required />);
+
+    expect(screen.getByLabelText("Ad")).toBeRequired();
+  });
 });

--- a/src/features/auth/ui/AuthField.tsx
+++ b/src/features/auth/ui/AuthField.tsx
@@ -33,7 +33,12 @@ export function AuthField({
   errors?: string[];
   /** Etiket yanında gösterilen açıklama, ör. "(opsiyonel)". */
   hint?: string;
-  /** Şifre alanları için göster/gizle düğmesi. */
+  /**
+   * Şifre alanları için göster/gizle düğmesi. **Dikkat (#169):** `revealable`
+   * verildiğinde input tipi `password`↔`text` arasında bu bileşen tarafından
+   * yönetilir; dışarıdan geçilen `type` **yok sayılır**. Yani `revealable` + özel
+   * bir `type` (ör. `email`) birlikte anlamlı değildir — biri ya da öteki seçilir.
+   */
   revealable?: boolean;
   /** Alanın altına eklenecek içerik (ör. "Şifremi Unuttum" bağlantısı). */
   belowField?: ReactNode;


### PR DESCRIPTION
#160 incelemesindeki P2 maddesini kapatır.

## 1) Kayıt formu ad/soyad `required` eksikti
`#155`'te email/şifre `required` alıyordu ama ad/soyad almıyordu — tarayıcı-native doğrulama boşluğu. Backend Zod (`signupSchema`) zaten `min(2)` ile zorunlu kıldığından `required` eklemek **ön/arka uç tutarlı** ve kullanıcıya anında geri bildirim verir.

## 2) AuthField `revealable` dış `type`'ı yok sayıyor — belgesizdi
`revealable` verildiğinde input tipini bileşen `password`↔`text` yönetir; dışarıdan geçilen `type` sessizce yok sayılır. Bu **kasıtlı** ama yazılı değildi. JSDoc + 2 test eklendi ki `revealable + type="email"` gibi yanlış kullanım gözden kaçmasın.

## Testler
AuthField testine 3 yeni: `revealable` type'ı yok sayar (password başlar), revealable olmayan verilen type'ı kullanır, `required` input'a geçer. → **242/242** ✓

## Doğrulama
- `npm test` → 242/242 ✓
- `npm run lint` → 0 hata
- `npm run build` → ✓

## ⚠️ Çakışma notu
Bu PR `signup/page.tsx`'e (ad/soyad `required`) dokunuyor; açık **#157** de aynı dosyanın **farklı bölgesine** (şifre kuralları) dokunuyor. Farklı satırlar olduğu için otomatik birleşmeleri beklenir; olası ufak bir çakışma çıkarsa 10 saniyelik iştir. AuthField.tsx'e #157 dokunmuyor.

Closes #169
Refs #160, #126