### PR TITLE
chore: Out Plane deploy hazirligi — guvenli entrypoint + non-root imaj + DEPLOYMENT.md

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,9 @@ Dockerfile*
 docker-compose*.yml
 README.md
 KURULUM.md
+# GÜVENLİK: kimlik bilgisi ve kullanıcı yüklemeleri ASLA imaj katmanına girmemeli.
+# (gcp-credentials.json .gitignore'da olduğu için repo'da yoktur; ama lokalde
+#  varken `docker build` yapılırsa COPY . . ile imaja sızardı — burada engelliyoruz.)
+gcp-credentials.json
+uploads
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell script'leri her platformda LF ile tut — CRLF, Linux konteynerinde
+# şebang'ı (#!/bin/sh) bozar ve entrypoint "not found" hatası verir.
+*.sh text eol=lf
+docker-entrypoint.sh text eol=lf

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,106 @@
+# AISigner — Dağıtım (Deployment) Rehberi
+
+Bu belge AISigner'ı **Out Plane** (yönetilen PostgreSQL + Docker/GitHub build) veya
+benzeri bir PaaS üzerinde **güvenli** biçimde canlıya almak içindir.
+
+> Mimari özet için `CLAUDE.md`, çok-instance/ölçekleme notları için ilgili başlığa bakın.
+
+---
+
+## 1. Mimari ve gereksinimler
+
+| Bileşen | Değer |
+|---|---|
+| Runtime | Node 20 (Docker imajı: `node:20-bookworm-slim`) |
+| Uygulama | Next.js 15 standalone, port **3000** |
+| Veritabanı | PostgreSQL 14–18, **SSL zorunlu** |
+| AI (opsiyonel) | Google Vertex AI / Gemini — kimlik JSON'u env'den |
+| Dosya yükleme | Yerel disk `/app/uploads` (kalıcılık için Volume gerekir) |
+
+Konteyner açılışta şunu yapar (`docker-entrypoint.sh`):
+1. `GCP_CREDENTIALS_JSON` env'i varsa `/app/gcp-credentials.json`'a **600 izinle** yazar.
+2. `npx prisma migrate deploy` — bekleyen şema göçlerini uygular.
+3. Uygulamayı başlatır. **Root değil, `node` kullanıcısı** olarak koşar.
+
+---
+
+## 2. Ortam değişkenleri (Environment variables)
+
+Out Plane konsolunda servisin **Variables** bölümüne girilir.
+
+### Zorunlu
+
+| Değişken | Açıklama | Örnek / Not |
+|---|---|---|
+| `DATABASE_URL` | Postgres bağlantısı. **`?sslmode=require` ekleyin.** | `postgresql://user:pass@host:5432/aisigner?sslmode=require` |
+| `AUTH_SECRET` | **JWT imzalama sırrı** (oturum + middleware). Yoksa uygulama prod'da açılmaz. **Yeni ve güçlü üretin.** | `openssl rand -base64 32` çıktısı |
+| `NEXTAUTH_URL` | Uygulamanın public URL'i (NextAuth callback'leri). | `https://aisigner.example.com` |
+
+> **Dikkat:** Bu proje NextAuth v4 ile **`AUTH_SECRET`** kullanır (`NEXTAUTH_SECRET` DEĞİL).
+> Bir platform şablonu `NEXTAUTH_SECRET` isterse, `AUTH_SECRET`'i mutlaka ayrıca girin.
+
+### Güvenlik için önerilen
+
+| Değişken | Açıklama |
+|---|---|
+| `NEXTAUTH_SECRET` | Parola-sıfırlama token'larının imzalanmasında kullanılır. Verilmezse sabit bir decoy fallback devreye girer → token'lar tahmin edilebilir olur. **Ayrı, güçlü bir değer girin.** |
+
+### AI için (opsiyonel — verilmezse AI özellikleri mock'a düşer)
+
+| Değişken | Açıklama |
+|---|---|
+| `GOOGLE_CLOUD_PROJECT` | GCP proje kimliği (ör. `projects-498900`). |
+| `GCP_CREDENTIALS_JSON` | Service-account JSON'unun **tam içeriği** (dosya değil). Açılışta dosyaya yazılır. |
+
+> **`GOOGLE_APPLICATION_CREDENTIALS` girmeyin** — entrypoint onu otomatik `/app/gcp-credentials.json`'a ayarlar.
+
+### Diğer (opsiyonel)
+
+| Değişken | Varsayılan | Açıklama |
+|---|---|---|
+| `GITHUB_ORG` | `Posinowa` | GitHub çalışma alanı URL'lerinde kullanılan org. |
+| `PORT` | `3000` | Platform farklı bir port dayatıyorsa. |
+
+---
+
+## 3. Out Plane adımları
+
+1. **PostgreSQL oluştur**: Out Plane'de yönetilen Postgres ekle; bağlantı dizesini al,
+   sonuna `?sslmode=require` ekleyip `DATABASE_URL` olarak kaydet.
+2. **Servis oluştur**: Repo'yu (`Posinowa/AISigner`) bağla — Out Plane kök dizindeki
+   `Dockerfile` ile imajı kendisi build eder. (Alternatif: hazır imaj push'la.)
+3. **Değişkenleri gir**: Yukarıdaki tablodaki tüm zorunlu + kullanacağın opsiyonel değişkenler.
+4. **Deploy et.** İlk açılışta `migrate deploy` şemayı kurar. Logda şunları görmelisin:
+   `→ Prisma migrate deploy çalışıyor...` ve `→ Uygulama başlatılıyor...`.
+5. **Doğrula**: `https://<url>/api/health` 200 dönmeli; ardından `/signin`.
+
+### İlk admin'i güvenli oluştur
+
+`npm run seed` **prod'da ÇALIŞTIRILMAZ** (aşağıdaki güvenlik listesine bakın). İlk yönetici için:
+tek seferlik güvenli bir script ile veya DB'ye elle, **güçlü ve benzersiz** bir parolayla
+(argon2 hash — `@node-rs/argon2`'nin `hash()` fonksiyonu; `scripts/seed.ts` örnek alınabilir)
+bir ADMIN kullanıcı ekleyin.
+
+---
+
+## 4. 🔒 Güvenlik kontrol listesi (deploy öncesi)
+
+- [ ] **`gcp-credentials.json` repoda YOK.** `.gitignore` + `.dockerignore` korur; imaja da girmez.
+- [ ] **`.env` repoda YOK.** Tüm sırlar platformun Variables bölümünde.
+- [ ] **`NEXTAUTH_SECRET` yeni üretildi** (`openssl rand -base64 32`) — demo/örnek değer DEĞİL.
+- [ ] **`DATABASE_URL` içinde `sslmode=require`** var.
+- [ ] **Prod'da `npm run seed` çalıştırılmadı.** Seed; `admin@example.com` / `mentor@example.com`
+      / `student@example.com` kullanıcılarını **sabit zayıf parola** ile açar — canlıda arka kapı olur.
+- [ ] İlk admin **güçlü, benzersiz parolayla** oluşturuldu.
+- [ ] Konteyner **root değil** (`node` kullanıcısı) — Dockerfile bunu sağlar.
+- [ ] `GCP_CREDENTIALS_JSON` yalnızca platform secret'ı olarak duruyor; logda içeriği görünmüyor.
+
+---
+
+## 5. Kalıcılık ve ölçekleme (dikkat)
+
+- **Dosya yüklemeleri** `/app/uploads`'a yazılır. Volume bağlanmazsa **her deploy'da silinir**.
+  Kalıcılık için Out Plane Volume'ünü `/app/uploads`'a bağlayın veya GCS/S3'e geçin.
+- **Tek-instance varsayımı**: `rate-limit.ts`, forgot-password token'ları ve `metrics.ts`
+  bellek-içi (process-local) tutulur. **Birden çok instance** çalıştıracaksanız bunlar
+  instance'lar arasında paylaşılmaz → Redis'e taşıyın. Tek instance ile sorun yok.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,15 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN npm run build -- --no-lint
+# Build sırasında Next "page data" toplarken route modülleri import edilir; bu
+# PrismaClient'ı kurar ve nextauth modülü AUTH_SECRET guard'ını çalıştırır
+# (build NODE_ENV=production altında koşar). Gerçek bağlantı/oturum kurulmaz; bu
+# YER TUTUCU değerler yalnızca bu RUN komutu süresince tanımlıdır — imaja/ENV'e
+# yazılmaz, runner stage'e taşınmaz. Runtime'da gerçek değerler kullanılır.
+# (AUTH_SECRET NEXT_PUBLIC_ değildir; client bundle'a da gömülmez.)
+RUN DATABASE_URL="postgresql://build:build@localhost:5432/build?schema=public" \
+    AUTH_SECRET="build-time-placeholder-not-used-at-runtime" \
+    npm run build -- --no-lint
 
 FROM base AS runner
 WORKDIR /app
@@ -26,6 +34,17 @@ RUN npm install --omit=dev && npm cache clean --force
 
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next ./.next
+COPY docker-entrypoint.sh ./docker-entrypoint.sh
+
+# GÜVENLİK: konteyner root olarak koşmasın (savunma-derinliği). node:20 imajında
+# hazır gelen 'node' (uid 1000) kullanıcısına geçiyoruz. uploads klasörü + tüm
+# /app node'a devrediliyor ki entrypoint gcp-credentials.json'ı yazabilsin ve
+# öğrenci dosya yüklemeleri çalışsın.
+RUN chmod +x ./docker-entrypoint.sh \
+    && mkdir -p /app/uploads \
+    && chown -R node:node /app
+
+USER node
 
 EXPOSE 3000
-CMD ["sh", "-c", "npx prisma migrate deploy && npm run start:docker"]
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# #193: Konteyner başlangıç script'i (Out Plane vb. platformlar için).
+set -e
+
+# --- GCP kimlik bilgisi: env değişkeninden dosyaya ---
+# Out Plane'de "dosya secret'ı" yoktur. Vertex AI (Gemini) SDK'sı ise kimlik
+# bilgisini bir DOSYA yolundan (GOOGLE_APPLICATION_CREDENTIALS) okur. Bu yüzden
+# JSON içeriğini GCP_CREDENTIALS_JSON env değişkeninde saklayıp açılışta dosyaya
+# yazıyoruz. GÜVENLİK: umask 077 → dosya yalnızca sahibine okunur/yazılır (600);
+# içerik ASLA loglanmaz.
+if [ -n "$GCP_CREDENTIALS_JSON" ]; then
+  umask 077
+  printf '%s' "$GCP_CREDENTIALS_JSON" > /app/gcp-credentials.json
+  export GOOGLE_APPLICATION_CREDENTIALS="/app/gcp-credentials.json"
+  echo "→ GCP kimlik dosyası env değişkeninden yazıldı (içerik gizli)."
+else
+  echo "→ GCP_CREDENTIALS_JSON tanımlı değil; AI özellikleri mock'a düşecek."
+fi
+
+# --- Şema göçleri ---
+# Prod'da güvenli: yalnızca uygulanmamış migration'ları uygular (db push/seed DEĞİL).
+echo "→ Prisma migrate deploy çalışıyor..."
+npx prisma migrate deploy
+
+# --- Sunucu ---
+# exec: sinyaller (SIGTERM) doğrudan Node sürecine iletilsin (temiz kapanış).
+echo "→ Uygulama başlatılıyor..."
+exec npm run start:docker


### PR DESCRIPTION
## Özet
Projeyi **Out Plane** (yönetilen Postgres + Docker/GitHub build) üzerinde **güvenli** canlıya almak için gereken altyapı. Docker imajı gerçekten build edilip lokalde uçtan uca test edildi.

## Neden gerekti (kritik bulgu)
Mevcut Dockerfile ile imaj **build bile olmuyordu**: `next build` "page data" toplarken route modülleri import ediliyor, bu da `PrismaClient`'ı kuruyor ve `nextauth` modülünün `AUTH_SECRET` guard'ını (prod'da) tetikliyordu → env'siz build ortamında hata. Lokalde `.env` olduğu için gizli kalmış.

## Değişiklikler
- **`docker-entrypoint.sh`** (yeni): `GCP_CREDENTIALS_JSON` env'ini açılışta `/app/gcp-credentials.json`'a **`600` izinle** yazar (içerik **loglanmaz**), sonra `prisma migrate deploy` + start. `exec` ile SIGTERM iletimi. Env yoksa AI mock'a düşer (mevcut sözleşme korunur).
- **`Dockerfile`**: 
  - Non-root **`node`** kullanıcısı (savunma-derinliği).
  - Builder'da yalnızca build süresince yer-tutucu `DATABASE_URL`/`AUTH_SECRET` (RUN satır-içi; imaja/ENV'e yazılmaz, runner stage'e taşınmaz; `NEXT_PUBLIC_` olmadığı için client bundle'a da girmez).
- **`.dockerignore`**: `gcp-credentials.json` + `uploads` hariç — kimlik bilgisi imaj katmanına sızmasın.
- **`.gitattributes`** (yeni): `*.sh` → LF (CRLF, Linux konteynerinde şebangı bozar).
- **`DEPLOYMENT.md`** (yeni): Out Plane adımları, tam env listesi (**`AUTH_SECRET`** — `NEXTAUTH_SECRET` değil), ve güvenlik kontrol listesi.

## Güvenlik notları
- Prod'da **`npm run seed` çalıştırılmamalı** — seed sabit zayıf parolayla demo admin açar (DEPLOYMENT.md'de vurgulandı).
- `DATABASE_URL`'e `sslmode=require`; `AUTH_SECRET` yeni/güçlü üretilmeli.

## Test (lokal, gerçek imaj)
- `docker build` ✓ (uyarısız)
- Konteyner **`node`** olarak koşuyor (`uid=1000`) ✓
- Creds env→dosya **`600`**, sahibi `node` ✓
- Yerel Postgres'e karşı: `migrate deploy` (21 migration, bekleyen yok) → sunucu ayakta → **`/api/health` HTTP 200** `{"status":"ok"}` ✓

Closes #193
Refs #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)