### PR TITLE
feat: Kullanim Kosullari (/terms) ve Gizlilik (/privacy) sayfalari

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,70 @@
+import type { Metadata } from "next";
+import { LegalPage } from "@/features/legal/LegalPage";
+
+export const metadata: Metadata = {
+  title: "Gizlilik Politikası — AISigner",
+  description: "AISigner platformu gizlilik politikası.",
+};
+
+export default function PrivacyPage() {
+  return (
+    <LegalPage
+      title="Gizlilik Politikası"
+      updatedAt="25 Temmuz 2026"
+      crossLink={{ href: "/terms", label: "Kullanım Koşulları →" }}
+    >
+      <p>
+        Gizliliğiniz bizim için önemlidir. Bu politika, AISigner platformunda hangi
+        verileri neden topladığımızı ve nasıl koruduğumuzu açıklar.
+      </p>
+
+      <h2>1. Topladığımız Veriler</h2>
+      <ul>
+        <li><strong>Hesap bilgileri:</strong> ad, soyad, e-posta, telefon (opsiyonel).</li>
+        <li><strong>Profil bilgileri:</strong> deneyim, ilgi alanları, hedefler, uygunluk.</li>
+        <li><strong>Platform içeriği:</strong> mesajlar, proje dosyaları, öneri/istekler.</li>
+        <li><strong>Güvenlik:</strong> şifreler argon2 ile özetlenerek saklanır; asla düz metin tutulmaz.</li>
+      </ul>
+
+      <h2>2. Verileri Nasıl Kullanırız</h2>
+      <ul>
+        <li>Sizi uygun mentör ve projelerle eşleştirmek.</li>
+        <li>Yapay zeka destekli profil analizi ve öneriler üretmek.</li>
+        <li>Platform güvenliğini sağlamak (kötüye kullanım ve spam koruması).</li>
+      </ul>
+
+      <h2>3. Yapay Zeka İşleme</h2>
+      <p>
+        Profil analizi ve öneriler için verileriniz Google Vertex AI servisine
+        işlenmek üzere iletilebilir. Bu işleme yalnızca ilgili özellikleri sağlamak
+        amacıyla yapılır.
+      </p>
+
+      <h2>4. Veri Paylaşımı</h2>
+      <p>
+        Verilerinizi üçüncü taraflara satmayız. Yalnızca hizmetin çalışması için
+        gerekli servis sağlayıcılarla (ör. bulut altyapısı) ve yasal zorunluluk
+        hâlinde paylaşılır.
+      </p>
+
+      <h2>5. Erişim ve Görünürlük</h2>
+      <ul>
+        <li>Mentörünüz yalnızca kendisine atanmış öğrencilerin bilgilerini görür.</li>
+        <li>Öneri/istekleriniz yalnızca size ve yöneticilere görünür.</li>
+        <li>Mesajlarınız yalnızca konuşma tarafları arasında görünür.</li>
+      </ul>
+
+      <h2>6. Veri Güvenliği</h2>
+      <p>
+        Şifreler ve güvenlik cevapları özetlenerek (hash) saklanır; oturumlar
+        güvenli belirteçlerle yönetilir; hassas uçlar hız sınırı ile korunur.
+      </p>
+
+      <h2>7. Haklarınız</h2>
+      <p>
+        Hesabınızla ilgili verilere erişim veya düzeltme talepleriniz için platform
+        üzerinden yöneticinizle iletişime geçebilirsiniz.
+      </p>
+    </LegalPage>
+  );
+}

--- a/src/app/terms/page.test.tsx
+++ b/src/app/terms/page.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import TermsPage from "./page";
+import PrivacyPage from "../privacy/page";
+
+describe("Yasal sayfalar (#171)", () => {
+  it("Kullanım Koşulları başlığı ve gizliliğe çapraz bağlantı render edilir", () => {
+    render(<TermsPage />);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Kullanım Koşulları" }),
+    ).toBeInTheDocument();
+    // Kayıt ekranındaki 404 linkinin hedefi artık gerçek içerik gösteriyor
+    expect(screen.getByRole("link", { name: /Gizlilik Politikası/ })).toHaveAttribute(
+      "href",
+      "/privacy",
+    );
+  });
+
+  it("Gizlilik Politikası başlığı ve koşullara çapraz bağlantı render edilir", () => {
+    render(<PrivacyPage />);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Gizlilik Politikası" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Kullanım Koşulları/ })).toHaveAttribute(
+      "href",
+      "/terms",
+    );
+  });
+
+  it("her iki sayfa da kayıt sayfasına dönüş bağlantısı sunar", () => {
+    const { unmount } = render(<TermsPage />);
+    expect(screen.getByRole("link", { name: /Kayıt sayfasına dön/ })).toHaveAttribute(
+      "href",
+      "/signup",
+    );
+    unmount();
+
+    render(<PrivacyPage />);
+    expect(screen.getByRole("link", { name: /Kayıt sayfasına dön/ })).toHaveAttribute(
+      "href",
+      "/signup",
+    );
+  });
+});

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,69 @@
+import type { Metadata } from "next";
+import { LegalPage } from "@/features/legal/LegalPage";
+
+export const metadata: Metadata = {
+  title: "Kullanım Koşulları — AISigner",
+  description: "AISigner platformu kullanım koşulları.",
+};
+
+export default function TermsPage() {
+  return (
+    <LegalPage
+      title="Kullanım Koşulları"
+      updatedAt="25 Temmuz 2026"
+      crossLink={{ href: "/privacy", label: "Gizlilik Politikası →" }}
+    >
+      <p>
+        AISigner&apos;a hoş geldiniz. Bu platform; mentör ve stajyerleri eşleştiren,
+        yapay zeka destekli bir staj ve proje yönetim aracıdır. Hesap oluşturarak
+        aşağıdaki koşulları kabul etmiş olursunuz.
+      </p>
+
+      <h2>1. Hesap ve Uygunluk</h2>
+      <ul>
+        <li>Verdiğiniz bilgilerin doğru ve güncel olduğunu taahhüt edersiniz.</li>
+        <li>Hesap güvenliğinizden (şifre, güvenlik soruları) siz sorumlusunuz.</li>
+        <li>Stajyer hesapları bir yönetici onayından sonra tam erişim kazanır.</li>
+      </ul>
+
+      <h2>2. Kabul Edilebilir Kullanım</h2>
+      <ul>
+        <li>Platformu yalnızca eğitim ve mesleki gelişim amacıyla kullanırsınız.</li>
+        <li>Diğer kullanıcıları taciz eden, yanıltan veya zarar veren içerik yasaktır.</li>
+        <li>Sistemi kötüye kullanma, otomatik kötüye kullanım ve izinsiz erişim girişimleri yasaktır.</li>
+      </ul>
+
+      <h2>3. İçerik ve Fikri Mülkiyet</h2>
+      <p>
+        Yüklediğiniz proje ve içeriklerin haklarının size ait olduğunu; bunları
+        platformda göstermemiz için gerekli izni verdiğinizi kabul edersiniz.
+        Platformun kendi markası, tasarımı ve yazılımı AISigner&apos;a aittir.
+      </p>
+
+      <h2>4. Yapay Zeka Özellikleri</h2>
+      <p>
+        Profil analizi, proje önerileri ve yol haritası gibi yapay zeka çıktıları
+        yol gösterici niteliktedir; kesin veya hatasız olmayabilir. Nihai kararlarda
+        mentör ve kullanıcı sorumludur.
+      </p>
+
+      <h2>5. Sorumluluğun Sınırlanması</h2>
+      <p>
+        Platform &quot;olduğu gibi&quot; sunulur. Hizmet kesintileri veya veri
+        kayıplarından doğabilecek dolaylı zararlardan sorumlu tutulamayız.
+      </p>
+
+      <h2>6. Değişiklikler</h2>
+      <p>
+        Bu koşulları zaman zaman güncelleyebiliriz. Önemli değişikliklerde
+        kullanıcıları bilgilendirmeye çalışırız. Güncel sürüm her zaman bu sayfada
+        yer alır.
+      </p>
+
+      <h2>7. İletişim</h2>
+      <p>
+        Sorularınız için platform üzerinden yöneticinizle iletişime geçebilirsiniz.
+      </p>
+    </LegalPage>
+  );
+}

--- a/src/features/legal/LegalPage.tsx
+++ b/src/features/legal/LegalPage.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import { ArrowLeft, GraduationCap } from "lucide-react";
+import type { ReactNode } from "react";
+
+/**
+ * #171: Kullanım Koşulları / Gizlilik gibi statik yasal sayfaların ortak kabuğu.
+ * Oturumsuz da erişilebilir (middleware public yollarında).
+ */
+export function LegalPage({
+  title,
+  updatedAt,
+  /** Diğer yasal sayfaya çapraz bağlantı (koşullar ↔ gizlilik). */
+  crossLink,
+  children,
+}: {
+  title: string;
+  updatedAt: string;
+  crossLink: { href: string; label: string };
+  children: ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/40">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 py-12">
+        <div className="mb-8 flex items-center gap-2">
+          <span className="w-9 h-9 rounded-xl bg-gradient-to-br from-blue-600 to-indigo-600 text-white flex items-center justify-center shadow-sm">
+            <GraduationCap className="w-5 h-5" aria-hidden="true" />
+          </span>
+          <span className="font-bold text-slate-900 text-lg">AISigner</span>
+        </div>
+
+        <article className="bg-white rounded-2xl border border-slate-200/80 shadow-sm p-8 sm:p-10">
+          <h1 className="text-3xl font-bold text-slate-900 tracking-tight">{title}</h1>
+          <p className="text-slate-400 text-sm mt-1.5">Son güncelleme: {updatedAt}</p>
+
+          <div className="mt-8 space-y-6 text-slate-600 leading-relaxed [&_h2]:text-lg [&_h2]:font-semibold [&_h2]:text-slate-900 [&_h2]:mt-8 [&_h2]:mb-2 [&_p]:text-sm [&_li]:text-sm [&_ul]:list-disc [&_ul]:pl-5 [&_ul]:space-y-1.5">
+            {children}
+          </div>
+        </article>
+
+        <div className="mt-6 flex items-center justify-between gap-4">
+          <Link
+            href="/signup"
+            className="inline-flex items-center text-sm text-slate-500 hover:text-slate-700 transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4 mr-1" aria-hidden="true" />
+            Kayıt sayfasına dön
+          </Link>
+          <Link
+            href={crossLink.href}
+            className="text-sm text-blue-600 hover:text-blue-700 font-medium transition-colors"
+          >
+            {crossLink.label}
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,7 +13,8 @@ const protectedRoutes: Record<string, string> = {
 
 // Auth gerektirmeyen public sayfalar
 // NOT: /forgot-password oturumsuz kullanıcılar için erişilebilir olmalı (şifre sıfırlama).
-const publicPaths = ["/signin", "/signup", "/forgot-password", "/api/auth", "/api/health"];
+// #171: /terms ve /privacy oturumsuz da okunabilmeli (kayıt ekranı bunlara link verir).
+const publicPaths = ["/signin", "/signup", "/forgot-password", "/terms", "/privacy", "/api/auth", "/api/health"];
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;


### PR DESCRIPTION
Kayıt ekranı `/terms`'e link veriyordu ama **sayfa yoktu → 404** (#154). Demoda/canlıda görünür bir kırıktı.

## Ne yapıldı
- **`/terms`** (Kullanım Koşulları) ve **`/privacy`** (Gizlilik Politikası) sayfaları
- Ortak `LegalPage` kabuğu; içerik AISigner platformuna özgü, sade Türkçe (hesap/onay akışı, AI özellikleri, mesaj/öneri görünürlüğü, argon2 hash gibi gerçek davranışlara referanslı)
- İki sayfa birbirine çapraz bağlantılı + "Kayıt sayfasına dön"
- `middleware` public yollarına `/terms` + `/privacy` eklendi (oturumsuz okunabilmeli — kullanıcı kayıt sırasında okur)
- 3 render testi

## Çakışma önlemi
signup ekranına **bilerek dokunulmadı** — #157 ve #170 zaten o dosyada açık. Mevcut `/terms` linki artık gerçek içerik gösteriyor; gizliliğe erişim koşullar sayfasından çapraz bağlantıyla veriliyor.

## Doğrulama
- `npm test` → 242/242 ✓ (3 yeni)
- `npm run lint` → 0 hata
- `npm run build` → ✓ (`/terms`, `/privacy` statik prerender)

Closes #154
Refs #126