### PR TITLE
chore: orta oncelikli route testleri — approval, security-questions, template edit, student detail

### DIFF
--- a/src/app/api/admin/project-templates/[id]/route.test.ts
+++ b/src/app/api/admin/project-templates/[id]/route.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, updateMock, deleteMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  updateMock: vi.fn(),
+  deleteMock: vi.fn(),
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...a: unknown[]) => requireAuthMock(...a),
+}));
+vi.mock("@/features/projects/server/templates", () => ({
+  updateTemplate: (...a: unknown[]) => updateMock(...a),
+  deleteTemplate: (...a: unknown[]) => deleteMock(...a),
+}));
+
+import { PATCH, DELETE } from "./route";
+
+function admin() {
+  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id: "admin-1", role: "ADMIN" } } });
+}
+const ctx = (id = "tpl-1") => ({ params: Promise.resolve({ id }) });
+function patchReq(body: unknown) {
+  return new Request("http://t", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("admin project-template [id] PATCH/DELETE (#187)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("PATCH ADMIN değil → 403", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: false, response: new Response(null, { status: 403 }) });
+    const res = await PATCH(patchReq({ title: "Yeni" }), ctx());
+    expect(res.status).toBe(403);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("PATCH geçersiz gövde (boş title) → 400", async () => {
+    admin();
+    const res = await PATCH(patchReq({ title: "" }), ctx());
+    expect(res.status).toBe(400);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("PATCH başlık çakışması (DUPLICATE_TITLE) → 409", async () => {
+    admin();
+    updateMock.mockRejectedValue(Object.assign(new Error("dup"), { code: "DUPLICATE_TITLE" }));
+    const res = await PATCH(patchReq({ title: "Var Olan" }), ctx());
+    expect(res.status).toBe(409);
+  });
+
+  it("PATCH geçerli → 200", async () => {
+    admin();
+    updateMock.mockResolvedValue({ id: "tpl-1", title: "Yeni" });
+    const res = await PATCH(patchReq({ title: "Yeni Başlık" }), ctx());
+    expect(res.status).toBe(200);
+    expect(updateMock).toHaveBeenCalledWith("tpl-1", expect.objectContaining({ title: "Yeni Başlık" }));
+  });
+
+  it("DELETE ADMIN değil → 403", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: false, response: new Response(null, { status: 403 }) });
+    const res = await DELETE(new Request("http://t", { method: "DELETE" }), ctx());
+    expect(res.status).toBe(403);
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("DELETE ADMIN → siler", async () => {
+    admin();
+    deleteMock.mockResolvedValue({});
+    const res = await DELETE(new Request("http://t", { method: "DELETE" }), ctx());
+    expect(res.status).toBe(200);
+    expect(deleteMock).toHaveBeenCalledWith("tpl-1");
+  });
+});

--- a/src/app/api/admin/users/approval/route.test.ts
+++ b/src/app/api/admin/users/approval/route.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, updateStatusMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  updateStatusMock: vi.fn(),
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...a: unknown[]) => requireAuthMock(...a),
+}));
+vi.mock("@/features/admin/server/user", () => ({
+  updateAccountStatus: (...a: unknown[]) => updateStatusMock(...a),
+}));
+
+import { POST } from "./route";
+
+function admin(id = "admin-1") {
+  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id, role: "ADMIN" } } });
+}
+function req(body: unknown) {
+  return new Request("http://t", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("admin users approval (#187)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("ADMIN değil → 403, güncelleme yok", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: false, response: new Response(null, { status: 403 }) });
+    const res = await POST(req({ userId: "u1", accountStatus: "APPROVED" }));
+    expect(res.status).toBe(403);
+    expect(updateStatusMock).not.toHaveBeenCalled();
+  });
+
+  it("geçersiz accountStatus → 400", async () => {
+    admin();
+    const res = await POST(req({ userId: "u1", accountStatus: "SILINDI" }));
+    expect(res.status).toBe(400);
+    expect(updateStatusMock).not.toHaveBeenCalled();
+  });
+
+  it("admin kendi hesabını değiştiremez → 403", async () => {
+    admin("admin-1");
+    const res = await POST(req({ userId: "admin-1", accountStatus: "REJECTED" }));
+    expect(res.status).toBe(403);
+    expect(updateStatusMock).not.toHaveBeenCalled();
+  });
+
+  it("geçerli → updateAccountStatus çağrılır", async () => {
+    admin("admin-1");
+    updateStatusMock.mockResolvedValue({ id: "u1", accountStatus: "APPROVED" });
+    const res = await POST(req({ userId: "u1", accountStatus: "APPROVED" }));
+    expect(res.status).toBe(200);
+    expect(updateStatusMock).toHaveBeenCalledWith("u1", "APPROVED");
+  });
+});

--- a/src/app/api/auth/security-questions/route.test.ts
+++ b/src/app/api/auth/security-questions/route.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, prismaMock, hashMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  prismaMock: {
+    securityAnswer: { findMany: vi.fn(), deleteMany: vi.fn(), createMany: vi.fn() },
+  },
+  hashMock: vi.fn(),
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...a: unknown[]) => requireAuthMock(...a),
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+vi.mock("@node-rs/argon2", () => ({ hash: (...a: unknown[]) => hashMock(...a) }));
+
+import { GET, POST } from "./route";
+
+function authAs(id: string) {
+  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id, role: "STUDENT" } } });
+}
+function postReq(body: unknown) {
+  return new Request("http://t", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+const threeValid = [
+  { questionId: 0, answer: "tekir" },
+  { questionId: 1, answer: "istanbul" },
+  { questionId: 2, answer: "yilmaz" },
+];
+
+describe("security-questions (#187)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hashMock.mockResolvedValue("HASHED");
+    prismaMock.securityAnswer.deleteMany.mockResolvedValue({});
+    prismaMock.securityAnswer.createMany.mockResolvedValue({});
+  });
+
+  it("GET yetkisiz → 403", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: false, response: new Response(null, { status: 403 }) });
+    const res = await GET();
+    expect(res.status).toBe(403);
+  });
+
+  it("GET: yalnızca kendi userId'siyle sorgular, isSetup döner", async () => {
+    authAs("user-1");
+    prismaMock.securityAnswer.findMany.mockResolvedValue([{ questionId: 0 }, { questionId: 1 }, { questionId: 2 }]);
+    const json = await (await GET()).json();
+    expect(prismaMock.securityAnswer.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: "user-1" } }),
+    );
+    expect(json.isSetup).toBe(true);
+  });
+
+  it("POST: 3'ten az cevap → 400, yazma yok", async () => {
+    authAs("user-1");
+    const res = await POST(postReq({ answers: [{ questionId: 0, answer: "tekir" }] }));
+    expect(res.status).toBe(400);
+    expect(prismaMock.securityAnswer.createMany).not.toHaveBeenCalled();
+  });
+
+  it("POST: geçersiz soru numarası → 400", async () => {
+    authAs("user-1");
+    const res = await POST(postReq({ answers: [...threeValid, { questionId: 999, answer: "xx" }] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("POST: çok kısa cevap → 400", async () => {
+    authAs("user-1");
+    const res = await POST(postReq({ answers: [{ questionId: 0, answer: "a" }, { questionId: 1, answer: "b" }, { questionId: 2, answer: "c" }] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("POST geçerli: cevaplar HASH'lenir ve userId oturumdan alınır (düz metin saklanmaz)", async () => {
+    authAs("user-1");
+    const res = await POST(postReq({ answers: threeValid }));
+    expect(res.status).toBe(200);
+    // argon2 her cevap için çağrıldı
+    expect(hashMock).toHaveBeenCalledTimes(3);
+    // önce eskiler silinir (yalnız kendi userId)
+    expect(prismaMock.securityAnswer.deleteMany).toHaveBeenCalledWith({ where: { userId: "user-1" } });
+    // kaydedilen veride düz cevap YOK, hash var; userId oturumdan
+    const created = prismaMock.securityAnswer.createMany.mock.calls[0][0].data;
+    expect(created.every((r: { userId: string; answer: string }) => r.userId === "user-1")).toBe(true);
+    expect(created.every((r: { answer: string }) => r.answer === "HASHED")).toBe(true);
+    expect(JSON.stringify(created)).not.toContain("tekir");
+  });
+});

--- a/src/app/api/mentor/students/[studentId]/route.test.ts
+++ b/src/app/api/mentor/students/[studentId]/route.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, getStudentDetailMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  getStudentDetailMock: vi.fn(),
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...a: unknown[]) => requireAuthMock(...a),
+}));
+vi.mock("@/features/mentors/server/actions", () => ({
+  getStudentDetail: (...a: unknown[]) => getStudentDetailMock(...a),
+}));
+
+import { GET } from "./route";
+
+function mentor(id: string) {
+  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id, role: "MENTOR" } } });
+}
+const ctx = (studentId = "st-1") => ({ params: Promise.resolve({ studentId }) });
+
+describe("mentor student detail GET (#187)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("MENTOR değil → 403, veri çekilmez", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: false, response: new Response(null, { status: 403 }) });
+    const res = await GET(new Request("http://t"), ctx());
+    expect(res.status).toBe(403);
+    expect(getStudentDetailMock).not.toHaveBeenCalled();
+  });
+
+  it("sahiplik: getStudentDetail'e (studentId, oturumdaki mentorId) geçilir", async () => {
+    mentor("mentor-1");
+    getStudentDetailMock.mockResolvedValue({ id: "st-1" });
+    await GET(new Request("http://t"), ctx("st-1"));
+    // mentorId gövdeden değil oturumdan → başka mentörün öğrencisi çekilemez
+    expect(getStudentDetailMock).toHaveBeenCalledWith("st-1", "mentor-1");
+  });
+
+  it("öğrenci bu mentöre atanmamışsa (null) → 404", async () => {
+    mentor("mentor-1");
+    getStudentDetailMock.mockResolvedValue(null);
+    const res = await GET(new Request("http://t"), ctx());
+    expect(res.status).toBe(404);
+  });
+
+  it("kendi öğrencisi → 200", async () => {
+    mentor("mentor-1");
+    getStudentDetailMock.mockResolvedValue({ id: "st-1", name: "Ali" });
+    const res = await GET(new Request("http://t"), ctx());
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
Yetki-hassas ama testsiz orta öncelikli uçlar için route testleri (yeni dosyalar → sıfır çakışma).

## Kapsam (`vi.hoisted`, 4 dosya, 20 test)
- **`admin/users/approval`**: ADMIN; **admin kendi hesabının durumunu değiştiremez → 403**; Zod (geçersiz status → 400)
- **`auth/security-questions`**: cevaplar **argon2 ile hash'lenir** (düz metin saklanmaz), **userId oturumdan** (başkası adına yazılamaz); min cevap sayısı / geçerli soru no / min uzunluk → 400
- **`mentor/students/[studentId]`**: `getStudentDetail(studentId, oturumdaki mentorId)` — **başka mentörün öğrencisi çekilemez**; atanmamış → 404
- **`admin/project-templates/[id]`** (PATCH/DELETE): ADMIN; boş title → 400; **`DUPLICATE_TITLE` → 409**; silme

## Doğrulama
- `npm test` → **319/319** ✓ (299 → +20)
- `npm run lint` → 0 hata

## Çakışma
Yalnız yeni test dosyaları; açık #180/#183/#185'in dosyalarına dokunmuyor.

Closes #187
Refs #160