### PR TITLE
chore: kalan dusuk-oncelik route testleri — health, mentor students, admin mentors, ai-recommend

### DIFF
--- a/src/app/api/admin/mentors/route.test.ts
+++ b/src/app/api/admin/mentors/route.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, getMentorsMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  getMentorsMock: vi.fn(),
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...a: unknown[]) => requireAuthMock(...a),
+}));
+vi.mock("@/features/admin/server/user", () => ({
+  getMentors: (...a: unknown[]) => getMentorsMock(...a),
+}));
+
+import { GET } from "./route";
+
+describe("admin mentors list (#189)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("ADMIN değil → 403, liste çekilmez", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: false, response: new Response(null, { status: 403 }) });
+    const res = await GET();
+    expect(res.status).toBe(403);
+    expect(getMentorsMock).not.toHaveBeenCalled();
+  });
+
+  it("ADMIN → 200 ve liste döner", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id: "admin-1", role: "ADMIN" } } });
+    getMentorsMock.mockResolvedValue([{ id: "m1" }]);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(getMentorsMock).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/health/route.test.ts
+++ b/src/app/api/health/route.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { prismaMock } = vi.hoisted(() => ({
+  prismaMock: { $queryRaw: vi.fn() },
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+
+import { GET } from "./route";
+
+describe("health route (#189)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("DB erişilebilirse → 200 status:ok", async () => {
+    prismaMock.$queryRaw.mockResolvedValue([{ "?column?": 1 }]);
+    const res = await GET();
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.status).toBe("ok");
+  });
+
+  it("DB hatasında → 500 status:error", async () => {
+    prismaMock.$queryRaw.mockRejectedValue(new Error("connection refused"));
+    const res = await GET();
+    const json = await res.json();
+    expect(res.status).toBe(500);
+    expect(json.status).toBe("error");
+    // ham hata mesajı sızmamalı
+    expect(JSON.stringify(json)).not.toContain("connection refused");
+  });
+});

--- a/src/app/api/mentor/ai-recommend-projects/route.test.ts
+++ b/src/app/api/mentor/ai-recommend-projects/route.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, prismaMock, recommendMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  prismaMock: {
+    studentProfile: { findFirst: vi.fn() },
+    projectTemplate: { findMany: vi.fn() },
+  },
+  recommendMock: vi.fn(),
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...a: unknown[]) => requireAuthMock(...a),
+}));
+vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+vi.mock("@/features/ai/server/project-recommendations", () => ({
+  recommendProjects: (...a: unknown[]) => recommendMock(...a),
+}));
+// Rate limiter: testte hep izin ver.
+vi.mock("@/lib/rate-limit", () => ({
+  createRateLimiter: () => ({ check: () => ({ allowed: true }) }),
+}));
+
+import { POST } from "./route";
+
+function mentor(id = "mentor-1") {
+  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id, role: "MENTOR" } } });
+}
+function req(body: unknown) {
+  return new Request("http://t", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("ai-recommend-projects (#189)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    recommendMock.mockResolvedValue([]);
+    // Sistemde değerlendirilecek şablon var (boşsa route 404 döner).
+    prismaMock.projectTemplate.findMany.mockResolvedValue([{ id: "t1" }]);
+  });
+
+  it("MENTOR değil → 403", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: false, response: new Response(null, { status: 403 }) });
+    const res = await POST(req({ studentProfileId: "sp-1" }));
+    expect(res.status).toBe(403);
+    expect(prismaMock.studentProfile.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("geçersiz gövde → 400", async () => {
+    mentor();
+    const res = await POST(req({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("sahiplik: başka mentörün öğrencisi (findFirst null) → 404, AI çağrılmaz", async () => {
+    mentor("mentor-1");
+    prismaMock.studentProfile.findFirst.mockResolvedValue(null);
+    const res = await POST(req({ studentProfileId: "sp-1" }));
+    expect(res.status).toBe(404);
+    expect(recommendMock).not.toHaveBeenCalled();
+    // sorgu mentorId ile sınırlı
+    expect(prismaMock.studentProfile.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "sp-1", mentorId: "mentor-1" } }),
+    );
+  });
+
+  it("kendi öğrencisi → 200, öneri döner", async () => {
+    mentor("mentor-1");
+    prismaMock.studentProfile.findFirst.mockResolvedValue({ id: "sp-1", mentorId: "mentor-1" });
+    const res = await POST(req({ studentProfileId: "sp-1" }));
+    expect(res.status).toBe(200);
+    expect(recommendMock).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/mentor/students/route.test.ts
+++ b/src/app/api/mentor/students/route.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { requireAuthMock, getStudentsMock } = vi.hoisted(() => ({
+  requireAuthMock: vi.fn(),
+  getStudentsMock: vi.fn(),
+}));
+vi.mock("@/lib/auth/guard", () => ({
+  requireAuth: (...a: unknown[]) => requireAuthMock(...a),
+}));
+vi.mock("@/features/mentors/server/actions", () => ({
+  getMentorStudents: (...a: unknown[]) => getStudentsMock(...a),
+}));
+
+import { GET } from "./route";
+
+describe("mentor students list (#189)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("MENTOR değil → 403, liste çekilmez", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: false, response: new Response(null, { status: 403 }) });
+    const res = await GET();
+    expect(res.status).toBe(403);
+    expect(getStudentsMock).not.toHaveBeenCalled();
+  });
+
+  it("liste oturumdaki mentorId ile çekilir (başka mentörün listesi değil)", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id: "mentor-1", role: "MENTOR" } } });
+    getStudentsMock.mockResolvedValue([{ id: "s1" }]);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(getStudentsMock).toHaveBeenCalledWith("mentor-1");
+  });
+
+  it("DB hatası → 500", async () => {
+    requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id: "mentor-1", role: "MENTOR" } } });
+    getStudentsMock.mockRejectedValue(new Error("db"));
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
Kalan testsiz uçların temel testleri — route test kapsamını tamamlar (yeni dosyalar → sıfır çakışma).

## Kapsam (`vi.hoisted`, 4 dosya, 11 test)
- **`health`**: DB ok → 200 `status:ok`; DB hata → 500 (ham hata sızmaz)
- **`mentor/students`**: MENTOR; liste **oturumdaki mentorId** ile; DB hata → 500
- **`admin/mentors`**: ADMIN; 403/200
- **`mentor/ai-recommend-projects`**: MENTOR; **başka mentörün öğrencisi → 404** (sahiplik `where`'i `mentorId` ile sınırlı); geçersiz gövde → 400; kendi öğrencisi → 200

## Kapsam dışı
`auth/[...nextauth]` — NextAuth framework handler'ı; kendi iş mantığımız değil, test edilmesi anlamsız.

## Sonuç
Bununla birlikte **anlamlı tüm API uçları test kapsamında** — başlangıçtaki 20 testsiz route kapandı.

## Doğrulama
- `npm test` → **310/310** ✓ (299 → +11)
- `npm run lint` → 0 hata

Closes #189
Refs #160