### PR TITLE
feat: bir ogrenciye birden fazla mentor atama (M:N)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,8 @@ src/
 | Model | Not |
 |---|---|
 | `User` | rol (ADMIN/MENTOR/STUDENT) + **accountStatus** (PENDING/APPROVED/REJECTED, #38) |
-| `StudentProfile` | mentorId FK; goals = **compiled** tek string (compiledGoals ile 3 alana ayrışır) |
+| `StudentProfile` | goals = **compiled** tek string (compiledGoals ile 3 alana ayrışır). **Mentör artık M:N** (#195) — `mentorId` FK KALDIRILDI |
+| `MentorAssignment` | **#195** — Öğrenci↔Mentör M:N join tablosu; `@@unique([studentProfileId, mentorId])`. Mentorlar **eşit yetkili** (birincil yok). Yetki: `mentorAssignments: { some: { mentorId } }` / `isAssignedMentor()` (`lib/auth/mentor-access.ts`) |
 | `ProjectTemplate` | **title @unique** (#112); githubRepoUrl (#49) |
 | `AssignedProject` | `@@unique([studentProfileId, projectTemplateId])` (#58) |
 | `Roadmap` / `RoadmapStep` | DRAFT/PUBLISHED; step'te githubIssueUrl (#50); öğrenci DRAFT'a etkileşemez (#52) |

--- a/prisma/migrations/20260805120000_mentor_many_to_many/migration.sql
+++ b/prisma/migrations/20260805120000_mentor_many_to_many/migration.sql
@@ -1,0 +1,36 @@
+-- #195: Öğrenci↔Mentör ilişkisini tek-mentor (StudentProfile.mentorId) yerine
+-- M:N (MentorAssignment join tablosu) yap. Mevcut atamalar backfill ile taşınır.
+
+-- CreateTable
+CREATE TABLE "MentorAssignment" (
+    "id" TEXT NOT NULL,
+    "studentProfileId" TEXT NOT NULL,
+    "mentorId" TEXT NOT NULL,
+    "assignedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MentorAssignment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "MentorAssignment_mentorId_idx" ON "MentorAssignment"("mentorId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MentorAssignment_studentProfileId_mentorId_key" ON "MentorAssignment"("studentProfileId", "mentorId");
+
+-- AddForeignKey
+ALTER TABLE "MentorAssignment" ADD CONSTRAINT "MentorAssignment_studentProfileId_fkey" FOREIGN KEY ("studentProfileId") REFERENCES "StudentProfile"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "MentorAssignment" ADD CONSTRAINT "MentorAssignment_mentorId_fkey" FOREIGN KEY ("mentorId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- #195 Backfill: eski StudentProfile.mentorId değerlerini join tablosuna kopyala.
+INSERT INTO "MentorAssignment" ("id", "studentProfileId", "mentorId", "assignedAt")
+SELECT gen_random_uuid()::text, "id", "mentorId", CURRENT_TIMESTAMP
+FROM "StudentProfile"
+WHERE "mentorId" IS NOT NULL;
+
+-- DropForeignKey (eski tek-mentor FK)
+ALTER TABLE "StudentProfile" DROP CONSTRAINT "StudentProfile_mentorId_fkey";
+
+-- DropColumn (artık join tablosu tek doğruluk kaynağı)
+ALTER TABLE "StudentProfile" DROP COLUMN "mentorId";

--- a/prisma/migrations/20260805120000_mentor_many_to_many/migration.sql
+++ b/prisma/migrations/20260805120000_mentor_many_to_many/migration.sql
@@ -1,5 +1,7 @@
 -- #195: Öğrenci↔Mentör ilişkisini tek-mentor (StudentProfile.mentorId) yerine
 -- M:N (MentorAssignment join tablosu) yap. Mevcut atamalar backfill ile taşınır.
+-- migration-safety-ack: mentorId drop'u backfill SONRASI yapılıyor (veri kaybı yok) ve
+--   proje henüz canlıda değil (ilk deploy — çakışacak eski sürüm yok). Detay: docs/MIGRATIONS.md (#198)
 
 -- CreateTable
 CREATE TABLE "MentorAssignment" (

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,9 +22,10 @@ model User {
 
   // Relations
   sessions            Session[]
-  studentProfile      StudentProfile?  @relation("StudentProfile_userIdToUser")
-  mentoredStudents    StudentProfile[] @relation("StudentProfile_mentorIdToUser")
-  sentMessages        Message[]        @relation("Message_senderIdToUser")
+  studentProfile      StudentProfile?    @relation("StudentProfile_userIdToUser")
+  // #195: Mentor→öğrenci artık M:N (join tablosu). Bir mentörün öğrencileri buradan.
+  mentorAssignments   MentorAssignment[] @relation("MentorAssignment_mentorIdToUser")
+  sentMessages        Message[]          @relation("Message_senderIdToUser")
   receivedMessages    Message[]        @relation("Message_receiverIdToUser")
   stepComments        StepComment[]
   stepFiles           StepFile[]
@@ -49,16 +50,31 @@ model StudentProfile {
   goals           String?
   availability    String?
   birthYear       Int?
-  mentorId        String?
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 
   // Relations
-  user             User              @relation("StudentProfile_userIdToUser", fields: [userId], references: [id], onDelete: Cascade)
-  mentor           User?             @relation("StudentProfile_mentorIdToUser", fields: [mentorId], references: [id])
+  user             User               @relation("StudentProfile_userIdToUser", fields: [userId], references: [id], onDelete: Cascade)
+  // #195: Tek mentorId yerine M:N. Bir öğrencinin mentorları buradan.
+  mentorAssignments MentorAssignment[]
   assignedProjects AssignedProject[]
   surveyAnswers    SurveyAnswer[]
   profileAnalysis  ProfileAnalysis?
+}
+
+// #195: Öğrenci↔Mentör M:N eşleştirmesi. Mentorlar eşit yetkili (birincil yok).
+model MentorAssignment {
+  id               String   @id @default(cuid())
+  studentProfileId String
+  mentorId         String
+  assignedAt       DateTime @default(now())
+
+  studentProfile StudentProfile @relation(fields: [studentProfileId], references: [id], onDelete: Cascade)
+  mentor         User           @relation("MentorAssignment_mentorIdToUser", fields: [mentorId], references: [id], onDelete: Cascade)
+
+  // Aynı mentor bir öğrenciye iki kez atanamaz.
+  @@unique([studentProfileId, mentorId])
+  @@index([mentorId])
 }
 
 model ProjectTemplate {

--- a/scripts/check-data.ts
+++ b/scripts/check-data.ts
@@ -13,6 +13,8 @@ async function main() {
   const profiles = await p.studentProfile.findMany({
     include: {
       user: { select: { name: true, email: true } },
+      // #195: M:N — atanmış mentorlar.
+      mentorAssignments: { include: { mentor: { select: { email: true } } } },
       assignedProjects: {
         include: {
           projectTemplate: { select: { title: true } },
@@ -30,7 +32,8 @@ async function main() {
 
   for (const p of profiles) {
     console.log(`\n👤 ${p.user.name} (${p.user.email})`);
-    console.log(`   Profile ID: ${p.id}, Mentor: ${p.mentorId || "YOK"}`);
+    const mentorList = p.mentorAssignments.map((a) => a.mentor.email).join(", ") || "YOK";
+    console.log(`   Profile ID: ${p.id}, Mentorlar: ${mentorList}`);
     
     if (p.assignedProjects.length === 0) {
       console.log("   📂 Atanmış proje yok");

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -43,18 +43,29 @@ async function main() {
     select: { id: true },
   });
 
-  await prisma.studentProfile.upsert({
+  const demoProfile = await prisma.studentProfile.upsert({
     where: { userId: student.id },
-    update: { mentorId: mentor.id },
+    update: {},
     create: {
       userId: student.id,
-      mentorId: mentor.id,
       experienceLevel: "BEGINNER", // #54: kanonik UPPERCASE
       interests: ["Web Development"],
       goals: "Demo amaçlı örnek stajyer profili — full-stack bir proje geliştirmeyi hedefliyor.",
       availability: "part-time",
       birthYear: 2002,
     },
+  });
+
+  // #195: Mentor ataması artık M:N join tablosunda (idempotent — @@unique).
+  await prisma.mentorAssignment.upsert({
+    where: {
+      studentProfileId_mentorId: {
+        studentProfileId: demoProfile.id,
+        mentorId: mentor.id,
+      },
+    },
+    update: {},
+    create: { studentProfileId: demoProfile.id, mentorId: mentor.id },
   });
   console.log(`✅ Student, mentor'a atandı: student@example.com → mentor@example.com`);
 

--- a/src/app/(admin)/admin-dashboard/assignments/page.tsx
+++ b/src/app/(admin)/admin-dashboard/assignments/page.tsx
@@ -22,8 +22,8 @@ export type StudentAssignmentProgress = {
   studentName: string;
   studentEmail: string;
   experienceLevel: string;
-  mentorId: string | null;
-  mentorName: string | null;
+  // #195: M:N — atanmış mentorlar (0..n).
+  mentors: { id: string; name: string }[];
   projectTemplateId: string;
   projectTitle: string;
   projectDifficulty: string;
@@ -267,9 +267,11 @@ export default function AdminAssignmentsPage() {
                           {item.experienceLevel}
                         </span>
                       </div>
-                      {item.mentorName && (
+                      {item.mentors.length > 0 && (
                         <div className="text-xs text-indigo-600 dark:text-indigo-400 mt-1 flex items-center gap-1">
-                          <Users className="w-3 h-3" /> Mentör: {item.mentorName}
+                          <Users className="w-3 h-3" />{" "}
+                          {item.mentors.length > 1 ? "Mentörler" : "Mentör"}:{" "}
+                          {item.mentors.map((m) => m.name).join(", ")}
                         </div>
                       )}
                     </td>

--- a/src/app/(admin)/admin-dashboard/page.tsx
+++ b/src/app/(admin)/admin-dashboard/page.tsx
@@ -34,7 +34,8 @@ type User = {
   accountStatus: "PENDING" | "APPROVED" | "REJECTED";
   studentProfile?: {
     id: string;
-    mentorId?: string | null;
+    // #195: M:N — atanmış mentorlar (0..n).
+    mentors: { id: string; name: string | null; lastName: string | null }[];
   } | null;
 };
 
@@ -154,32 +155,29 @@ export default function AdminDashboard() {
     }
   }
 
-  async function handleAssignMentor(studentId: string, mentorId: string) {
+  // #195: Öğrencinin mentor LİSTESİNİ ayarla (M:N). mentorIds = olması gereken tam küme.
+  async function handleSetMentors(studentId: string, mentorIds: string[]) {
     setUpdating(studentId);
     try {
       const response = await fetch("/api/admin/users", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          studentId,
-          mentorId: mentorId === "" ? null : mentorId,
-        }),
+        body: JSON.stringify({ studentId, mentorIds }),
       });
       if (response.ok) {
+        // Seçili id'leri mentor nesnelerine çevirip yerel state'i güncelle.
+        const newMentors = mentorIds
+          .map((id) => mentors.find((m) => m.id === id))
+          .filter((m): m is Mentor => Boolean(m))
+          .map((m) => ({ id: m.id, name: m.name, lastName: m.lastName }));
         setUsers((prev) =>
           prev.map((u) =>
             u.id === studentId && u.studentProfile
-              ? {
-                  ...u,
-                  studentProfile: {
-                    ...u.studentProfile,
-                    mentorId: mentorId === "" ? null : mentorId,
-                  },
-                }
+              ? { ...u, studentProfile: { ...u.studentProfile, mentors: newMentors } }
               : u,
           ),
         );
-        toast.success(mentorId === "" ? "Mentor ataması kaldırıldı." : "Mentor atandı.");
+        toast.success("Mentor atamaları güncellendi.");
       } else {
         // #43/#114: Geçersiz rol gibi 4xx hatalarında anlamlı mesajı göster.
         const data = await response.json().catch(() => null);
@@ -242,7 +240,8 @@ export default function AdminDashboard() {
       (u) => u.role === "STUDENT" && u.studentProfile,
     ).length;
     const studentsWithoutMentor = users.filter(
-      (u) => u.role === "STUDENT" && u.studentProfile && !u.studentProfile.mentorId,
+      // #195: M:N — hiç mentoru olmayan öğrenciler.
+      (u) => u.role === "STUDENT" && u.studentProfile && u.studentProfile.mentors.length === 0,
     ).length;
     const pendingCount = users.filter(
       (u) => u.role === "STUDENT" && u.accountStatus === "PENDING",
@@ -250,9 +249,9 @@ export default function AdminDashboard() {
     return { total, studentCount, mentorCount, adminCount, studentsWithProfile, studentsWithoutMentor, pendingCount };
   }, [users]);
 
-  const getDisplayName = (u: { name: string | null; lastName: string | null; email: string }) => {
+  const getDisplayName = (u: { name: string | null; lastName: string | null; email?: string }) => {
     const full = `${u.name ?? ""} ${u.lastName ?? ""}`.trim();
-    return full || u.email.split("@")[0];
+    return full || u.email?.split("@")[0] || "İsimsiz";
   };
 
   const getInitials = (u: { name: string | null; lastName: string | null; email: string }) => {
@@ -500,21 +499,65 @@ export default function AdminDashboard() {
                             {isUpdating && <Loader2 className="animate-spin w-3.5 h-3.5 text-blue-600 dark:text-blue-400" />}
                           </div>
                         ) : user.studentProfile ? (
-                          <div className="flex items-center gap-2 w-full">
-                            <select
-                              value={user.studentProfile.mentorId || ""}
-                              onChange={(e) => handleAssignMentor(user.id, e.target.value)}
-                              disabled={isUpdating}
-                              className="flex-1 border border-slate-200 dark:border-slate-700 rounded-xl px-3 py-2 bg-white dark:bg-slate-900 text-sm text-slate-700 dark:text-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-60"
-                            >
-                              <option value="">— Mentor seçilmedi —</option>
-                              {mentors.map((mentor) => (
-                                <option key={mentor.id} value={mentor.id}>
-                                  {getDisplayName(mentor)} ({mentor.email})
-                                </option>
-                              ))}
-                            </select>
-                            {isUpdating && <Loader2 className="animate-spin w-3.5 h-3.5 text-blue-600 dark:text-blue-400" />}
+                          <div className="flex flex-col gap-2 w-full">
+                            {/* #195: Atanmış mentorlar — chip + kaldır (x) */}
+                            {user.studentProfile.mentors.length > 0 && (
+                              <div className="flex flex-wrap gap-1.5">
+                                {user.studentProfile.mentors.map((m) => (
+                                  <span
+                                    key={m.id}
+                                    className="inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium bg-blue-50 dark:bg-blue-950/40 text-blue-700 dark:text-blue-300 border border-blue-200"
+                                  >
+                                    {getDisplayName(m)}
+                                    <button
+                                      type="button"
+                                      onClick={() =>
+                                        handleSetMentors(
+                                          user.id,
+                                          user.studentProfile!.mentors
+                                            .filter((x) => x.id !== m.id)
+                                            .map((x) => x.id),
+                                        )
+                                      }
+                                      disabled={isUpdating}
+                                      aria-label={`${getDisplayName(m)} mentörünü kaldır`}
+                                      className="hover:text-red-600 disabled:opacity-60"
+                                    >
+                                      <XCircle className="w-3 h-3" />
+                                    </button>
+                                  </span>
+                                ))}
+                              </div>
+                            )}
+                            {/* Mentor ekle — yalnız henüz atanmamış mentorları göster */}
+                            <div className="flex items-center gap-2 w-full">
+                              <select
+                                value=""
+                                onChange={(e) => {
+                                  if (e.target.value) {
+                                    handleSetMentors(user.id, [
+                                      ...user.studentProfile!.mentors.map((x) => x.id),
+                                      e.target.value,
+                                    ]);
+                                  }
+                                }}
+                                disabled={isUpdating}
+                                className="flex-1 border border-slate-200 dark:border-slate-700 rounded-xl px-3 py-2 bg-white dark:bg-slate-900 text-sm text-slate-700 dark:text-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-60"
+                              >
+                                <option value="">+ Mentor ekle…</option>
+                                {mentors
+                                  .filter(
+                                    (mentor) =>
+                                      !user.studentProfile!.mentors.some((x) => x.id === mentor.id),
+                                  )
+                                  .map((mentor) => (
+                                    <option key={mentor.id} value={mentor.id}>
+                                      {getDisplayName(mentor)} ({mentor.email})
+                                    </option>
+                                  ))}
+                              </select>
+                              {isUpdating && <Loader2 className="animate-spin w-3.5 h-3.5 text-blue-600 dark:text-blue-400" />}
+                            </div>
                           </div>
                         ) : (
                           <span className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300 border border-amber-200 rounded-lg">

--- a/src/app/(student)/student-dashboard/page.tsx
+++ b/src/app/(student)/student-dashboard/page.tsx
@@ -60,6 +60,8 @@ export default async function StudentDashboardPage() {
         },
         orderBy: { createdAt: "desc" },
       },
+      // #195: M:N — "mentörün var mı?" kontrolü için atamalar.
+      mentorAssignments: { select: { mentorId: true } },
     },
   });
 
@@ -106,7 +108,7 @@ export default async function StudentDashboardPage() {
         <p className="text-slate-500 dark:text-slate-400 mt-2 text-sm">
           {profile.assignedProjects.length > 0
             ? "Çalışma masan hazır. Odaklanman gereken güncel görevler aşağıda listelenmiştir."
-            : profile.mentorId
+            : profile.mentorAssignments.length > 0
               ? "Mentörün gelişim planını hazırlıyor. Lütfen beklemede kal."
               : "Profilin inceleniyor. Yakında bir mentör ile eşleştirileceksin."}
         </p>

--- a/src/app/api/admin/users/route.test.ts
+++ b/src/app/api/admin/users/route.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-// requireAuth + prisma mock'lanır; assignMentor GERÇEK çalışır (uçtan uca 400/200 doğrulaması).
+// requireAuth + prisma mock'lanır; setStudentMentors GERÇEK çalışır (uçtan uca 400/200).
 const { requireAuthMock, prismaMock } = vi.hoisted(() => ({
   requireAuthMock: vi.fn(),
   prismaMock: {
-    user: { findUnique: vi.fn() },
+    user: { findUnique: vi.fn(), findMany: vi.fn() },
     studentProfile: { upsert: vi.fn() },
+    mentorAssignment: { deleteMany: vi.fn(), createMany: vi.fn() },
+    $transaction: vi.fn(),
   },
 }));
 vi.mock("@/lib/auth/guard", () => ({
@@ -22,10 +24,15 @@ function authAsAdmin() {
   });
 }
 
+// findUnique → öğrenci rolü; findMany → verilen id'lerden MENTOR olanlar (#195 doğrulama).
 function mockRoles(roles: Record<string, "STUDENT" | "MENTOR" | "ADMIN">) {
   prismaMock.user.findUnique.mockImplementation(
     ({ where: { id } }: { where: { id: string } }) =>
       Promise.resolve(roles[id] ? { role: roles[id] } : null),
+  );
+  prismaMock.user.findMany.mockImplementation(
+    ({ where: { id } }: { where: { id: { in: string[] } } }) =>
+      Promise.resolve(id.in.filter((i) => roles[i] === "MENTOR").map((i) => ({ id: i }))),
   );
 }
 
@@ -37,10 +44,13 @@ function postReq(body: unknown) {
   });
 }
 
-describe("POST /api/admin/users — mentor atama rol doğrulaması (#43)", () => {
+describe("POST /api/admin/users — mentor atama rol doğrulaması (#43/#195)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     prismaMock.studentProfile.upsert.mockResolvedValue({ id: "sp-1" });
+    prismaMock.mentorAssignment.deleteMany.mockReturnValue("del-op");
+    prismaMock.mentorAssignment.createMany.mockReturnValue("create-op");
+    prismaMock.$transaction.mockResolvedValue([]);
   });
 
   it("admin değilse requireAuth yanıtını döner (403)", async () => {
@@ -49,56 +59,56 @@ describe("POST /api/admin/users — mentor atama rol doğrulaması (#43)", () =>
       response: new Response(JSON.stringify({ error: "yetkisiz" }), { status: 403 }),
     });
 
-    const res = await POST(postReq({ studentId: "s1", mentorId: "m1" }));
+    const res = await POST(postReq({ studentId: "s1", mentorIds: ["m1"] }));
     expect(res.status).toBe(403);
   });
 
-  it("geçerli STUDENT + MENTOR → 200, upsert çağrılır", async () => {
+  it("geçerli STUDENT + MENTOR listesi → 200, reconcile çağrılır", async () => {
     authAsAdmin();
     mockRoles({ s1: "STUDENT", m1: "MENTOR" });
 
-    const res = await POST(postReq({ studentId: "s1", mentorId: "m1" }));
+    const res = await POST(postReq({ studentId: "s1", mentorIds: ["m1"] }));
 
     expect(res.status).toBe(200);
-    expect(prismaMock.studentProfile.upsert).toHaveBeenCalledOnce();
+    expect(prismaMock.$transaction).toHaveBeenCalledOnce();
   });
 
-  it("studentId STUDENT değilse → 400 + anlamlı mesaj, upsert yok", async () => {
+  it("studentId STUDENT değilse → 400 + anlamlı mesaj, reconcile yok", async () => {
     authAsAdmin();
     mockRoles({ s1: "MENTOR", m1: "MENTOR" });
 
-    const res = await POST(postReq({ studentId: "s1", mentorId: "m1" }));
+    const res = await POST(postReq({ studentId: "s1", mentorIds: ["m1"] }));
     const json = await res.json();
 
     expect(res.status).toBe(400);
     expect(typeof json.error).toBe("string");
-    expect(prismaMock.studentProfile.upsert).not.toHaveBeenCalled();
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
   });
 
-  it("mentorId MENTOR değilse → 400, upsert yok", async () => {
+  it("listedeki id MENTOR değilse → 400, reconcile yok", async () => {
     authAsAdmin();
     mockRoles({ s1: "STUDENT", m1: "STUDENT" });
 
-    const res = await POST(postReq({ studentId: "s1", mentorId: "m1" }));
+    const res = await POST(postReq({ studentId: "s1", mentorIds: ["m1"] }));
 
     expect(res.status).toBe(400);
-    expect(prismaMock.studentProfile.upsert).not.toHaveBeenCalled();
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
   });
 
-  it("mentorId null (atama kaldırma) → 200", async () => {
+  it("boş liste (tüm mentorları kaldır) → 200", async () => {
     authAsAdmin();
     mockRoles({ s1: "STUDENT" });
 
-    const res = await POST(postReq({ studentId: "s1", mentorId: null }));
+    const res = await POST(postReq({ studentId: "s1", mentorIds: [] }));
 
     expect(res.status).toBe(200);
-    expect(prismaMock.studentProfile.upsert).toHaveBeenCalledOnce();
+    expect(prismaMock.$transaction).toHaveBeenCalledOnce();
   });
 
   it("eksik studentId → 400 (zod validation)", async () => {
     authAsAdmin();
 
-    const res = await POST(postReq({ mentorId: "m1" }));
+    const res = await POST(postReq({ mentorIds: ["m1"] }));
     expect(res.status).toBe(400);
   });
 });

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { getAllUsers, updateUserRole, assignMentor, AssignmentValidationError } from "@/features/admin/server/user";
+import { getAllUsers, updateUserRole, setStudentMentors, AssignmentValidationError } from "@/features/admin/server/user";
 import { requireAuth } from "@/lib/auth/guard";
 import { updateRoleSchema, assignMentorSchema } from "@/lib/validations/api";
 
@@ -44,7 +44,7 @@ export async function POST(req: Request) {
   }
 
   try {
-    const updated = await assignMentor(parsed.data.studentId, parsed.data.mentorId);
+    const updated = await setStudentMentors(parsed.data.studentId, parsed.data.mentorIds);
     return NextResponse.json(updated);
   } catch (error) {
     // #43: Geçersiz rol → 400 (anlamlı mesaj). Diğer hatalar → 500.

--- a/src/app/api/mentor/ai-recommend-projects/route.test.ts
+++ b/src/app/api/mentor/ai-recommend-projects/route.test.ts
@@ -62,7 +62,7 @@ describe("ai-recommend-projects (#189)", () => {
     expect(recommendMock).not.toHaveBeenCalled();
     // sorgu mentorId ile sınırlı
     expect(prismaMock.studentProfile.findFirst).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { id: "sp-1", mentorId: "mentor-1" } }),
+      expect.objectContaining({ where: { id: "sp-1", mentorAssignments: { some: { mentorId: "mentor-1" } } } }),
     );
   });
 

--- a/src/app/api/mentor/ai-recommend-projects/route.ts
+++ b/src/app/api/mentor/ai-recommend-projects/route.ts
@@ -37,7 +37,8 @@ export async function POST(req: Request) {
     const studentProfile = await prisma.studentProfile.findFirst({
       where: {
         id: studentProfileId,
-        mentorId: auth.session.user.id,
+        // #195: M:N — bu mentör öğrencinin mentorlarından biri mi?
+        mentorAssignments: { some: { mentorId: auth.session.user.id } },
       },
     });
 

--- a/src/app/api/mentor/generate-roadmap/route.test.ts
+++ b/src/app/api/mentor/generate-roadmap/route.test.ts
@@ -37,7 +37,8 @@ function req(body: unknown) {
 function assignedProject(roadmap: { id: string; status: string } | null) {
   return {
     id: "ap-1",
-    studentProfile: { mentorId: MENTOR_ID },
+    // #195: M:N — bu mentöre atanmış öğrenci.
+    studentProfile: { mentorAssignments: [{ mentorId: MENTOR_ID }] },
     projectTemplate: { title: "Proje" },
     roadmap,
   };
@@ -61,7 +62,7 @@ describe("generate-roadmap overwrite koruması (#178-4)", () => {
     mentor();
     prismaMock.assignedProject.findUnique.mockResolvedValue({
       ...assignedProject(null),
-      studentProfile: { mentorId: "baska-mentor" },
+      studentProfile: { mentorAssignments: [{ mentorId: "baska-mentor" }] },
     });
     const res = await POST(req({ assignedProjectId: "ap-1" }));
     expect(res.status).toBe(403);

--- a/src/app/api/mentor/generate-roadmap/route.ts
+++ b/src/app/api/mentor/generate-roadmap/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { generateRoadmap } from "@/features/ai/server/generate-roadmap";
 import { requireAuth } from "@/lib/auth/guard";
+import { isAssignedMentor } from "@/lib/auth/mentor-access";
 import { generateRoadmapSchema } from "@/lib/validations/api";
 import { createRateLimiter } from "@/lib/rate-limit";
 
@@ -38,7 +39,9 @@ export async function POST(req: Request) {
     const assignedProject = await prisma.assignedProject.findUnique({
       where: { id: assignedProjectId },
       include: {
-        studentProfile: true,
+        studentProfile: {
+          include: { mentorAssignments: { select: { mentorId: true } } },
+        },
         projectTemplate: true,
         roadmap: true // Zaten bir yol haritası var mı diye kontrol etmek için
       }
@@ -48,8 +51,8 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Atanmış proje bulunamadı!" }, { status: 404 });
     }
 
-    // Mentor ownership kontrolü: Proje, bu mentörün öğrencisine ait mi?
-    if (assignedProject.studentProfile.mentorId !== auth.session.user.id) {
+    // Mentor ownership kontrolü — #195: öğrencinin mentorlarından biri mi?
+    if (!isAssignedMentor(assignedProject.studentProfile.mentorAssignments, auth.session.user.id)) {
       return NextResponse.json(
         { error: "Bu proje üzerinde işlem yapma yetkiniz yok." },
         { status: 403 }

--- a/src/app/api/mentor/roadmap/[roadmapId]/ai-step/route.ts
+++ b/src/app/api/mentor/roadmap/[roadmapId]/ai-step/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { getModel } from "@/lib/ai/gemini-client";
 import { requireAuth } from "@/lib/auth/guard";
+import { isAssignedMentor } from "@/lib/auth/mentor-access";
 import { experienceLevelLabel } from "@/lib/experience-level";
 
 export async function POST(
@@ -32,7 +33,11 @@ export async function POST(
         assignedProject: {
           include: {
             studentProfile: {
-              include: { user: true },
+              include: {
+                user: true,
+                // #195: M:N yetki kontrolü için atanmış mentorlar.
+                mentorAssignments: { select: { mentorId: true } },
+              },
             },
             projectTemplate: true,
           },
@@ -44,7 +49,8 @@ export async function POST(
       return NextResponse.json({ error: "Yol haritası bulunamadı" }, { status: 404 });
     }
 
-    if (roadmap.assignedProject.studentProfile.mentorId !== auth.session.user.id) {
+    // #195: öğrencinin mentorlarından biri mi?
+    if (!isAssignedMentor(roadmap.assignedProject.studentProfile.mentorAssignments, auth.session.user.id)) {
       return NextResponse.json({ error: "Yetkisiz işlem" }, { status: 403 });
     }
 

--- a/src/app/api/mentor/roadmap/[roadmapId]/route.test.ts
+++ b/src/app/api/mentor/roadmap/[roadmapId]/route.test.ts
@@ -26,7 +26,11 @@ function putReq(body: unknown) {
 function roadmap(mentorId: string | null) {
   return {
     id: "rm-1",
-    assignedProject: { studentProfile: { mentorId }, projectTemplate: {} },
+    // #195: M:N — mentorId varsa tek elemanlı atama listesi, yoksa boş.
+    assignedProject: {
+      studentProfile: { mentorAssignments: mentorId ? [{ mentorId }] : [] },
+      projectTemplate: {},
+    },
     steps: [],
   };
 }
@@ -63,6 +67,30 @@ describe("mentor roadmap GET/PUT — sahiplik (#184)", () => {
     prismaMock.roadmap.findUnique.mockResolvedValue(roadmap("mentor-1"));
     const res = await GET(new Request("http://t"), { params: params() });
     expect(res.status).toBe(200);
+  });
+
+  // #195: Çoklu mentor — aynı öğrenciye iki mentor atanmışsa ikisi de erişir.
+  const roadmapMulti = (mentorIds: string[]) => ({
+    id: "rm-1",
+    assignedProject: {
+      studentProfile: { mentorAssignments: mentorIds.map((mentorId) => ({ mentorId })) },
+      projectTemplate: {},
+    },
+    steps: [],
+  });
+
+  it("GET: öğrencinin İKİNCİ mentörü de erişebilir → 200 (#195)", async () => {
+    mentor("mentor-2");
+    prismaMock.roadmap.findUnique.mockResolvedValue(roadmapMulti(["mentor-1", "mentor-2"]));
+    const res = await GET(new Request("http://t"), { params: params() });
+    expect(res.status).toBe(200);
+  });
+
+  it("GET: atanmamış üçüncü mentör erişemez → 403 (#195)", async () => {
+    mentor("mentor-3");
+    prismaMock.roadmap.findUnique.mockResolvedValue(roadmapMulti(["mentor-1", "mentor-2"]));
+    const res = await GET(new Request("http://t"), { params: params() });
+    expect(res.status).toBe(403);
   });
 
   it("PUT: başka mentörün roadmap'i → 403, güncelleme YOK", async () => {

--- a/src/app/api/mentor/roadmap/[roadmapId]/route.ts
+++ b/src/app/api/mentor/roadmap/[roadmapId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { requireAuth } from "@/lib/auth/guard";
+import { isAssignedMentor } from "@/lib/auth/mentor-access";
 import { updateRoadmapSchema } from "@/lib/validations/api";
 
 // GET: Roadmap detayını getir
@@ -26,6 +27,8 @@ export async function GET(
                 user: {
                   select: { name: true, lastName: true, email: true },
                 },
+                // #195: M:N yetki kontrolü için atanmış mentorlar.
+                mentorAssignments: { select: { mentorId: true } },
               },
             },
           },
@@ -40,8 +43,8 @@ export async function GET(
       );
     }
 
-    // Mentor ownership kontrolü
-    if (roadmap.assignedProject.studentProfile.mentorId !== auth.session.user.id) {
+    // Mentor ownership kontrolü — #195: öğrencinin mentorlarından biri mi?
+    if (!isAssignedMentor(roadmap.assignedProject.studentProfile.mentorAssignments, auth.session.user.id)) {
       return NextResponse.json(
         { error: "Bu yol haritasına erişim yetkiniz yok." },
         { status: 403 }
@@ -79,7 +82,11 @@ export async function PUT(
       where: { id: roadmapId },
       include: {
         assignedProject: {
-          include: { studentProfile: true },
+          include: {
+            studentProfile: {
+              include: { mentorAssignments: { select: { mentorId: true } } },
+            },
+          },
         },
       },
     });
@@ -88,7 +95,8 @@ export async function PUT(
       return NextResponse.json({ error: "Yol haritası bulunamadı!" }, { status: 404 });
     }
 
-    if (existingRoadmap.assignedProject.studentProfile.mentorId !== auth.session.user.id) {
+    // #195: öğrencinin mentorlarından biri mi?
+    if (!isAssignedMentor(existingRoadmap.assignedProject.studentProfile.mentorAssignments, auth.session.user.id)) {
       return NextResponse.json(
         { error: "Bu yol haritasını güncelleme yetkiniz yok." },
         { status: 403 }

--- a/src/app/api/mentor/roadmap/[roadmapId]/steps/[stepId]/route.test.ts
+++ b/src/app/api/mentor/roadmap/[roadmapId]/steps/[stepId]/route.test.ts
@@ -19,7 +19,13 @@ function mentor(id: string) {
 }
 const params = (roadmapId = "rm-1", stepId = "s-1") => Promise.resolve({ roadmapId, stepId });
 function roadmap(mentorId: string | null) {
-  return { id: "rm-1", assignedProject: { studentProfile: { mentorId } } };
+  // #195: M:N — mentorId varsa tek elemanlı atama listesi, yoksa boş.
+  return {
+    id: "rm-1",
+    assignedProject: {
+      studentProfile: { mentorAssignments: mentorId ? [{ mentorId }] : [] },
+    },
+  };
 }
 function putReq(body: unknown) {
   return new Request("http://t", {

--- a/src/app/api/mentor/roadmap/[roadmapId]/steps/[stepId]/route.ts
+++ b/src/app/api/mentor/roadmap/[roadmapId]/steps/[stepId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { requireAuth } from "@/lib/auth/guard";
+import { isAssignedMentor } from "@/lib/auth/mentor-access";
 import { updateStepSchema } from "@/lib/validations/api";
 
 // PUT: Adımı güncelle
@@ -19,7 +20,11 @@ export async function PUT(
       where: { id: roadmapId },
       include: {
         assignedProject: {
-          include: { studentProfile: true },
+          include: {
+            studentProfile: {
+              include: { mentorAssignments: { select: { mentorId: true } } },
+            },
+          },
         },
       },
     });
@@ -28,7 +33,7 @@ export async function PUT(
       return NextResponse.json({ error: "Yol haritası bulunamadı!" }, { status: 404 });
     }
 
-    if (roadmap.assignedProject.studentProfile.mentorId !== auth.session.user.id) {
+    if (!isAssignedMentor(roadmap.assignedProject.studentProfile.mentorAssignments, auth.session.user.id)) {
       return NextResponse.json(
         { error: "Bu adımı güncelleme yetkiniz yok." },
         { status: 403 }
@@ -76,7 +81,11 @@ export async function DELETE(
       where: { id: roadmapId },
       include: {
         assignedProject: {
-          include: { studentProfile: true },
+          include: {
+            studentProfile: {
+              include: { mentorAssignments: { select: { mentorId: true } } },
+            },
+          },
         },
       },
     });
@@ -85,7 +94,7 @@ export async function DELETE(
       return NextResponse.json({ error: "Yol haritası bulunamadı!" }, { status: 404 });
     }
 
-    if (roadmap.assignedProject.studentProfile.mentorId !== auth.session.user.id) {
+    if (!isAssignedMentor(roadmap.assignedProject.studentProfile.mentorAssignments, auth.session.user.id)) {
       return NextResponse.json(
         { error: "Bu adımı silme yetkiniz yok." },
         { status: 403 }

--- a/src/app/api/mentor/roadmap/[roadmapId]/steps/route.test.ts
+++ b/src/app/api/mentor/roadmap/[roadmapId]/steps/route.test.ts
@@ -35,7 +35,7 @@ describe("POST /api/mentor/roadmap/[roadmapId]/steps — githubIssueUrl (#50)", 
     vi.clearAllMocks();
     prismaMock.roadmap.findUnique.mockResolvedValue({
       id: "rm-1",
-      assignedProject: { studentProfile: { mentorId: "mentor-1" } },
+      assignedProject: { studentProfile: { mentorAssignments: [{ mentorId: "mentor-1" }] } },
     });
     prismaMock.roadmapStep.findFirst.mockResolvedValue(null);
     prismaMock.roadmapStep.create.mockResolvedValue({ id: "step-1" });
@@ -77,7 +77,7 @@ describe("POST /api/mentor/roadmap/[roadmapId]/steps — githubIssueUrl (#50)", 
     authMentor();
     prismaMock.roadmap.findUnique.mockResolvedValue({
       id: "rm-1",
-      assignedProject: { studentProfile: { mentorId: "baska-mentor" } },
+      assignedProject: { studentProfile: { mentorAssignments: [{ mentorId: "baska-mentor" }] } },
     });
 
     const res = await POST(postReq(validBody), ctx);

--- a/src/app/api/mentor/roadmap/[roadmapId]/steps/route.ts
+++ b/src/app/api/mentor/roadmap/[roadmapId]/steps/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { requireAuth } from "@/lib/auth/guard";
+import { isAssignedMentor } from "@/lib/auth/mentor-access";
 import { createStepSchema } from "@/lib/validations/api";
 
 // POST: Roadmap'e yeni adım ekle
@@ -19,7 +20,11 @@ export async function POST(
       where: { id: roadmapId },
       include: {
         assignedProject: {
-          include: { studentProfile: true },
+          include: {
+            studentProfile: {
+              include: { mentorAssignments: { select: { mentorId: true } } },
+            },
+          },
         },
       },
     });
@@ -28,7 +33,8 @@ export async function POST(
       return NextResponse.json({ error: "Yol haritası bulunamadı!" }, { status: 404 });
     }
 
-    if (roadmap.assignedProject.studentProfile.mentorId !== auth.session.user.id) {
+    // #195: öğrencinin mentorlarından biri mi?
+    if (!isAssignedMentor(roadmap.assignedProject.studentProfile.mentorAssignments, auth.session.user.id)) {
       return NextResponse.json(
         { error: "Bu yol haritasına adım ekleme yetkiniz yok." },
         { status: 403 }

--- a/src/app/api/messages/conversations/route.test.ts
+++ b/src/app/api/messages/conversations/route.test.ts
@@ -43,9 +43,9 @@ describe("messages/conversations (#158)", () => {
     const res = await GET();
     const json = await res.json();
 
-    // Kapsam kritik: sorgu mentorId ile sınırlanmalı
+    // Kapsam kritik: sorgu bu mentörün atamalarıyla sınırlanmalı (#195 M:N)
     expect(prismaMock.studentProfile.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { mentorId: "mentor-1" } }),
+      expect.objectContaining({ where: { mentorAssignments: { some: { mentorId: "mentor-1" } } } }),
     );
     expect(res.status).toBe(200);
     expect(json.conversations.map((c: { partner: { id: string } }) => c.partner.id)).toContain(
@@ -55,8 +55,11 @@ describe("messages/conversations (#158)", () => {
 
   it("STUDENT yalnızca kendi mentörünü görür", async () => {
     authAs("ogrenci-1", "STUDENT");
+    // #195: M:N — öğrencinin mentorları mentorAssignments üzerinden gelir.
     prismaMock.studentProfile.findUnique.mockResolvedValue({
-      mentor: { id: "mentor-1", name: "Ayşe", lastName: null, role: "MENTOR" },
+      mentorAssignments: [
+        { mentor: { id: "mentor-1", name: "Ayşe", lastName: null, role: "MENTOR" } },
+      ],
     });
 
     const res = await GET();

--- a/src/app/api/messages/conversations/route.ts
+++ b/src/app/api/messages/conversations/route.ts
@@ -25,8 +25,9 @@ export async function GET() {
       });
       conversationPartners = users;
     } else if (userRole === "MENTOR") {
+      // #195: M:N — bu mentörün atandığı öğrenciler.
       const profiles = await prisma.studentProfile.findMany({
-        where: { mentorId: userId },
+        where: { mentorAssignments: { some: { mentorId: userId } } },
         include: {
           user: {
             select: { id: true, name: true, lastName: true, role: true },
@@ -42,16 +43,21 @@ export async function GET() {
       });
       conversationPartners = [...conversationPartners, ...admins];
     } else if (userRole === "STUDENT") {
+      // #195: M:N — öğrencinin TÜM mentorları konuşma partneri olur.
       const profile = await prisma.studentProfile.findUnique({
         where: { userId },
         include: {
-          mentor: {
-            select: { id: true, name: true, lastName: true, role: true },
+          mentorAssignments: {
+            include: {
+              mentor: {
+                select: { id: true, name: true, lastName: true, role: true },
+              },
+            },
           },
         },
       });
-      if (profile?.mentor) {
-        conversationPartners = [profile.mentor];
+      if (profile) {
+        conversationPartners = profile.mentorAssignments.map((a) => a.mentor);
       }
 
       // ADMIN'lerle de mesajlaşabilir

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -190,13 +190,15 @@ async function verifyConversationAccess(
   });
   if (other?.role === "ADMIN") return true;
 
+  // #195: M:N — karşı taraf, benim (mentör) öğrencilerimden biri mi?
   const asMentor = await prisma.studentProfile.findFirst({
-    where: { userId: otherUserId, mentorId: userId },
+    where: { userId: otherUserId, mentorAssignments: { some: { mentorId: userId } } },
   });
   if (asMentor) return true;
 
+  // #195: M:N — karşı taraf, benim (öğrenci) mentorlarımdan biri mi?
   const asStudent = await prisma.studentProfile.findFirst({
-    where: { userId, mentorId: otherUserId },
+    where: { userId, mentorAssignments: { some: { mentorId: otherUserId } } },
   });
   if (asStudent) return true;
 

--- a/src/app/api/steps/[stepId]/comments/[commentId]/route.test.ts
+++ b/src/app/api/steps/[stepId]/comments/[commentId]/route.test.ts
@@ -84,7 +84,7 @@ describe("yorum düzenle/sil — yetki sınırları (#181)", () => {
     authAs("mentor-1", "MENTOR");
     prismaMock.stepComment.findUnique.mockResolvedValue({ id: "c-1", stepId: "step-1", authorId: "student-1" });
     prismaMock.roadmapStep.findUnique.mockResolvedValue({
-      roadmap: { assignedProject: { studentProfile: { mentorId: "mentor-1" } } },
+      roadmap: { assignedProject: { studentProfile: { mentorAssignments: [{ mentorId: "mentor-1" }] } } },
     });
 
     const res = await DELETE(req({}), { params: params() });
@@ -97,7 +97,7 @@ describe("yorum düzenle/sil — yetki sınırları (#181)", () => {
     authAs("baska-mentor", "MENTOR");
     prismaMock.stepComment.findUnique.mockResolvedValue({ id: "c-1", stepId: "step-1", authorId: "student-1" });
     prismaMock.roadmapStep.findUnique.mockResolvedValue({
-      roadmap: { assignedProject: { studentProfile: { mentorId: "gercek-mentor" } } },
+      roadmap: { assignedProject: { studentProfile: { mentorAssignments: [{ mentorId: "gercek-mentor" }] } } },
     });
 
     const res = await DELETE(req({}), { params: params() });

--- a/src/app/api/steps/[stepId]/comments/[commentId]/route.ts
+++ b/src/app/api/steps/[stepId]/comments/[commentId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { requireAuth } from "@/lib/auth/guard";
+import { isAssignedMentor } from "@/lib/auth/mentor-access";
 import { updateStepCommentSchema } from "@/lib/validations/api";
 
 /**
@@ -109,14 +110,19 @@ export async function DELETE(
         roadmap: {
           include: {
             assignedProject: {
-              include: { studentProfile: true },
+              include: {
+                studentProfile: {
+                  include: { mentorAssignments: { select: { mentorId: true } } },
+                },
+              },
             },
           },
         },
       },
     });
 
-    if (step?.roadmap.assignedProject.studentProfile.mentorId === userId) {
+    // #195: M:N — öğrencinin mentorlarından biri mi?
+    if (isAssignedMentor(step?.roadmap.assignedProject.studentProfile.mentorAssignments, userId)) {
       await prisma.stepComment.delete({ where: { id: commentId } });
       return NextResponse.json({ success: true });
     }

--- a/src/app/api/steps/[stepId]/comments/route.test.ts
+++ b/src/app/api/steps/[stepId]/comments/route.test.ts
@@ -26,7 +26,7 @@ function buildStep(status: "DRAFT" | "PUBLISHED") {
     roadmap: {
       status,
       assignedProject: {
-        studentProfile: { userId: STUDENT_USER, mentorId: MENTOR_USER },
+        studentProfile: { userId: STUDENT_USER, mentorAssignments: [{ mentorId: MENTOR_USER }] },
       },
     },
   };

--- a/src/app/api/steps/[stepId]/comments/route.ts
+++ b/src/app/api/steps/[stepId]/comments/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { requireAuth } from "@/lib/auth/guard";
+import { isAssignedMentor } from "@/lib/auth/mentor-access";
 import { createStepCommentSchema } from "@/lib/validations/api";
 import { createRateLimiter } from "@/lib/rate-limit";
 
@@ -142,7 +143,9 @@ async function getStepWithAccess(stepId: string, userId: string) {
         include: {
           assignedProject: {
             include: {
-              studentProfile: true,
+              studentProfile: {
+                include: { mentorAssignments: { select: { mentorId: true } } },
+              },
             },
           },
         },
@@ -157,8 +160,8 @@ async function getStepWithAccess(stepId: string, userId: string) {
   // Öğrenci kendi adımına erişebilir
   if (profile.userId === userId) return step;
 
-  // Mentor, atanmış öğrencisinin adımına erişebilir
-  if (profile.mentorId === userId) return step;
+  // #195: M:N — mentor, atanmış öğrencisinin adımına erişebilir (mentorlardan biri mi?)
+  if (isAssignedMentor(profile.mentorAssignments, userId)) return step;
 
   return null;
 }

--- a/src/app/api/steps/[stepId]/files/[fileId]/route.test.ts
+++ b/src/app/api/steps/[stepId]/files/[fileId]/route.test.ts
@@ -36,7 +36,11 @@ function stepFile(over: { uploaderId: string; ownerUserId: string; mentorId: str
     step: {
       roadmap: {
         assignedProject: {
-          studentProfile: { userId: over.ownerUserId, mentorId: over.mentorId },
+          studentProfile: {
+            userId: over.ownerUserId,
+            // #195: M:N — mentorId varsa tek elemanlı atama listesi, yoksa boş.
+            mentorAssignments: over.mentorId ? [{ mentorId: over.mentorId }] : [],
+          },
         },
       },
     },

--- a/src/app/api/steps/[stepId]/files/[fileId]/route.ts
+++ b/src/app/api/steps/[stepId]/files/[fileId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { requireAuth } from "@/lib/auth/guard";
+import { isAssignedMentor } from "@/lib/auth/mentor-access";
 import { readFile, unlink } from "fs/promises";
 import { existsSync } from "fs";
 import path from "path";
@@ -30,7 +31,11 @@ export async function GET(
             roadmap: {
               include: {
                 assignedProject: {
-                  include: { studentProfile: true },
+                  include: {
+                    studentProfile: {
+                      include: { mentorAssignments: { select: { mentorId: true } } },
+                    },
+                  },
                 },
               },
             },
@@ -48,7 +53,8 @@ export async function GET(
 
     // Erişim kontrolü
     const profile = stepFile.step.roadmap.assignedProject.studentProfile;
-    if (profile.userId !== userId && profile.mentorId !== userId) {
+    // #195: M:N — sahibi ya da mentorlarından biri değilse reddet.
+    if (profile.userId !== userId && !isAssignedMentor(profile.mentorAssignments, userId)) {
       return NextResponse.json(
         { error: "Bu dosyaya erişim yetkiniz yok." },
         { status: 403 }
@@ -115,7 +121,11 @@ export async function DELETE(
             roadmap: {
               include: {
                 assignedProject: {
-                  include: { studentProfile: true },
+                  include: {
+                    studentProfile: {
+                      include: { mentorAssignments: { select: { mentorId: true } } },
+                    },
+                  },
                 },
               },
             },
@@ -134,7 +144,8 @@ export async function DELETE(
     // Erişim kontrolü: yükleyen veya mentor silebilir
     const profile = stepFile.step.roadmap.assignedProject.studentProfile;
     const isUploader = stepFile.uploaderId === userId;
-    const isMentor = userRole === "MENTOR" && profile.mentorId === userId;
+    // #195: M:N — mentör, öğrencinin mentorlarından biri mi?
+    const isMentor = userRole === "MENTOR" && isAssignedMentor(profile.mentorAssignments, userId);
 
     if (!isUploader && !isMentor) {
       return NextResponse.json(

--- a/src/app/api/steps/[stepId]/files/route.test.ts
+++ b/src/app/api/steps/[stepId]/files/route.test.ts
@@ -25,7 +25,7 @@ function buildStep(status: "DRAFT" | "PUBLISHED") {
     roadmap: {
       status,
       assignedProject: {
-        studentProfile: { userId: STUDENT_USER, mentorId: MENTOR_USER },
+        studentProfile: { userId: STUDENT_USER, mentorAssignments: [{ mentorId: MENTOR_USER }] },
       },
     },
   };

--- a/src/app/api/steps/[stepId]/files/route.ts
+++ b/src/app/api/steps/[stepId]/files/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { requireAuth } from "@/lib/auth/guard";
+import { isAssignedMentor } from "@/lib/auth/mentor-access";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { matchesExtensionSignature } from "@/lib/file-signature";
 import { writeFile, mkdir } from "fs/promises";
@@ -242,7 +243,11 @@ async function getStepWithAccess(stepId: string, userId: string) {
       roadmap: {
         include: {
           assignedProject: {
-            include: { studentProfile: true },
+            include: {
+              studentProfile: {
+                include: { mentorAssignments: { select: { mentorId: true } } },
+              },
+            },
           },
         },
       },
@@ -253,7 +258,8 @@ async function getStepWithAccess(stepId: string, userId: string) {
 
   const profile = step.roadmap.assignedProject.studentProfile;
   if (profile.userId === userId) return step;
-  if (profile.mentorId === userId) return step;
+  // #195: M:N — öğrencinin mentorlarından biri mi?
+  if (isAssignedMentor(profile.mentorAssignments, userId)) return step;
 
   return null;
 }

--- a/src/features/admin/server/assignment-progress.ts
+++ b/src/features/admin/server/assignment-progress.ts
@@ -7,8 +7,8 @@ export type StudentAssignmentProgress = {
   studentName: string;
   studentEmail: string;
   experienceLevel: string;
-  mentorId: string | null;
-  mentorName: string | null;
+  // #195: M:N — öğrenciye atanmış mentorlar (0..n).
+  mentors: { id: string; name: string }[];
   projectTemplateId: string;
   projectTitle: string;
   projectDifficulty: string;
@@ -52,12 +52,12 @@ export async function getStudentAssignmentsProgress(): Promise<StudentAssignment
               email: true,
             },
           },
-          mentor: {
-            select: {
-              id: true,
-              name: true,
-              lastName: true,
-              email: true,
+          // #195: M:N — atanmış mentorlar.
+          mentorAssignments: {
+            include: {
+              mentor: {
+                select: { id: true, name: true, lastName: true, email: true },
+              },
             },
           },
         },
@@ -96,10 +96,11 @@ export async function getStudentAssignmentsProgress(): Promise<StudentAssignment
       .filter(Boolean)
       .join(" ") || studentUser.email;
 
-    const mentorUser = assignment.studentProfile.mentor;
-    const mentorName = mentorUser
-      ? [mentorUser.name, mentorUser.lastName].filter(Boolean).join(" ") || mentorUser.email
-      : null;
+    // #195: M:N — atanmış mentorların görünen adları.
+    const mentors = assignment.studentProfile.mentorAssignments.map((a) => ({
+      id: a.mentor.id,
+      name: [a.mentor.name, a.mentor.lastName].filter(Boolean).join(" ") || a.mentor.email,
+    }));
 
     const steps = assignment.roadmap?.steps ?? [];
     const totalSteps = steps.length;
@@ -120,8 +121,7 @@ export async function getStudentAssignmentsProgress(): Promise<StudentAssignment
       studentName,
       studentEmail: studentUser.email,
       experienceLevel: assignment.studentProfile.experienceLevel,
-      mentorId: assignment.studentProfile.mentorId,
-      mentorName,
+      mentors,
       projectTemplateId: assignment.projectTemplate.id,
       projectTitle: assignment.projectTemplate.title,
       projectDifficulty: assignment.projectTemplate.difficulty,

--- a/src/features/admin/server/user.test.ts
+++ b/src/features/admin/server/user.test.ts
@@ -3,69 +3,74 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 // prisma'yı mock'la (gerçek DB gerekmez)
 const { prismaMock } = vi.hoisted(() => ({
   prismaMock: {
-    user: { findUnique: vi.fn() },
+    user: { findUnique: vi.fn(), findMany: vi.fn() },
     studentProfile: { upsert: vi.fn() },
+    mentorAssignment: { deleteMany: vi.fn(), createMany: vi.fn() },
+    $transaction: vi.fn(),
   },
 }));
 vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
 
-import { assignMentor, AssignmentValidationError } from "./user";
+import { setStudentMentors, AssignmentValidationError } from "./user";
 
-/** user.findUnique için id→rol eşlemesi kuran yardımcı. */
-function mockRoles(roles: Record<string, "STUDENT" | "MENTOR" | "ADMIN">) {
-  prismaMock.user.findUnique.mockImplementation(
-    ({ where: { id } }: { where: { id: string } }) =>
-      Promise.resolve(roles[id] ? { role: roles[id] } : null),
-  );
-}
-
-describe("assignMentor — rol doğrulaması (#43)", () => {
+// #195: assignMentor (tek mentor) → setStudentMentors (M:N liste reconcile).
+describe("setStudentMentors — rol doğrulaması + M:N reconcile (#43/#195)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     prismaMock.studentProfile.upsert.mockResolvedValue({ id: "sp-1" });
+    prismaMock.mentorAssignment.deleteMany.mockReturnValue("del-op");
+    prismaMock.mentorAssignment.createMany.mockReturnValue("create-op");
+    prismaMock.$transaction.mockResolvedValue([]);
   });
 
-  it("geçerli STUDENT + MENTOR → upsert çağrılır", async () => {
-    mockRoles({ s1: "STUDENT", m1: "MENTOR" });
+  it("geçerli STUDENT + MENTOR listesi → reconcile ($transaction) çağrılır", async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ role: "STUDENT" });
+    prismaMock.user.findMany.mockResolvedValue([{ id: "m1" }]);
 
-    await assignMentor("s1", "m1");
+    await setStudentMentors("s1", ["m1"]);
 
     expect(prismaMock.studentProfile.upsert).toHaveBeenCalledOnce();
+    expect(prismaMock.$transaction).toHaveBeenCalledOnce();
   });
 
-  it("studentId STUDENT değilse → AssignmentValidationError, upsert yok", async () => {
-    mockRoles({ s1: "MENTOR", m1: "MENTOR" });
+  it("studentId STUDENT değilse → hata, reconcile yok", async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ role: "MENTOR" });
 
-    await expect(assignMentor("s1", "m1")).rejects.toBeInstanceOf(AssignmentValidationError);
-    expect(prismaMock.studentProfile.upsert).not.toHaveBeenCalled();
+    await expect(setStudentMentors("s1", ["m1"])).rejects.toBeInstanceOf(AssignmentValidationError);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
   });
 
-  it("mentorId MENTOR değilse → AssignmentValidationError, upsert yok", async () => {
-    mockRoles({ s1: "STUDENT", m1: "STUDENT" });
+  it("listedeki id MENTOR değilse → hata, reconcile yok", async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ role: "STUDENT" });
+    prismaMock.user.findMany.mockResolvedValue([]); // m1 MENTOR değil → doğrulama düşer
 
-    await expect(assignMentor("s1", "m1")).rejects.toBeInstanceOf(AssignmentValidationError);
-    expect(prismaMock.studentProfile.upsert).not.toHaveBeenCalled();
+    await expect(setStudentMentors("s1", ["m1"])).rejects.toBeInstanceOf(AssignmentValidationError);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
   });
 
-  it("öğrenci bulunamazsa → AssignmentValidationError", async () => {
-    mockRoles({});
+  it("öğrenci bulunamazsa → hata", async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
 
-    await expect(assignMentor("yok", "m1")).rejects.toBeInstanceOf(AssignmentValidationError);
+    await expect(setStudentMentors("yok", ["m1"])).rejects.toBeInstanceOf(AssignmentValidationError);
   });
 
-  it("mentor bulunamazsa → AssignmentValidationError", async () => {
-    mockRoles({ s1: "STUDENT" });
+  it("boş liste (tüm mentorları kaldır) → mentor doğrulaması yok, reconcile çağrılır", async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ role: "STUDENT" });
 
-    await expect(assignMentor("s1", "yok")).rejects.toBeInstanceOf(AssignmentValidationError);
+    await setStudentMentors("s1", []);
+
+    // Boş listede MENTOR-rol sorgusu (findMany) YAPILMAZ.
+    expect(prismaMock.user.findMany).not.toHaveBeenCalled();
+    expect(prismaMock.$transaction).toHaveBeenCalledOnce();
   });
 
-  it("mentorId null (atama kaldırma) → mentor kontrolü yok, upsert çağrılır", async () => {
-    mockRoles({ s1: "STUDENT" });
+  it("aynı mentor iki kez verilse → tekilleştirilir", async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ role: "STUDENT" });
+    prismaMock.user.findMany.mockResolvedValue([{ id: "m1" }]);
 
-    await assignMentor("s1", null);
+    await setStudentMentors("s1", ["m1", "m1"]);
 
-    // Yalnızca öğrenci için 1 findUnique; mentor sorgusu yapılmaz
-    expect(prismaMock.user.findUnique).toHaveBeenCalledOnce();
-    expect(prismaMock.studentProfile.upsert).toHaveBeenCalledOnce();
+    const arg = prismaMock.user.findMany.mock.calls[0][0] as { where: { id: { in: string[] } } };
+    expect(arg.where.id.in).toEqual(["m1"]);
   });
 });

--- a/src/features/admin/server/user.ts
+++ b/src/features/admin/server/user.ts
@@ -12,7 +12,8 @@ export type UserWithProfile = {
     id: string;
     experienceLevel?: string | null;
     interests: string[];
-    mentorId?: string | null;
+    // #195: M:N — öğrenciye atanmış mentorlar (0..n).
+    mentors: { id: string; name: string | null; lastName: string | null }[];
   } | null;
 };
 
@@ -21,7 +22,7 @@ export type UserWithProfile = {
 // NOT: Explicit select kullanılır — password hash gibi hassas alanlar
 // hiçbir zaman API response'una sızmamalı (include tüm scalar alanları döndürürdü).
 export async function getAllUsers(): Promise<UserWithProfile[]> {
-  return prisma.user.findMany({
+  const users = await prisma.user.findMany({
     select: {
       id: true,
       email: true,
@@ -34,12 +35,30 @@ export async function getAllUsers(): Promise<UserWithProfile[]> {
           id: true,
           experienceLevel: true,
           interests: true,
-          mentorId: true,
+          // #195: M:N — atanmış mentorların özet bilgisi (hash sızmaz, sadece seçili alanlar).
+          mentorAssignments: {
+            select: {
+              mentor: { select: { id: true, name: true, lastName: true } },
+            },
+          },
         },
       },
     },
     orderBy: { createdAt: "desc" },
   });
+
+  // mentorAssignments[] → düz mentors[] listesine indir (UI'ın beklediği şekil).
+  return users.map((u) => ({
+    ...u,
+    studentProfile: u.studentProfile
+      ? {
+          id: u.studentProfile.id,
+          experienceLevel: u.studentProfile.experienceLevel,
+          interests: u.studentProfile.interests,
+          mentors: u.studentProfile.mentorAssignments.map((a) => a.mentor),
+        }
+      : u.studentProfile,
+  }));
 }
 
 // ------------------------------------
@@ -85,9 +104,11 @@ export class AssignmentValidationError extends Error {
 }
 
 // ------------------------------------
-// Öğrenciye mentor atama (profil yoksa otomatik oluştur)
-// #43: Rolleri doğrula — yalnızca STUDENT'a, yalnızca MENTOR atanabilir.
-export async function assignMentor(studentId: string, mentorId: string | null) {
+// #195: Öğrencinin mentor LİSTESİNİ ayarla (M:N). Gelen liste "olması gereken tam
+// küme"dir: listede olmayan atamalar kaldırılır, eksikler eklenir (atomik reconcile).
+// Boş liste → tüm mentorlar kaldırılır. Profil yoksa oluşturulur.
+// #43: Roller doğrulanır — yalnız STUDENT'a, yalnız MENTOR atanabilir.
+export async function setStudentMentors(studentId: string, mentorIds: string[]) {
   const student = await prisma.user.findUnique({
     where: { id: studentId },
     select: { role: true },
@@ -101,30 +122,49 @@ export async function assignMentor(studentId: string, mentorId: string | null) {
     );
   }
 
-  // mentorId null → atamayı kaldır (rol kontrolü gerekmez)
-  if (mentorId !== null) {
-    const mentor = await prisma.user.findUnique({
-      where: { id: mentorId },
-      select: { role: true },
+  // Tekrarları ayıkla; her ID gerçekten MENTOR mü tek sorguda doğrula.
+  const uniqueMentorIds = [...new Set(mentorIds)];
+  if (uniqueMentorIds.length > 0) {
+    const mentors = await prisma.user.findMany({
+      where: { id: { in: uniqueMentorIds }, role: "MENTOR" },
+      select: { id: true },
     });
-    if (!mentor) {
-      throw new AssignmentValidationError("Mentor bulunamadı.");
-    }
-    if (mentor.role !== "MENTOR") {
+    if (mentors.length !== uniqueMentorIds.length) {
       throw new AssignmentValidationError(
-        "Yalnızca MENTOR rolündeki kullanıcı mentor olarak atanabilir.",
+        "Geçersiz mentor: yalnızca MENTOR rolündeki kullanıcılar atanabilir.",
       );
     }
   }
 
-  return prisma.studentProfile.upsert({
+  // Profil yoksa oluştur (eski assignMentor davranışı korunur).
+  const profile = await prisma.studentProfile.upsert({
     where: { userId: studentId },
-    update: { mentorId },
+    update: {},
     create: {
       userId: studentId,
-      mentorId,
       experienceLevel: "BEGINNER",
       interests: [],
     },
+    select: { id: true },
   });
+
+  // Atomik reconcile: listede olmayanları sil + eksikleri ekle.
+  await prisma.$transaction([
+    prisma.mentorAssignment.deleteMany({
+      where: {
+        studentProfileId: profile.id,
+        // Liste boşsa filtre yok → hepsi silinir (mentor ataması kaldırıldı).
+        ...(uniqueMentorIds.length > 0 ? { mentorId: { notIn: uniqueMentorIds } } : {}),
+      },
+    }),
+    prisma.mentorAssignment.createMany({
+      data: uniqueMentorIds.map((mentorId) => ({
+        studentProfileId: profile.id,
+        mentorId,
+      })),
+      skipDuplicates: true, // aynı mentor tekrar → sessizce atla (@@unique)
+    }),
+  ]);
+
+  return { studentProfileId: profile.id, mentorIds: uniqueMentorIds };
 }

--- a/src/features/mentors/server/actions.ts
+++ b/src/features/mentors/server/actions.ts
@@ -42,7 +42,8 @@ export async function getMentorStudents(mentorId: string): Promise<StudentWithPr
       where: {
         role: "STUDENT",
         studentProfile: {
-          mentorId: mentorId,
+          // #195: M:N — bu mentörün atandığı öğrenciler.
+          mentorAssignments: { some: { mentorId } },
         },
       },
       include: {
@@ -87,7 +88,8 @@ export async function getStudentDetail(studentId: string, mentorId: string) {
         id: studentId,
         role: "STUDENT",
         studentProfile: {
-          mentorId: mentorId,
+          // #195: M:N — öğrencinin mentorlarından biri bu mentör mü?
+          mentorAssignments: { some: { mentorId } },
         },
       },
       include: {
@@ -138,7 +140,8 @@ export async function assignProjectToStudent(
     const studentProfile = await prisma.studentProfile.findFirst({
       where: {
         id: studentProfileId,
-        mentorId: mentorId,
+        // #195: M:N — bu mentör öğrencinin mentorlarından biri mi?
+        mentorAssignments: { some: { mentorId } },
       },
     });
 
@@ -212,7 +215,8 @@ export async function updateProjectStatus(
       where: {
         id: assignedProjectId,
         studentProfile: {
-          mentorId: mentorId,
+          // #195: M:N — öğrencinin mentorlarından biri mi?
+          mentorAssignments: { some: { mentorId } },
         },
       },
     });
@@ -250,7 +254,8 @@ export async function unassignProject(
   const assignedProject = await prisma.assignedProject.findFirst({
     where: {
       id: assignedProjectId,
-      studentProfile: { mentorId },
+      // #195: M:N — öğrencinin mentorlarından biri mi?
+      studentProfile: { mentorAssignments: { some: { mentorId } } },
     },
     include: {
       roadmap: {

--- a/src/features/mentors/server/unassign-project.test.ts
+++ b/src/features/mentors/server/unassign-project.test.ts
@@ -46,7 +46,7 @@ describe("unassignProject action — sahiplik + force (#184)", () => {
     await unassignProject("ap-1", "mentor-1", false);
 
     const where = prismaMock.assignedProject.findFirst.mock.calls[0][0].where;
-    expect(where).toMatchObject({ id: "ap-1", studentProfile: { mentorId: "mentor-1" } });
+    expect(where).toMatchObject({ id: "ap-1", studentProfile: { mentorAssignments: { some: { mentorId: "mentor-1" } } } });
   });
 
   it("ilerleme yoksa (PENDING, DRAFT) force'suz → siler", async () => {

--- a/src/lib/auth/mentor-access.test.ts
+++ b/src/lib/auth/mentor-access.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { isAssignedMentor } from "./mentor-access";
+
+// #195: Çoklu mentor (M:N) yetki mantığı — regresyona karşı kilit.
+describe("isAssignedMentor (#195)", () => {
+  it("öğrencinin mentorlarından biriyse → true (birden fazla mentor)", () => {
+    const assignments = [{ mentorId: "A" }, { mentorId: "B" }];
+    expect(isAssignedMentor(assignments, "A")).toBe(true);
+    expect(isAssignedMentor(assignments, "B")).toBe(true);
+  });
+
+  it("öğrencinin mentoru DEĞİLSE → false (üçüncü bir mentor erişemez)", () => {
+    const assignments = [{ mentorId: "A" }, { mentorId: "B" }];
+    expect(isAssignedMentor(assignments, "C")).toBe(false);
+  });
+
+  it("hiç mentor atanmamışsa → false", () => {
+    expect(isAssignedMentor([], "A")).toBe(false);
+  });
+
+  it("liste veya kullanıcı yoksa güvenli tarafta kal → false", () => {
+    expect(isAssignedMentor(null, "A")).toBe(false);
+    expect(isAssignedMentor(undefined, "A")).toBe(false);
+    expect(isAssignedMentor([{ mentorId: "A" }], null)).toBe(false);
+    expect(isAssignedMentor([{ mentorId: "A" }], undefined)).toBe(false);
+  });
+});

--- a/src/lib/auth/mentor-access.ts
+++ b/src/lib/auth/mentor-access.ts
@@ -1,0 +1,14 @@
+// #195: Öğrenci ↔ mentör ilişkisi artık M:N (MentorAssignment join tablosu).
+// Bir mentörün bir öğrenciye erişim yetkisi, o öğrencinin mentor atamalarında
+// yer alıp almamasıyla belirlenir. Eski `studentProfile.mentorId === userId`
+// tek-eşleşme kontrolünün yerine bu yardımcı kullanılır.
+//
+// Kullanım: sorguya `mentorAssignments: { select: { mentorId: true } }` ekleyip
+// dönen listeyi buraya geçir.
+export function isAssignedMentor(
+  mentorAssignments: { mentorId: string }[] | null | undefined,
+  mentorUserId: string | null | undefined,
+): boolean {
+  if (!mentorUserId || !mentorAssignments) return false;
+  return mentorAssignments.some((a) => a.mentorId === mentorUserId);
+}

--- a/src/lib/validations/api.ts
+++ b/src/lib/validations/api.ts
@@ -8,10 +8,11 @@ export const updateRoleSchema = z.object({
   }),
 });
 
-// Admin: Mentor atama (mentorId null → atamayı kaldır)
+// #195: Admin — öğrencinin mentor LİSTESİNİ ayarla (M:N). Gelen dizi "olması
+// gereken tam küme"dir; boş dizi → tüm mentorlar kaldırılır.
 export const assignMentorSchema = z.object({
   studentId: z.string().min(1, "Öğrenci ID gerekli"),
-  mentorId: z.string().nullable(),
+  mentorIds: z.array(z.string().min(1)).max(20, "En fazla 20 mentor atanabilir"),
 });
 
 // ==========================================


### PR DESCRIPTION
## Özet
Bir öğrenciye **birden fazla mentor** atanabilir. `StudentProfile.mentorId` (tek mentor) yerine **`MentorAssignment` join tablosu** (M:N). Mentorlar **eşit yetkili** (birincil/lider yok). Güvenlik için **tek doğruluk kaynağı**: `mentorId` FK kaldırıldı.

## Değişiklikler
- **Şema + migration**: `MentorAssignment` (`@@unique([studentProfileId, mentorId])`, `@@index([mentorId])`). Mevcut atamalar **backfill** ile taşındı, sonra `mentorId` kolonu drop edildi. (Migration elle yazıldı: create → backfill → drop.)
- **Yetkilendirme (güvenlik-kritik)**: tüm `studentProfile.mentorId === userId` ve `where: { mentorId }` kontrolleri → `mentorAssignments: { some: { mentorId } }` + tek yardımcı `isAssignedMentor()` (`lib/auth/mentor-access.ts`). Kapsam: roadmap (GET/PUT/steps/step/ai-step), generate-roadmap, dosya + dosya[id], yorum + yorum[id], mesajlaşma (izin + konuşma listesi), AI proje önerisi, unassign/updateStatus/assignProject.
- **Admin**: `assignMentor` → `setStudentMentors(studentId, mentorIds[])` — liste "olması gereken tam küme", **atomik reconcile** (`$transaction` deleteMany+createMany). UI çoklu-mentor: atanmışlar **chip (kaldır)** + **"Mentor ekle" dropdown** (yalnız atanmamışlar). `assignment-progress`, admin panel ve student dashboard M:N'e uyarlandı.
- **Seed**: mentor ataması `MentorAssignment` upsert (idempotent).
- **Docs**: CLAUDE.md model tablosu.

## Test
- Mevcut `mentorId` mock'ları M:N şekline çevrildi (yetki + sorgu-assertion testleri).
- **Yeni çoklu-mentor senaryoları** (regresyon kilidi): `isAssignedMentor` birim testi; roadmap route'ta *ikinci mentor erişebilir → 200, atanmamış üçüncü → 403*; `setStudentMentors` reconcile + rol doğrulama.
- **408 test / 66 dosya geçti**; `tsc --noEmit` (production) temiz; `eslint` temiz.
- Migration lokal DB'ye uygulandı, backfill doğrulandı; `npm run seed` çalışıyor.

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)