### PR TITLE
chore: #175 sonrasi teknik borc — yetki, overwrite guvenligi, simulasyon etiketi, testler

### DIFF
--- a/src/app/(admin)/admin-dashboard/assignments/page.tsx
+++ b/src/app/(admin)/admin-dashboard/assignments/page.tsx
@@ -414,8 +414,18 @@ export default function AdminAssignmentsPage() {
             </div>
 
             <p className="text-xs text-slate-500 dark:text-slate-400">
-              Bu işlem, <strong className="text-slate-700 dark:text-slate-200">Posinowa</strong> GitHub organizasyonunda öğrenciye özel repository oluşturacak, fazları Milestone olarak ekleyecek ve her fazın altında AI tarafından detaylandırılmış görev Issue&apos;larını otomatik açacaktır.
+              Bu akış, <strong className="text-slate-700 dark:text-slate-200">Posinowa</strong> organizasyonu için öğrenciye özel repo, faz (Milestone) ve AI ile detaylandırılmış görev (Issue) yapısını hazırlar.
             </p>
+
+            {/* #178-1: Bu özellik şu an ÖNİZLEME/simülasyondur — dürüstçe belirtilir. */}
+            <div className="mt-3 flex items-start gap-2 rounded-xl bg-amber-50 dark:bg-amber-950/40 border border-amber-200 dark:border-amber-900/50 px-3 py-2 text-xs text-amber-700 dark:text-amber-300">
+              <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" aria-hidden="true" />
+              <span>
+                <strong>Önizleme:</strong> Bu işlem şu an bir <strong>simülasyondur</strong>. AI görev
+                içerikleri gerçekten üretilip kaydedilir, ancak GitHub&apos;da fiziksel bir repo/issue
+                <strong> oluşturulmaz</strong> — üretilen linkler yer tutucudur. Gerçek GitHub entegrasyonu ayrı olarak planlanmaktadır.
+              </span>
+            </div>
 
             <div className="flex items-center justify-end gap-3 pt-2">
               <button

--- a/src/app/api/admin/assignments/route.test.ts
+++ b/src/app/api/admin/assignments/route.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, progressMock, provisionMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  progressMock: vi.fn(),
+  provisionMock: vi.fn(),
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+}));
+vi.mock("@/features/admin/server/assignment-progress", () => ({
+  getStudentAssignmentsProgress: (...a: unknown[]) => progressMock(...a),
+}));
+vi.mock("@/features/github/server/provisioning", () => ({
+  provisionGitHubWorkspace: (...a: unknown[]) => provisionMock(...a),
+}));
+
+import { GET, POST } from "./route";
+
+function admin() {
+  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id: "admin-1", role: "ADMIN" } } });
+}
+function forbidden() {
+  requireAuthMock.mockResolvedValue({ authorized: false, response: new Response(JSON.stringify({ error: "x" }), { status: 403 }) });
+}
+function postReq(body: unknown) {
+  return new Request("http://test/api/admin/assignments", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("admin/assignments route (#178-3)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("GET admin değil → 403, veri çekilmez", async () => {
+    forbidden();
+    const res = await GET();
+    expect(res.status).toBe(403);
+    expect(progressMock).not.toHaveBeenCalled();
+  });
+
+  it("GET admin → 200 ve ilerleme verisi döner", async () => {
+    admin();
+    progressMock.mockResolvedValue([{ id: "a1" }]);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(progressMock).toHaveBeenCalled();
+  });
+
+  it("POST admin değil → 403, provisioning çağrılmaz", async () => {
+    forbidden();
+    const res = await POST(postReq({ assignmentId: "a1" }));
+    expect(res.status).toBe(403);
+    expect(provisionMock).not.toHaveBeenCalled();
+  });
+
+  it("POST geçersiz assignmentId → 400, provisioning çağrılmaz", async () => {
+    admin();
+    const res = await POST(postReq({ assignmentId: 123 }));
+    expect(res.status).toBe(400);
+    expect(provisionMock).not.toHaveBeenCalled();
+  });
+
+  it("POST geçerli → provisioning çağrılır ve sonucu döner", async () => {
+    admin();
+    provisionMock.mockResolvedValue({ success: true, simulated: true });
+    const res = await POST(postReq({ assignmentId: "a1" }));
+    expect(res.status).toBe(200);
+    expect(provisionMock).toHaveBeenCalledWith("a1");
+  });
+});

--- a/src/app/api/mentor/generate-roadmap/route.test.ts
+++ b/src/app/api/mentor/generate-roadmap/route.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, prismaMock, generateRoadmapMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  prismaMock: {
+    assignedProject: { findUnique: vi.fn() },
+    roadmap: { delete: vi.fn(), create: vi.fn() },
+  },
+  generateRoadmapMock: vi.fn(),
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...a: unknown[]) => requireAuthMock(...a),
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+vi.mock("@/features/ai/server/generate-roadmap", () => ({
+  generateRoadmap: (...a: unknown[]) => generateRoadmapMock(...a),
+}));
+// Rate limiter: testte hep izin ver.
+vi.mock("@/lib/rate-limit", () => ({
+  createRateLimiter: () => ({ check: () => ({ allowed: true }) }),
+}));
+
+import { POST } from "./route";
+
+const MENTOR_ID = "mentor-1";
+function mentor() {
+  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id: MENTOR_ID, role: "MENTOR" } } });
+}
+function req(body: unknown) {
+  return new Request("http://test/api/mentor/generate-roadmap", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+/** Bu mentöre ait, verilen roadmap durumuyla atanmış proje. */
+function assignedProject(roadmap: { id: string; status: string } | null) {
+  return {
+    id: "ap-1",
+    studentProfile: { mentorId: MENTOR_ID },
+    projectTemplate: { title: "Proje" },
+    roadmap,
+  };
+}
+
+describe("generate-roadmap overwrite koruması (#178-4)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    generateRoadmapMock.mockResolvedValue([]);
+    prismaMock.roadmap.create.mockResolvedValue({ id: "r-new", steps: [] });
+  });
+
+  it("MENTOR değil → guard yanıtı döner (403)", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: false, response: new Response(null, { status: 403 }) });
+    const res = await POST(req({ assignedProjectId: "ap-1" }));
+    expect(res.status).toBe(403);
+    expect(prismaMock.assignedProject.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("başkasının öğrencisi → 403", async () => {
+    mentor();
+    prismaMock.assignedProject.findUnique.mockResolvedValue({
+      ...assignedProject(null),
+      studentProfile: { mentorId: "baska-mentor" },
+    });
+    const res = await POST(req({ assignedProjectId: "ap-1" }));
+    expect(res.status).toBe(403);
+  });
+
+  it("PUBLISHED roadmap + overwrite → 409, SİLME YAPILMAZ (öğrenci ilerlemesi korunur)", async () => {
+    mentor();
+    prismaMock.assignedProject.findUnique.mockResolvedValue(
+      assignedProject({ id: "r-1", status: "PUBLISHED" }),
+    );
+
+    const res = await POST(req({ assignedProjectId: "ap-1", overwrite: true }));
+
+    expect(res.status).toBe(409);
+    expect(prismaMock.roadmap.delete).not.toHaveBeenCalled();
+    expect(prismaMock.roadmap.create).not.toHaveBeenCalled();
+  });
+
+  it("DRAFT roadmap + overwrite → eski silinir, yenisi üretilir", async () => {
+    mentor();
+    prismaMock.assignedProject.findUnique.mockResolvedValue(
+      assignedProject({ id: "r-1", status: "DRAFT" }),
+    );
+
+    const res = await POST(req({ assignedProjectId: "ap-1", overwrite: true }));
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.roadmap.delete).toHaveBeenCalledWith({ where: { id: "r-1" } });
+    expect(prismaMock.roadmap.create).toHaveBeenCalled();
+  });
+
+  it("roadmap var + overwrite yok → 400, silme yok", async () => {
+    mentor();
+    prismaMock.assignedProject.findUnique.mockResolvedValue(
+      assignedProject({ id: "r-1", status: "DRAFT" }),
+    );
+
+    const res = await POST(req({ assignedProjectId: "ap-1" }));
+
+    expect(res.status).toBe(400);
+    expect(prismaMock.roadmap.delete).not.toHaveBeenCalled();
+  });
+
+  it("overwrite boolean değilse → 400 (Zod)", async () => {
+    mentor();
+    const res = await POST(req({ assignedProjectId: "ap-1", overwrite: "evet" }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/mentor/generate-roadmap/route.ts
+++ b/src/app/api/mentor/generate-roadmap/route.ts
@@ -56,17 +56,29 @@ export async function POST(req: Request) {
       );
     }
 
-    // 3. Eğer zaten bir yol haritası varsa ve overwrite istenmemişse uyarı veriyoruz
-    const bodyObj = body as { overwrite?: boolean };
+    // 3. Zaten bir yol haritası varsa: overwrite istenmemişse uyar; istenmişse
+    //    yalnızca DRAFT ise sil (#178-4).
     if (assignedProject.roadmap) {
-      if (bodyObj.overwrite) {
-        // Eski adımları ve roadmap'i temizle, Posilog ile yeniden üret
+      if (parsed.data.overwrite) {
+        // #178-4: PUBLISHED roadmap öğrenci erişimindedir — silme, adımlara bağlı
+        // yorum/dosya/issue kayıtlarını cascade götürür (geri dönüşsüz veri kaybı).
+        // Bu yüzden yalnızca henüz yayınlanmamış (DRAFT) roadmap silinebilir.
+        if (assignedProject.roadmap.status !== "DRAFT") {
+          return NextResponse.json(
+            {
+              error:
+                "Yayınlanmış bir yol haritası yeniden üretilerek silinemez. Öğrencinin ilerlemesini korumak için bu işlem yalnızca taslak (DRAFT) yol haritalarında yapılabilir.",
+            },
+            { status: 409 }
+          );
+        }
+        // Eski taslağı temizle, Posilog ile yeniden üret
         await prisma.roadmap.delete({
           where: { id: assignedProject.roadmap.id },
         });
       } else {
         return NextResponse.json(
-          { error: "Bu proje için zaten bir yol haritası oluşturulmuş!" }, 
+          { error: "Bu proje için zaten bir yol haritası oluşturulmuş!" },
           { status: 400 }
         );
       }

--- a/src/app/api/mentor/roadmap/[roadmapId]/ai-step/route.test.ts
+++ b/src/app/api/mentor/roadmap/[roadmapId]/ai-step/route.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, prismaMock, getModelMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  prismaMock: { roadmap: { findUnique: vi.fn() } },
+  getModelMock: vi.fn(),
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...a: unknown[]) => requireAuthMock(...a),
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/ai/gemini-client", () => ({ getModel: (...a: unknown[]) => getModelMock(...a) }));
+
+import { POST } from "./route";
+
+const ctx = { params: Promise.resolve({ roadmapId: "r-1" }) };
+function req(body: unknown = {}) {
+  return new Request("http://test/api/mentor/roadmap/r-1/ai-step", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("mentor ai-step route — yetki (#178-3)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("MENTOR rolü zorunlu — guard'a geçirilir", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: false, response: new Response(null, { status: 403 }) });
+    const res = await POST(req(), ctx);
+    expect(res.status).toBe(403);
+    expect(requireAuthMock).toHaveBeenCalledWith("MENTOR");
+    expect(prismaMock.roadmap.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("roadmap yoksa 404", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id: "m", role: "MENTOR" } } });
+    prismaMock.roadmap.findUnique.mockResolvedValue(null);
+    const res = await POST(req(), ctx);
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/features/admin/server/assignment-progress.test.ts
+++ b/src/features/admin/server/assignment-progress.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, prismaMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  prismaMock: { assignedProject: { findMany: vi.fn() } },
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+
+import { getStudentAssignmentsProgress } from "./assignment-progress";
+
+describe("getStudentAssignmentsProgress — yetki (#178-2)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.assignedProject.findMany.mockResolvedValue([]);
+  });
+
+  it("ADMIN rolü guard'a geçirilir", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id: "a", role: "ADMIN" } } });
+
+    await getStudentAssignmentsProgress();
+
+    expect(requireAuthMock).toHaveBeenCalledWith(["ADMIN"]);
+  });
+
+  it("yetkisizse hata fırlatır ve DB'ye HİÇ gidilmez", async () => {
+    requireAuthMock.mockResolvedValue({
+      authorized: false,
+      response: new Response(null, { status: 403 }),
+    });
+
+    await expect(getStudentAssignmentsProgress()).rejects.toThrow();
+    expect(prismaMock.assignedProject.findMany).not.toHaveBeenCalled();
+  });
+
+  it("yetkiliyse veriyi döndürür", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id: "a", role: "ADMIN" } } });
+    prismaMock.assignedProject.findMany.mockResolvedValue([]);
+
+    const res = await getStudentAssignmentsProgress();
+
+    expect(Array.isArray(res)).toBe(true);
+    expect(prismaMock.assignedProject.findMany).toHaveBeenCalled();
+  });
+});

--- a/src/features/admin/server/assignment-progress.ts
+++ b/src/features/admin/server/assignment-progress.ts
@@ -31,7 +31,14 @@ export type StudentAssignmentProgress = {
  * Admin için tüm öğrencilerin projedeki canlı ilerleme durumunu ve atamalarını çeker.
  */
 export async function getStudentAssignmentsProgress(): Promise<StudentAssignmentProgress[]> {
-  await requireAuth(["ADMIN"]);
+  // Güvenlik (#178-2): requireAuth hata FIRLATMAZ, { authorized } döndürür.
+  // Dönüş değeri kontrol edilmezse kontrol işlevsizdir. provisioning.ts ile
+  // birebir aynı desen — çağıran route ADMIN kontrolü yapsa da savunma-derinliği
+  // için burada da açıkça reddediyoruz.
+  const auth = await requireAuth(["ADMIN"]);
+  if (!auth.authorized) {
+    throw new Error("Bu işlem için yönetici yetkisi gerekiyor");
+  }
 
   const assignments = await prisma.assignedProject.findMany({
     include: {

--- a/src/features/github/server/provisioning.test.ts
+++ b/src/features/github/server/provisioning.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, prismaMock, genIssuesMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  prismaMock: {
+    assignedProject: { findUnique: vi.fn(), update: vi.fn() },
+    roadmapStep: { update: vi.fn() },
+    stepIssue: { findMany: vi.fn(), update: vi.fn() },
+  },
+  genIssuesMock: vi.fn(),
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...a: unknown[]) => requireAuthMock(...a),
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+vi.mock("@/features/ai/server/issue-generator", () => ({
+  generateStepIssues: (...a: unknown[]) => genIssuesMock(...a),
+}));
+vi.mock("@/lib/logger", () => ({ logger: { info: vi.fn(), error: vi.fn() } }));
+
+import { provisionGitHubWorkspace } from "./provisioning";
+
+function admin() {
+  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id: "a", role: "ADMIN" } } });
+}
+
+describe("provisionGitHubWorkspace (#178-1/2/3)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    genIssuesMock.mockResolvedValue([]);
+    prismaMock.stepIssue.findMany.mockResolvedValue([]);
+    prismaMock.assignedProject.update.mockResolvedValue({});
+    prismaMock.roadmapStep.update.mockResolvedValue({});
+  });
+
+  it("yetkisizse hata fırlatır, DB'ye gidilmez", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: false, response: new Response(null, { status: 403 }) });
+    await expect(provisionGitHubWorkspace("ap-1")).rejects.toThrow();
+    expect(prismaMock.assignedProject.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("atama yoksa hata fırlatır", async () => {
+    admin();
+    prismaMock.assignedProject.findUnique.mockResolvedValue(null);
+    await expect(provisionGitHubWorkspace("yok")).rejects.toThrow(/bulunamadı/i);
+  });
+
+  it("başarı: simulated=true döner ve mesaj simülasyon olduğunu belirtir", async () => {
+    admin();
+    prismaMock.assignedProject.findUnique.mockResolvedValue({
+      id: "ap-1",
+      studentProfile: { user: { name: "Ali" }, experienceLevel: "BEGINNER" },
+      projectTemplate: { title: "Proje" },
+      roadmap: { steps: [{ id: "s1", title: "Faz 1", description: "d" }] },
+    });
+
+    const res = await provisionGitHubWorkspace("ap-1");
+
+    expect(res.simulated).toBe(true);
+    expect(res.success).toBe(true);
+    expect(res.message.toLowerCase()).toContain("simülasyon");
+  });
+});

--- a/src/features/github/server/provisioning.ts
+++ b/src/features/github/server/provisioning.ts
@@ -9,11 +9,23 @@ export type ProvisioningResult = {
   createdMilestonesCount: number;
   createdIssuesCount: number;
   message: string;
+  /** #178-1: Bu sonucun gerçek GitHub değil, ÖNİZLEME (simülasyon) olduğunu belirtir. */
+  simulated: true;
 };
 
 /**
- * Admin tarafından onaylanan proje için GitHub Reposunu, Milestones (Fazlar) ve
- * detaylı AI Issue'larını oluşturan servis.
+ * ⚠️ #178-1: SİMÜLASYON / ÖNİZLEME — GERÇEK GITHUB ENTEGRASYONU DEĞİLDİR.
+ *
+ * Bu servis GERÇEK GitHub API'sine (Octokit/GITHUB_TOKEN) bağlanmaz. Repo,
+ * Milestone ve Issue URL'lerini yalnızca **string olarak türetir** ve DB'ye yazar;
+ * GitHub'da fiziksel olarak hiçbir şey oluşturmaz. Bu yüzden üretilen "Repo'ya Git"
+ * ve issue linkleri gerçek hayatta 404 verir — akışın önizlemesini göstermek içindir.
+ *
+ * AI ile üretilen görev (Issue) içerikleri gerçektir ve DB'de saklanır; yalnızca
+ * GitHub'a **push edilmeleri** simüledir.
+ *
+ * Gerçek entegrasyon (Octokit + GitHub App/token, org izinleri, hata/rate-limit
+ * yönetimi) ayrı bir issue'da ele alınacaktır — bkz. #179.
  */
 export async function provisionGitHubWorkspace(assignmentId: string): Promise<ProvisioningResult> {
   // Güvenlik: requireAuth hata FIRLATMAZ, { authorized } döndürür. Dönüş değeri
@@ -130,7 +142,9 @@ export async function provisionGitHubWorkspace(assignmentId: string): Promise<Pr
       githubRepoUrl,
       createdMilestonesCount: milestonesCount,
       createdIssuesCount,
-      message: `${githubRepoUrl} de deposu, ${milestonesCount} faz ve ${createdIssuesCount} detaylı issue oluşturuldu.`,
+      simulated: true,
+      // #178-1: "oluşturuldu" değil "önizlendi" — GitHub'da fiziksel bir şey yaratılmadı.
+      message: `Önizleme: ${milestonesCount} faz ve ${createdIssuesCount} detaylı issue hazırlandı. (Not: Bu bir simülasyondur; GitHub'da gerçek repo/issue oluşturulmaz.)`,
     };
   } catch (error) {
     logger.error("GitHub workspace oluşturulurken hata oluştu", { assignmentId, error });

--- a/src/lib/validations/api.ts
+++ b/src/lib/validations/api.ts
@@ -106,6 +106,9 @@ export const assignProjectSchema = z.object({
 // Mentor: Roadmap oluşturma
 export const generateRoadmapSchema = z.object({
   assignedProjectId: z.string().min(1, "Atanmış proje ID gerekli"),
+  // #178-4: Var olan yol haritasını silip yeniden üretme. Ham `as` cast yerine
+  // şemadan geçer; route yalnızca DRAFT roadmap için siler (PUBLISHED korunur).
+  overwrite: z.boolean().optional(),
 });
 
 // Mentor: AI proje önerisi


### PR DESCRIPTION
Yusuf'un #178 post-merge incelemesindeki 4 maddeyi kapatır. Her madde ayrı commit.

## Madde 2 — Etkisiz yetki kontrolü (`assignment-progress.ts`)
`requireAuth(["ADMIN"])` dönüş değeri kontrol edilmiyordu → kontrol işlevsizdi (provisioning.ts'te düzeltilmişti, kardeş dosya atlanmıştı). Artık `auth.authorized` kontrol edilip yetkisizse hata fırlatılıyor. *(Benim önceki güvenlik incelememde kaçırdığım nokta — Yusuf yakaladı.)*

## Madde 4 — `overwrite` cascade silme güvenliği (`generate-roadmap`)
- `overwrite` artık **Zod'dan** geçiyor (`generateRoadmapSchema`), ham `as` cast kaldırıldı
- Silme yalnızca **DRAFT** roadmap'te yapılabilir; `PUBLISHED` → **409** (öğrencinin üzerinde çalıştığı yol haritası + bağlı yorum/dosya/issue korunur)
- Meşru "taslağı yeniden üret" akışı korunur

## Madde 1 — Sahte GitHub entegrasyonu → net "önizleme" etiketi
Provisioning gerçek GitHub API'sine bağlanmıyor (URL'leri string olarak türetir). Artık **dürüstçe işaretlendi**:
- `provisioning.ts`: belirgin JSDoc uyarısı + `simulated: true` bayrağı + mesaj "oluşturuldu" yerine "önizlendi"
- Assignments onay modalında görünür **amber uyarı**: "Bu bir simülasyondur, GitHub'da gerçek repo/issue oluşturulmaz"
- Gerçek entegrasyon ayrı issue'ya bırakıldı → **#179**

## Madde 3 — Yeni iş mantığı için testler
`vi.hoisted` deseniyle **5 dosya, 19 test**: yetki sınırları (401/403, DB'ye gidilmemesi), başarılı akış, geçersiz girdi, ve **güvenlik düzeltmelerinin regresyon kilidi**. Madde 4'ün DRAFT koruması geri alınınca PUBLISHED testi düşüyor (kanıtlandı).

## Doğrulama
- `npm test` → **318/318** ✓ (299 → +19)
- `npm run lint` → 0 hata
- `npm run build` → ✓

Closes #178
Refs #160, #179