### PR TITLE
chore: dosya ve yorum silme/duzenleme yetki testleri (IDOR kilidi)

### DIFF
--- a/src/app/api/steps/[stepId]/comments/[commentId]/route.test.ts
+++ b/src/app/api/steps/[stepId]/comments/[commentId]/route.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, prismaMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  prismaMock: {
+    stepComment: { findUnique: vi.fn(), update: vi.fn(), delete: vi.fn() },
+    roadmapStep: { findUnique: vi.fn() },
+  },
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...a: unknown[]) => requireAuthMock(...a),
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+
+import { PUT, DELETE } from "./route";
+
+function authAs(id: string, role: "MENTOR" | "STUDENT" = "STUDENT") {
+  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id, role } } });
+}
+const params = (stepId = "step-1", commentId = "c-1") => Promise.resolve({ stepId, commentId });
+function req(body: unknown) {
+  return new Request("http://test", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("yorum düzenle/sil — yetki sınırları (#181)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // ---- PUT (düzenle) ----
+  it("PUT: başkasının yorumu → 403, güncelleme yok", async () => {
+    authAs("student-1");
+    prismaMock.stepComment.findUnique.mockResolvedValue({ id: "c-1", stepId: "step-1", authorId: "baskasi" });
+
+    const res = await PUT(req({ content: "yeni" }), { params: params() });
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.stepComment.update).not.toHaveBeenCalled();
+  });
+
+  it("PUT: kendi yorumu → 200, güncellenir", async () => {
+    authAs("student-1");
+    prismaMock.stepComment.findUnique.mockResolvedValue({ id: "c-1", stepId: "step-1", authorId: "student-1" });
+    prismaMock.stepComment.update.mockResolvedValue({ id: "c-1", content: "yeni" });
+
+    const res = await PUT(req({ content: "yeterince uzun yorum" }), { params: params() });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.stepComment.update).toHaveBeenCalled();
+  });
+
+  it("PUT: yorum başka adıma aitse → 400", async () => {
+    authAs("student-1");
+    prismaMock.stepComment.findUnique.mockResolvedValue({ id: "c-1", stepId: "baska-step", authorId: "student-1" });
+
+    const res = await PUT(req({ content: "x" }), { params: params() });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("PUT: yorum yoksa → 404", async () => {
+    authAs("student-1");
+    prismaMock.stepComment.findUnique.mockResolvedValue(null);
+
+    const res = await PUT(req({ content: "x" }), { params: params() });
+
+    expect(res.status).toBe(404);
+  });
+
+  // ---- DELETE (sil) ----
+  it("DELETE: yorum sahibi → siler", async () => {
+    authAs("student-1");
+    prismaMock.stepComment.findUnique.mockResolvedValue({ id: "c-1", stepId: "step-1", authorId: "student-1" });
+
+    const res = await DELETE(req({}), { params: params() });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.stepComment.delete).toHaveBeenCalledWith({ where: { id: "c-1" } });
+  });
+
+  it("DELETE: öğrencinin mentörü → siler (başkasının yorumu olsa da)", async () => {
+    authAs("mentor-1", "MENTOR");
+    prismaMock.stepComment.findUnique.mockResolvedValue({ id: "c-1", stepId: "step-1", authorId: "student-1" });
+    prismaMock.roadmapStep.findUnique.mockResolvedValue({
+      roadmap: { assignedProject: { studentProfile: { mentorId: "mentor-1" } } },
+    });
+
+    const res = await DELETE(req({}), { params: params() });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.stepComment.delete).toHaveBeenCalled();
+  });
+
+  it("DELETE: ne sahip ne mentör → 403, silme yok", async () => {
+    authAs("baska-mentor", "MENTOR");
+    prismaMock.stepComment.findUnique.mockResolvedValue({ id: "c-1", stepId: "step-1", authorId: "student-1" });
+    prismaMock.roadmapStep.findUnique.mockResolvedValue({
+      roadmap: { assignedProject: { studentProfile: { mentorId: "gercek-mentor" } } },
+    });
+
+    const res = await DELETE(req({}), { params: params() });
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.stepComment.delete).not.toHaveBeenCalled();
+  });
+
+  it("DELETE: cross-step (yorum bu adıma ait değil) → 400", async () => {
+    authAs("student-1");
+    prismaMock.stepComment.findUnique.mockResolvedValue({ id: "c-1", stepId: "baska-step", authorId: "student-1" });
+
+    const res = await DELETE(req({}), { params: params() });
+
+    expect(res.status).toBe(400);
+    expect(prismaMock.stepComment.delete).not.toHaveBeenCalled();
+  });
+
+  it("yetkisiz (guard) → 403, DB'ye gidilmez", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: false, response: new Response(null, { status: 403 }) });
+
+    const res = await DELETE(req({}), { params: params() });
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.stepComment.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/steps/[stepId]/files/[fileId]/route.test.ts
+++ b/src/app/api/steps/[stepId]/files/[fileId]/route.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, prismaMock, unlinkMock, existsMock, readFileMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  prismaMock: { stepFile: { findUnique: vi.fn(), delete: vi.fn() } },
+  unlinkMock: vi.fn(),
+  existsMock: vi.fn(() => false),
+  readFileMock: vi.fn(),
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...a: unknown[]) => requireAuthMock(...a),
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+vi.mock("fs/promises", () => ({
+  unlink: (...a: unknown[]) => unlinkMock(...a),
+  readFile: (...a: unknown[]) => readFileMock(...a),
+}));
+vi.mock("fs", () => ({ existsSync: (...a: unknown[]) => existsMock(...a) }));
+
+import { DELETE, GET } from "./route";
+
+function authAs(id: string, role: "MENTOR" | "STUDENT" = "STUDENT") {
+  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id, role } } });
+}
+const params = (stepId = "step-1", fileId = "f-1") => Promise.resolve({ stepId, fileId });
+
+/** stepFile kaydı: yükleyen + öğrenci/mentör bilgisiyle. */
+function stepFile(over: { uploaderId: string; ownerUserId: string; mentorId: string | null; stepId?: string }) {
+  return {
+    id: "f-1",
+    stepId: over.stepId ?? "step-1",
+    uploaderId: over.uploaderId,
+    storedName: "abc.png",
+    fileName: "abc.png",
+    mimeType: "image/png",
+    step: {
+      roadmap: {
+        assignedProject: {
+          studentProfile: { userId: over.ownerUserId, mentorId: over.mentorId },
+        },
+      },
+    },
+  };
+}
+
+describe("dosya sil/indir — yetki sınırları (#181)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    existsMock.mockReturnValue(false);
+  });
+
+  // ---- DELETE ----
+  it("DELETE: yükleyen siler", async () => {
+    authAs("student-1");
+    prismaMock.stepFile.findUnique.mockResolvedValue(
+      stepFile({ uploaderId: "student-1", ownerUserId: "student-1", mentorId: "mentor-1" }),
+    );
+
+    const res = await DELETE(new Request("http://t", { method: "DELETE" }), { params: params() });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.stepFile.delete).toHaveBeenCalledWith({ where: { id: "f-1" } });
+  });
+
+  it("DELETE: öğrencinin mentörü siler (yüklemese de)", async () => {
+    authAs("mentor-1", "MENTOR");
+    prismaMock.stepFile.findUnique.mockResolvedValue(
+      stepFile({ uploaderId: "student-1", ownerUserId: "student-1", mentorId: "mentor-1" }),
+    );
+
+    const res = await DELETE(new Request("http://t", { method: "DELETE" }), { params: params() });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.stepFile.delete).toHaveBeenCalled();
+  });
+
+  it("DELETE: ne yükleyen ne mentör → 403, silme YOK", async () => {
+    authAs("baska-student");
+    prismaMock.stepFile.findUnique.mockResolvedValue(
+      stepFile({ uploaderId: "student-1", ownerUserId: "student-1", mentorId: "mentor-1" }),
+    );
+
+    const res = await DELETE(new Request("http://t", { method: "DELETE" }), { params: params() });
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.stepFile.delete).not.toHaveBeenCalled();
+    expect(unlinkMock).not.toHaveBeenCalled();
+  });
+
+  it("DELETE: başka öğrenci mentör rolüyle gelse de (o öğrencinin mentörü değil) → 403", async () => {
+    authAs("baska-mentor", "MENTOR");
+    prismaMock.stepFile.findUnique.mockResolvedValue(
+      stepFile({ uploaderId: "student-1", ownerUserId: "student-1", mentorId: "gercek-mentor" }),
+    );
+
+    const res = await DELETE(new Request("http://t", { method: "DELETE" }), { params: params() });
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.stepFile.delete).not.toHaveBeenCalled();
+  });
+
+  it("DELETE: dosya bulunamazsa → 404", async () => {
+    authAs("student-1");
+    prismaMock.stepFile.findUnique.mockResolvedValue(null);
+
+    const res = await DELETE(new Request("http://t", { method: "DELETE" }), { params: params() });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("DELETE: stepId uyuşmazlığı → 404", async () => {
+    authAs("student-1");
+    prismaMock.stepFile.findUnique.mockResolvedValue(
+      stepFile({ uploaderId: "student-1", ownerUserId: "student-1", mentorId: "m", stepId: "baska-step" }),
+    );
+
+    const res = await DELETE(new Request("http://t", { method: "DELETE" }), { params: params() });
+
+    expect(res.status).toBe(404);
+    expect(prismaMock.stepFile.delete).not.toHaveBeenCalled();
+  });
+
+  // ---- GET (indir) erişim kontrolü ----
+  it("GET: ne sahip ne mentör → 403", async () => {
+    authAs("yabanci");
+    prismaMock.stepFile.findUnique.mockResolvedValue(
+      stepFile({ uploaderId: "student-1", ownerUserId: "student-1", mentorId: "mentor-1" }),
+    );
+
+    const res = await GET(new Request("http://t"), { params: params() });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("GET: sahip öğrenci → dosya servis edilir", async () => {
+    authAs("student-1");
+    prismaMock.stepFile.findUnique.mockResolvedValue(
+      stepFile({ uploaderId: "student-1", ownerUserId: "student-1", mentorId: "mentor-1" }),
+    );
+    existsMock.mockReturnValue(true);
+    readFileMock.mockResolvedValue(Buffer.from("veri"));
+
+    const res = await GET(new Request("http://t"), { params: params() });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+  });
+
+  it("yetkisiz (guard) → 403, DB'ye gidilmez", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: false, response: new Response(null, { status: 403 }) });
+
+    const res = await DELETE(new Request("http://t", { method: "DELETE" }), { params: params() });
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.stepFile.findUnique).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
> #182'nin kural-uyumlu hâli. Önceki dal/başlık `test/`+`test:` ile başlıyordu; pr-guard'ın izin verdiği tipler feat/fix/chore/refactor/ci/docs olduğu için reddedildi. İçerik aynı. #182 kapatıldı.

İki güvenlik-hassas ucun (`steps/[stepId]/files/[fileId]`, `steps/[stepId]/comments/[commentId]`) **hiç testi yoktu.** Yetkilendirmeleri doğru ama testsiz oldukları için ileride sessizce bozulabilirdi (IDOR).

## Kapsam (`vi.hoisted`, 2 dosya, 18 test)
**Dosya:** DELETE yalnız yükleyen veya öğrencinin mentörü; başkası → 403 (DB silme + disk `unlink` yapılmaz); `stepId` uyuşmazlığı → 404; GET erişim (sahip/mentör) + `nosniff` başlığı.
**Yorum:** PUT yalnız sahip (başkasınınki → 403); DELETE sahip veya mentör; cross-step → 400.

## Regresyon kilidi kanıtlandı
Dosya silme yetki kontrolü kaldırılınca "izinsiz → 403" testleri düşüyor.

## Doğrulama
- `npm test` → 317/317 ✓ (+18)
- `npm run lint` → 0 hata

Closes #181
Refs #160