### PR TITLE
chore: IDOR/yetki route testleri — student steps, mentor roadmap/steps, unassign

### DIFF
--- a/src/app/api/mentor/roadmap/[roadmapId]/route.test.ts
+++ b/src/app/api/mentor/roadmap/[roadmapId]/route.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, prismaMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  prismaMock: { roadmap: { findUnique: vi.fn(), update: vi.fn() } },
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...a: unknown[]) => requireAuthMock(...a),
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+
+import { GET, PUT } from "./route";
+
+function mentor(id: string) {
+  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id, role: "MENTOR" } } });
+}
+const params = (roadmapId = "rm-1") => Promise.resolve({ roadmapId });
+function putReq(body: unknown) {
+  return new Request("http://t", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+/** Verilen mentöre ait roadmap. */
+function roadmap(mentorId: string | null) {
+  return {
+    id: "rm-1",
+    assignedProject: { studentProfile: { mentorId }, projectTemplate: {} },
+    steps: [],
+  };
+}
+
+describe("mentor roadmap GET/PUT — sahiplik (#184)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.roadmap.update.mockResolvedValue({ id: "rm-1", steps: [] });
+  });
+
+  it("MENTOR değil (guard) → 403", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: false, response: new Response(null, { status: 403 }) });
+    const res = await GET(new Request("http://t"), { params: params() });
+    expect(res.status).toBe(403);
+    expect(prismaMock.roadmap.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("GET: roadmap yok → 404", async () => {
+    mentor("mentor-1");
+    prismaMock.roadmap.findUnique.mockResolvedValue(null);
+    const res = await GET(new Request("http://t"), { params: params() });
+    expect(res.status).toBe(404);
+  });
+
+  it("GET: başka mentörün roadmap'i → 403", async () => {
+    mentor("mentor-1");
+    prismaMock.roadmap.findUnique.mockResolvedValue(roadmap("baska-mentor"));
+    const res = await GET(new Request("http://t"), { params: params() });
+    expect(res.status).toBe(403);
+  });
+
+  it("GET: kendi roadmap'i → 200", async () => {
+    mentor("mentor-1");
+    prismaMock.roadmap.findUnique.mockResolvedValue(roadmap("mentor-1"));
+    const res = await GET(new Request("http://t"), { params: params() });
+    expect(res.status).toBe(200);
+  });
+
+  it("PUT: başka mentörün roadmap'i → 403, güncelleme YOK", async () => {
+    mentor("mentor-1");
+    prismaMock.roadmap.findUnique.mockResolvedValue(roadmap("baska-mentor"));
+    const res = await PUT(putReq({ status: "PUBLISHED" }), { params: params() });
+    expect(res.status).toBe(403);
+    expect(prismaMock.roadmap.update).not.toHaveBeenCalled();
+  });
+
+  it("PUT: kendi roadmap'i → 200, güncellenir", async () => {
+    mentor("mentor-1");
+    prismaMock.roadmap.findUnique.mockResolvedValue(roadmap("mentor-1"));
+    const res = await PUT(putReq({ status: "PUBLISHED" }), { params: params() });
+    expect(res.status).toBe(200);
+    expect(prismaMock.roadmap.update).toHaveBeenCalled();
+  });
+
+  it("PUT: geçersiz status (Zod) → 400", async () => {
+    mentor("mentor-1");
+    const res = await PUT(putReq({ status: "YAYINDA" }), { params: params() });
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/mentor/roadmap/[roadmapId]/steps/[stepId]/route.test.ts
+++ b/src/app/api/mentor/roadmap/[roadmapId]/steps/[stepId]/route.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, prismaMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  prismaMock: {
+    roadmap: { findUnique: vi.fn() },
+    roadmapStep: { findUnique: vi.fn(), update: vi.fn(), delete: vi.fn(), findMany: vi.fn() },
+  },
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...a: unknown[]) => requireAuthMock(...a),
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+
+import { PUT, DELETE } from "./route";
+
+function mentor(id: string) {
+  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id, role: "MENTOR" } } });
+}
+const params = (roadmapId = "rm-1", stepId = "s-1") => Promise.resolve({ roadmapId, stepId });
+function roadmap(mentorId: string | null) {
+  return { id: "rm-1", assignedProject: { studentProfile: { mentorId } } };
+}
+function putReq(body: unknown) {
+  return new Request("http://t", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+function delReq(force = false) {
+  return new Request(`http://t/api/mentor/roadmap/rm-1/steps/s-1${force ? "?force=true" : ""}`, {
+    method: "DELETE",
+  });
+}
+
+describe("mentor step PUT/DELETE — sahiplik + force (#184)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.roadmapStep.update.mockResolvedValue({ id: "s-1" });
+    prismaMock.roadmapStep.delete.mockResolvedValue({});
+    prismaMock.roadmapStep.findMany.mockResolvedValue([]);
+  });
+
+  // ---- PUT ----
+  it("PUT: başka mentörün adımı → 403, güncelleme YOK", async () => {
+    mentor("mentor-1");
+    prismaMock.roadmap.findUnique.mockResolvedValue(roadmap("baska-mentor"));
+    const res = await PUT(putReq({ title: "Yeni" }), { params: params() });
+    expect(res.status).toBe(403);
+    expect(prismaMock.roadmapStep.update).not.toHaveBeenCalled();
+  });
+
+  it("PUT: roadmap yok → 404", async () => {
+    mentor("mentor-1");
+    prismaMock.roadmap.findUnique.mockResolvedValue(null);
+    const res = await PUT(putReq({ title: "Yeni" }), { params: params() });
+    expect(res.status).toBe(404);
+  });
+
+  it("PUT: kendi öğrencisinin adımı → 200, güncellenir", async () => {
+    mentor("mentor-1");
+    prismaMock.roadmap.findUnique.mockResolvedValue(roadmap("mentor-1"));
+    const res = await PUT(putReq({ title: "Güncel Başlık" }), { params: params() });
+    expect(res.status).toBe(200);
+    expect(prismaMock.roadmapStep.update).toHaveBeenCalled();
+  });
+
+  // ---- DELETE ----
+  it("DELETE: başka mentörün adımı → 403, silme YOK", async () => {
+    mentor("mentor-1");
+    prismaMock.roadmap.findUnique.mockResolvedValue(roadmap("baska-mentor"));
+    const res = await DELETE(delReq(), { params: params() });
+    expect(res.status).toBe(403);
+    expect(prismaMock.roadmapStep.delete).not.toHaveBeenCalled();
+  });
+
+  it("DELETE: TODO adım → silinir", async () => {
+    mentor("mentor-1");
+    prismaMock.roadmap.findUnique.mockResolvedValue(roadmap("mentor-1"));
+    prismaMock.roadmapStep.findUnique.mockResolvedValue({ status: "TODO" });
+    const res = await DELETE(delReq(), { params: params() });
+    expect(res.status).toBe(200);
+    expect(prismaMock.roadmapStep.delete).toHaveBeenCalledWith({ where: { id: "s-1" } });
+  });
+
+  it("DELETE: aktif adım (IN_PROGRESS) force'suz → 409, silme YOK (öğrenci ilerlemesi)", async () => {
+    mentor("mentor-1");
+    prismaMock.roadmap.findUnique.mockResolvedValue(roadmap("mentor-1"));
+    prismaMock.roadmapStep.findUnique.mockResolvedValue({ status: "IN_PROGRESS" });
+    const res = await DELETE(delReq(false), { params: params() });
+    expect(res.status).toBe(409);
+    expect(prismaMock.roadmapStep.delete).not.toHaveBeenCalled();
+  });
+
+  it("DELETE: aktif adım + force=true → silinir", async () => {
+    mentor("mentor-1");
+    prismaMock.roadmap.findUnique.mockResolvedValue(roadmap("mentor-1"));
+    prismaMock.roadmapStep.findUnique.mockResolvedValue({ status: "IN_PROGRESS" });
+    const res = await DELETE(delReq(true), { params: params() });
+    expect(res.status).toBe(200);
+    expect(prismaMock.roadmapStep.delete).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/mentor/unassign-project/route.test.ts
+++ b/src/app/api/mentor/unassign-project/route.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, unassignMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  unassignMock: vi.fn(),
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...a: unknown[]) => requireAuthMock(...a),
+}));
+vi.mock("@/features/mentors/server/actions", () => ({
+  unassignProject: (...a: unknown[]) => unassignMock(...a),
+}));
+
+import { DELETE } from "./route";
+
+function mentor(id: string) {
+  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id, role: "MENTOR" } } });
+}
+function req(body: unknown) {
+  return new Request("http://t", {
+    method: "DELETE",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("unassign-project route (#184)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("MENTOR değil (guard) → 403, action çağrılmaz", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: false, response: new Response(null, { status: 403 }) });
+    const res = await DELETE(req({ assignedProjectId: "ap-1" }));
+    expect(res.status).toBe(403);
+    expect(unassignMock).not.toHaveBeenCalled();
+  });
+
+  it("geçersiz gövde → 400", async () => {
+    mentor("mentor-1");
+    const res = await DELETE(req({}));
+    expect(res.status).toBe(400);
+    expect(unassignMock).not.toHaveBeenCalled();
+  });
+
+  it("mentorId gövdeden DEĞİL oturumdan alınır (spoof engeli)", async () => {
+    mentor("mentor-1");
+    unassignMock.mockResolvedValue({});
+    await DELETE(req({ assignedProjectId: "ap-1", mentorId: "baska-mentor", force: false }));
+    // 2. argüman: her zaman oturum sahibinin id'si
+    expect(unassignMock).toHaveBeenCalledWith("ap-1", "mentor-1", false);
+  });
+
+  it("action REQUIRES_CONFIRMATION fırlatırsa → 409", async () => {
+    mentor("mentor-1");
+    const err = Object.assign(new Error("onay gerekiyor"), { code: "REQUIRES_CONFIRMATION" });
+    unassignMock.mockRejectedValue(err);
+    const res = await DELETE(req({ assignedProjectId: "ap-1" }));
+    expect(res.status).toBe(409);
+  });
+
+  it("başarılı → 200", async () => {
+    mentor("mentor-1");
+    unassignMock.mockResolvedValue({});
+    const res = await DELETE(req({ assignedProjectId: "ap-1", force: true }));
+    expect(res.status).toBe(200);
+    expect(unassignMock).toHaveBeenCalledWith("ap-1", "mentor-1", true);
+  });
+});

--- a/src/app/api/student/steps/[stepId]/route.test.ts
+++ b/src/app/api/student/steps/[stepId]/route.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, prismaMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  prismaMock: {
+    roadmapStep: { findUnique: vi.fn(), update: vi.fn(), findMany: vi.fn() },
+    assignedProject: { update: vi.fn() },
+  },
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...a: unknown[]) => requireAuthMock(...a),
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+
+import { PATCH } from "./route";
+
+function student(id: string) {
+  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id, role: "STUDENT" } } });
+}
+const params = (stepId = "s-1") => Promise.resolve({ stepId });
+function req(body: unknown) {
+  return new Request("http://t", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Hedef adım "s-1" (order 1), önünde tamamlanmış "s-0" (order 0).
+ * ownerUserId: adımın ait olduğu öğrenci; roadmapStatus: yayın durumu.
+ */
+function stepGraph(over: {
+  ownerUserId: string;
+  roadmapStatus?: string;
+  targetStatus?: string;
+  prevStatus?: string;
+}) {
+  const target = { id: "s-1", order: 1, status: over.targetStatus ?? "TODO" };
+  const prev = { id: "s-0", order: 0, status: over.prevStatus ?? "COMPLETED" };
+  return {
+    id: "s-1",
+    status: target.status,
+    roadmapId: "rm-1",
+    roadmap: {
+      status: over.roadmapStatus ?? "PUBLISHED",
+      assignedProjectId: "ap-1",
+      assignedProject: {
+        id: "ap-1",
+        status: "IN_PROGRESS",
+        studentProfile: { userId: over.ownerUserId },
+      },
+      steps: [prev, target],
+    },
+  };
+}
+
+describe("student steps PATCH — IDOR + kurallar (#184)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.roadmapStep.update.mockResolvedValue({ id: "s-1", status: "IN_PROGRESS" });
+    prismaMock.roadmapStep.findMany.mockResolvedValue([]);
+    prismaMock.assignedProject.update.mockResolvedValue({});
+  });
+
+  it("STUDENT değil (guard) → 403, DB'ye gidilmez", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: false, response: new Response(null, { status: 403 }) });
+    const res = await PATCH(req({ status: "IN_PROGRESS" }), { params: params() });
+    expect(res.status).toBe(403);
+    expect(prismaMock.roadmapStep.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("IDOR: başka öğrencinin adımı → 403, güncelleme YOK", async () => {
+    student("student-1");
+    prismaMock.roadmapStep.findUnique.mockResolvedValue(stepGraph({ ownerUserId: "baska-ogrenci" }));
+
+    const res = await PATCH(req({ status: "IN_PROGRESS" }), { params: params() });
+
+    expect(res.status).toBe(403);
+    expect(prismaMock.roadmapStep.update).not.toHaveBeenCalled();
+  });
+
+  it("adım yoksa → 404", async () => {
+    student("student-1");
+    prismaMock.roadmapStep.findUnique.mockResolvedValue(null);
+    const res = await PATCH(req({ status: "IN_PROGRESS" }), { params: params() });
+    expect(res.status).toBe(404);
+  });
+
+  it("geçersiz status (Zod) → 400", async () => {
+    student("student-1");
+    const res = await PATCH(req({ status: "TODO" }), { params: params() });
+    expect(res.status).toBe(400);
+    expect(prismaMock.roadmapStep.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("roadmap PUBLISHED değilse → 400", async () => {
+    student("student-1");
+    prismaMock.roadmapStep.findUnique.mockResolvedValue(
+      stepGraph({ ownerUserId: "student-1", roadmapStatus: "DRAFT" }),
+    );
+    const res = await PATCH(req({ status: "IN_PROGRESS" }), { params: params() });
+    expect(res.status).toBe(400);
+    expect(prismaMock.roadmapStep.update).not.toHaveBeenCalled();
+  });
+
+  it("önceki adım tamamlanmadıysa → 400", async () => {
+    student("student-1");
+    prismaMock.roadmapStep.findUnique.mockResolvedValue(
+      stepGraph({ ownerUserId: "student-1", prevStatus: "IN_PROGRESS" }),
+    );
+    const res = await PATCH(req({ status: "IN_PROGRESS" }), { params: params() });
+    expect(res.status).toBe(400);
+  });
+
+  it("kendi yayınlanmış adımını başlatma → 200, güncellenir", async () => {
+    student("student-1");
+    prismaMock.roadmapStep.findUnique.mockResolvedValue(stepGraph({ ownerUserId: "student-1" }));
+
+    const res = await PATCH(req({ status: "IN_PROGRESS" }), { params: params() });
+
+    expect(res.status).toBe(200);
+    expect(prismaMock.roadmapStep.update).toHaveBeenCalledWith({
+      where: { id: "s-1" },
+      data: { status: "IN_PROGRESS" },
+    });
+  });
+
+  it("TODO adımı doğrudan COMPLETED yapmak → 400", async () => {
+    student("student-1");
+    prismaMock.roadmapStep.findUnique.mockResolvedValue(
+      stepGraph({ ownerUserId: "student-1", targetStatus: "TODO" }),
+    );
+    const res = await PATCH(req({ status: "COMPLETED" }), { params: params() });
+    expect(res.status).toBe(400);
+  });
+
+  it("tamamlanmış adımın durumu değiştirilemez → 400", async () => {
+    student("student-1");
+    prismaMock.roadmapStep.findUnique.mockResolvedValue(
+      stepGraph({ ownerUserId: "student-1", targetStatus: "COMPLETED" }),
+    );
+    const res = await PATCH(req({ status: "IN_PROGRESS" }), { params: params() });
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/features/mentors/server/unassign-project.test.ts
+++ b/src/features/mentors/server/unassign-project.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { prismaMock } = vi.hoisted(() => ({
+  prismaMock: { assignedProject: { findFirst: vi.fn(), delete: vi.fn() } },
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+
+import { unassignProject } from "./actions";
+
+/** Bu mentöre ait, verilen ilerleme durumuyla proje. */
+function ownedProject(over: {
+  status?: string;
+  roadmapStatus?: string | null;
+  stepStatuses?: string[];
+} = {}) {
+  return {
+    id: "ap-1",
+    status: over.status ?? "PENDING",
+    roadmap:
+      over.roadmapStatus === null
+        ? null
+        : {
+            status: over.roadmapStatus ?? "DRAFT",
+            steps: (over.stepStatuses ?? []).map((s) => ({ status: s })),
+          },
+  };
+}
+
+describe("unassignProject action — sahiplik + force (#184)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.assignedProject.delete.mockResolvedValue({});
+  });
+
+  it("IDOR: başka mentörün projesi (bulunamaz) → hata, silme YOK", async () => {
+    // findFirst where: { studentProfile: { mentorId } } — başka mentör için null döner
+    prismaMock.assignedProject.findFirst.mockResolvedValue(null);
+
+    await expect(unassignProject("ap-1", "mentor-1", false)).rejects.toThrow(/yetkiniz yok|bulunamadı/i);
+    expect(prismaMock.assignedProject.delete).not.toHaveBeenCalled();
+  });
+
+  it("sahiplik sorgusu mentorId ile sınırlıdır", async () => {
+    prismaMock.assignedProject.findFirst.mockResolvedValue(ownedProject());
+
+    await unassignProject("ap-1", "mentor-1", false);
+
+    const where = prismaMock.assignedProject.findFirst.mock.calls[0][0].where;
+    expect(where).toMatchObject({ id: "ap-1", studentProfile: { mentorId: "mentor-1" } });
+  });
+
+  it("ilerleme yoksa (PENDING, DRAFT) force'suz → siler", async () => {
+    prismaMock.assignedProject.findFirst.mockResolvedValue(ownedProject());
+
+    await unassignProject("ap-1", "mentor-1", false);
+
+    expect(prismaMock.assignedProject.delete).toHaveBeenCalledWith({ where: { id: "ap-1" } });
+  });
+
+  it("proje IN_PROGRESS + force'suz → REQUIRES_CONFIRMATION, silme YOK", async () => {
+    prismaMock.assignedProject.findFirst.mockResolvedValue(ownedProject({ status: "IN_PROGRESS" }));
+
+    await expect(unassignProject("ap-1", "mentor-1", false)).rejects.toMatchObject({
+      code: "REQUIRES_CONFIRMATION",
+    });
+    expect(prismaMock.assignedProject.delete).not.toHaveBeenCalled();
+  });
+
+  it("yayınlanmış roadmap + force'suz → REQUIRES_CONFIRMATION", async () => {
+    prismaMock.assignedProject.findFirst.mockResolvedValue(
+      ownedProject({ roadmapStatus: "PUBLISHED" }),
+    );
+
+    await expect(unassignProject("ap-1", "mentor-1", false)).rejects.toMatchObject({
+      code: "REQUIRES_CONFIRMATION",
+    });
+  });
+
+  it("adım ilerlemesi (COMPLETED) + force'suz → REQUIRES_CONFIRMATION", async () => {
+    prismaMock.assignedProject.findFirst.mockResolvedValue(
+      ownedProject({ stepStatuses: ["TODO", "COMPLETED"] }),
+    );
+
+    await expect(unassignProject("ap-1", "mentor-1", false)).rejects.toMatchObject({
+      code: "REQUIRES_CONFIRMATION",
+    });
+  });
+
+  it("ilerleme olsa bile force=true → siler", async () => {
+    prismaMock.assignedProject.findFirst.mockResolvedValue(ownedProject({ status: "IN_PROGRESS" }));
+
+    await unassignProject("ap-1", "mentor-1", true);
+
+    expect(prismaMock.assignedProject.delete).toHaveBeenCalledWith({ where: { id: "ap-1" } });
+  });
+});


### PR DESCRIPTION
Yetki açısından kritik ama testsiz uçlar için route/action testleri (yeni dosyalar → sıfır çakışma). Kırmızı öncelikli IDOR uçları.

## Kapsam (`vi.hoisted`, 6 dosya, 35 test)
- **`student/steps/[stepId]`** (PATCH): **başka öğrencinin adımı → 403**; yayın (PUBLISHED) / sıralama / geçiş kuralları
- **`mentor/roadmap/[roadmapId]`** (GET/PUT): **başka mentörün roadmap'i → 403**; Zod
- **`mentor/roadmap/[roadmapId]/steps/[stepId]`** (PUT/DELETE): sahiplik → 403; **aktif adım force'suz → 409** (öğrenci ilerlemesi korunur); force ile silme
- **`mentor/unassign-project`** (route): **mentorId gövdeden değil oturumdan** (spoof engeli); 409/400 akışı
- **`unassignProject`** (action, güvenlik çekirdeği): sahiplik `where`'i `mentorId` ile sınırlı; ilerleme koruması (force'suz `REQUIRES_CONFIRMATION`)

## Regresyon kilidi kanıtlandı
Öğrenci adım sahiplik kontrolü geçici kaldırılınca "başka öğrencinin adımı → 403" testi düşüyor — testler gerçekten IDOR'u kilitliyor, mevcut davranışı fotoğraflamıyor.

## Doğrulama
- `npm test` → **334/334** ✓ (299 → +35)
- `npm run lint` → 0 hata

## Çakışma
Yalnız yeni test dosyaları; açık #180/#183'ün dosyalarına dokunmuyor.

Closes #184
Refs #160