### PR TITLE
feat: dosya yuklemelerini GCS'e tasi (deploy'da kalicilik + cok-instance)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,9 @@ olduğunu hatırlayın; aksi halde onboarding tamamen çöker.
 ### Dosya Yükleme (`/api/steps/[stepId]/files`)
 - Uzantı whitelist + **magic-byte içerik doğrulaması** (#113) + 10MB/10 dosya limiti.
 - Erişim: öğrenci(sahip) veya mentoru; öğrenci yalnızca PUBLISHED roadmap'e yükler.
-- Yerel disk (`uploads/`, docker volume). Çok-instance → GCS/S3: `DEPLOYMENT.md`.
+- **Depolama soyutlaması** `lib/storage/step-files.ts` (#197): `GCS_BUCKET` env varsa
+  **GCS**, yoksa **yerel disk** (graceful degradation). İndirme signed URL değil **proxy**
+  (route dosyayı okuyup akıtır) → per-request yetki kontrolü korunur. Detay: `DEPLOYMENT.md`.
 
 ### Process-local durumlar (tek instance varsayımı)
 `rate-limit.ts`, forgot-password `resetTokens`, `metrics.ts` — çok-instance/serverless'ta

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -58,6 +58,7 @@ Out Plane konsolunda servisin **Variables** bölümüne girilir.
 
 | Değişken | Varsayılan | Açıklama |
 |---|---|---|
+| `GCS_BUCKET` | _(yok)_ | **#197** — Dosya yüklemelerinin kalıcılığı. Verilirse yüklemeler bu GCS bucket'ına yazılır (deploy'da silinmez, çok-instance ölçeklenir). Kimlik: mevcut `GCP_CREDENTIALS_JSON` (ADC). Verilmezse yerel disk. |
 | `GITHUB_ORG` | `Posinowa` | GitHub çalışma alanı URL'lerinde kullanılan org. |
 | `PORT` | `3000` | Platform farklı bir port dayatıyorsa. |
 
@@ -99,8 +100,12 @@ bir ADMIN kullanıcı ekleyin.
 
 ## 5. Kalıcılık ve ölçekleme (dikkat)
 
-- **Dosya yüklemeleri** `/app/uploads`'a yazılır. Volume bağlanmazsa **her deploy'da silinir**.
-  Kalıcılık için Out Plane Volume'ünü `/app/uploads`'a bağlayın veya GCS/S3'e geçin.
+- **Dosya yüklemeleri (kalıcılık)** — iki seçenek (#197):
+  - **`GCS_BUCKET` ver (önerilen):** yüklemeler GCS'e yazılır, deploy'da silinmez, çok-instance
+    ölçeklenir. Ek kimlik gerekmez (mevcut `GCP_CREDENTIALS_JSON` kullanılır). Bucket'ı önceden
+    oluştur; servis hesabına `Storage Object Admin` yetkisi ver.
+  - **`GCS_BUCKET` verme:** yerel disk `/app/uploads`. Volume bağlanmazsa **her deploy'da silinir**;
+    kalıcılık için Out Plane Volume'ünü `/app/uploads`'a bağla (tek-instance).
 - **Tek-instance varsayımı**: `rate-limit.ts`, forgot-password token'ları ve `metrics.ts`
   bellek-içi (process-local) tutulur. **Birden çok instance** çalıştıracaksanız bunlar
   instance'lar arasında paylaşılmaz → Redis'e taşıyın. Tek instance ile sorun yok.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "aisigner",
       "version": "0.1.0",
       "dependencies": {
+        "@google-cloud/storage": "^7.21.0",
         "@google-cloud/vertexai": "^1.10.0",
         "@hookform/resolvers": "^5.2.1",
         "@node-rs/argon2": "^2.0.2",
@@ -929,6 +930,62 @@
         }
       }
     },
+    "node_modules/@google-cloud/paginator": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+      "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.21.0.tgz",
+      "integrity": "sha512-l+IFTkd+6Y5LoAuXyYCKNAKtw/Ci+rAMqgdTB1jv4iZiLhw0rtq+0qjIRbBizXkNzEFmXiXUW0H7sZQQvk1ffA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "<4.1.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^5.3.4",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@google-cloud/vertexai": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/vertexai/-/vertexai-1.12.0.tgz",
@@ -1822,6 +1879,18 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@node-rs/argon2": {
       "version": "2.0.2",
@@ -3091,6 +3160,15 @@
         }
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -3106,6 +3184,12 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
       "license": "MIT"
     },
     "node_modules/@types/chai": {
@@ -3216,10 +3300,28 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/request": {
+      "version": "2.48.13",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.5"
+      }
+    },
     "node_modules/@types/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "license": "MIT"
     },
     "node_modules/@types/unist": {
@@ -3974,6 +4076,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -4048,6 +4162,18 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4226,6 +4352,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4252,6 +4387,21 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -4448,7 +4598,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4669,6 +4818,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -4942,6 +5103,15 @@
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -5016,7 +5186,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5025,6 +5194,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -5060,6 +5241,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -5181,7 +5371,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5191,7 +5380,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5236,7 +5424,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -5249,7 +5436,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5813,6 +5999,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -5907,6 +6102,45 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -6021,6 +6255,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/form-data": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+      "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -6052,7 +6303,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6136,7 +6386,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -6161,7 +6410,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -6299,7 +6547,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6384,7 +6631,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6397,7 +6643,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -6413,7 +6658,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6475,6 +6719,22 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -6483,6 +6743,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -6544,6 +6830,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -7012,6 +7304,18 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
@@ -7677,7 +7981,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8559,6 +8862,39 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -9020,6 +9356,15 @@
         "node": "^10.13.0 || >=12.0.0"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/openid-client": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
@@ -9087,7 +9432,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -9187,6 +9531,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {
@@ -9575,6 +9934,20 @@
         "react": ">=18"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -9773,6 +10146,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/reusify": {
@@ -10231,6 +10618,30 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "license": "MIT",
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -10415,6 +10826,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -10518,6 +10950,47 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/teeny-request": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.9",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/teeny-request/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/tinybench": {
@@ -11041,6 +11514,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/uuid": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
@@ -11509,6 +11988,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.21.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
@@ -11540,6 +12025,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -11557,7 +12057,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:ai": "tsx --env-file=.env scripts/test-ai.ts"
   },
   "dependencies": {
+    "@google-cloud/storage": "^7.21.0",
     "@google-cloud/vertexai": "^1.10.0",
     "@hookform/resolvers": "^5.2.1",
     "@node-rs/argon2": "^2.0.2",

--- a/src/app/api/steps/[stepId]/files/[fileId]/route.test.ts
+++ b/src/app/api/steps/[stepId]/files/[fileId]/route.test.ts
@@ -1,21 +1,20 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-const { requireAuthMock, prismaMock, unlinkMock, existsMock, readFileMock } = vi.hoisted(() => ({
+// #197: fs yerine depolama katmanı (`@/lib/storage/step-files`) mock'lanır.
+const { requireAuthMock, prismaMock, deleteStepFileMock, readStepFileMock } = vi.hoisted(() => ({
   requireAuthMock: vi.fn(),
   prismaMock: { stepFile: { findUnique: vi.fn(), delete: vi.fn() } },
-  unlinkMock: vi.fn(),
-  existsMock: vi.fn(() => false),
-  readFileMock: vi.fn(),
+  deleteStepFileMock: vi.fn(),
+  readStepFileMock: vi.fn(() => Promise.resolve(null)),
 }));
 vi.mock("@/lib/auth/guard", () => ({
   requireAuth: (...a: unknown[]) => requireAuthMock(...a),
 }));
 vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
-vi.mock("fs/promises", () => ({
-  unlink: (...a: unknown[]) => unlinkMock(...a),
-  readFile: (...a: unknown[]) => readFileMock(...a),
+vi.mock("@/lib/storage/step-files", () => ({
+  deleteStepFile: (...a: unknown[]) => deleteStepFileMock(...a),
+  readStepFile: (...a: unknown[]) => readStepFileMock(...a),
 }));
-vi.mock("fs", () => ({ existsSync: (...a: unknown[]) => existsMock(...a) }));
 
 import { DELETE, GET } from "./route";
 
@@ -50,7 +49,7 @@ function stepFile(over: { uploaderId: string; ownerUserId: string; mentorId: str
 describe("dosya sil/indir — yetki sınırları (#181)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    existsMock.mockReturnValue(false);
+    readStepFileMock.mockResolvedValue(null); // varsayılan: dosya yok
   });
 
   // ---- DELETE ----
@@ -88,7 +87,7 @@ describe("dosya sil/indir — yetki sınırları (#181)", () => {
 
     expect(res.status).toBe(403);
     expect(prismaMock.stepFile.delete).not.toHaveBeenCalled();
-    expect(unlinkMock).not.toHaveBeenCalled();
+    expect(deleteStepFileMock).not.toHaveBeenCalled();
   });
 
   it("DELETE: başka öğrenci mentör rolüyle gelse de (o öğrencinin mentörü değil) → 403", async () => {
@@ -141,8 +140,7 @@ describe("dosya sil/indir — yetki sınırları (#181)", () => {
     prismaMock.stepFile.findUnique.mockResolvedValue(
       stepFile({ uploaderId: "student-1", ownerUserId: "student-1", mentorId: "mentor-1" }),
     );
-    existsMock.mockReturnValue(true);
-    readFileMock.mockResolvedValue(Buffer.from("veri"));
+    readStepFileMock.mockResolvedValue(Buffer.from("veri"));
 
     const res = await GET(new Request("http://t"), { params: params() });
 

--- a/src/app/api/steps/[stepId]/files/[fileId]/route.ts
+++ b/src/app/api/steps/[stepId]/files/[fileId]/route.ts
@@ -2,11 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/db";
 import { requireAuth } from "@/lib/auth/guard";
 import { isAssignedMentor } from "@/lib/auth/mentor-access";
-import { readFile, unlink } from "fs/promises";
-import { existsSync } from "fs";
-import path from "path";
-
-const UPLOAD_DIR = path.join(process.cwd(), "uploads", "steps");
+import { readStepFile, deleteStepFile } from "@/lib/storage/step-files";
 
 /**
  * GET /api/steps/[stepId]/files/[fileId]
@@ -61,15 +57,15 @@ export async function GET(
       );
     }
 
-    const filePath = path.join(UPLOAD_DIR, stepFile.storedName);
-    if (!existsSync(filePath)) {
+    // #197: GCS veya yerel diskten oku (backend env'e göre).
+    const buffer = await readStepFile(stepFile.storedName);
+    if (!buffer) {
       return NextResponse.json(
         { error: "Dosya sunucuda bulunamadı." },
         { status: 404 }
       );
     }
 
-    const buffer = await readFile(filePath);
     const uint8 = new Uint8Array(buffer);
 
     // Resim ve PDF için inline, diğerleri için attachment
@@ -154,11 +150,8 @@ export async function DELETE(
       );
     }
 
-    // Dosyayı diskten sil
-    const filePath = path.join(UPLOAD_DIR, stepFile.storedName);
-    if (existsSync(filePath)) {
-      await unlink(filePath);
-    }
+    // #197: GCS veya yerel diskten sil (backend env'e göre).
+    await deleteStepFile(stepFile.storedName);
 
     // Veritabanından sil
     await prisma.stepFile.delete({ where: { id: fileId } });

--- a/src/app/api/steps/[stepId]/files/route.test.ts
+++ b/src/app/api/steps/[stepId]/files/route.test.ts
@@ -129,5 +129,5 @@ describe("POST /api/steps/[stepId]/files — içerik imzası (#113)", () => {
 
 // #113: fs erişimi mock'lanır (vi.mock hoist edilir, tüm dosya için geçerli) —
 // imza testleri gerçek diske yazmasın. Önceki testler fs'e zaten ulaşmıyor.
-vi.mock("fs/promises", () => ({ writeFile: vi.fn(), mkdir: vi.fn() }));
-vi.mock("fs", () => ({ existsSync: vi.fn(() => true) }));
+// #197: Depolama katmanı mock'lanır — imza testleri gerçek diske/GCS'e yazmasın.
+vi.mock("@/lib/storage/step-files", () => ({ saveStepFile: vi.fn() }));

--- a/src/app/api/steps/[stepId]/files/route.ts
+++ b/src/app/api/steps/[stepId]/files/route.ts
@@ -4,8 +4,7 @@ import { requireAuth } from "@/lib/auth/guard";
 import { isAssignedMentor } from "@/lib/auth/mentor-access";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { matchesExtensionSignature } from "@/lib/file-signature";
-import { writeFile, mkdir } from "fs/promises";
-import { existsSync } from "fs";
+import { saveStepFile } from "@/lib/storage/step-files";
 import path from "path";
 import crypto from "crypto";
 
@@ -45,9 +44,8 @@ const SAFE_MIME_MAP: Record<string, string> = {
 const ALLOWED_EXTENSIONS = Object.keys(SAFE_MIME_MAP);
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
-// ⚠️ ÖLÇEKLEME: Yerel disk. Tek instance'ta kalıcı volume ile çalışır; çok
-// instance/serverless'ta GCS/S3'e taşıyın (bkz. DEPLOYMENT.md).
-const UPLOAD_DIR = path.join(process.cwd(), "uploads", "steps");
+// #197: Depolama artık `@/lib/storage/step-files` üzerinden — GCS_BUCKET varsa
+// GCS, yoksa yerel disk. (Yerel disk çok-instance/deploy'da kalıcı değildir.)
 
 /**
  * GET /api/steps/[stepId]/files
@@ -185,11 +183,6 @@ export async function POST(
     const safeExt = ext.replace(/[^a-z0-9.]/gi, "");
     const storedName = `${stepId}_${uniqueId}${safeExt}`;
 
-    // Upload dizinini oluştur
-    if (!existsSync(UPLOAD_DIR)) {
-      await mkdir(UPLOAD_DIR, { recursive: true });
-    }
-
     const buffer = Buffer.from(await file.arrayBuffer());
 
     // #113: Binary formatlarda dosya içeriği (magic bytes) uzantıyla eşleşmeli.
@@ -202,9 +195,8 @@ export async function POST(
       );
     }
 
-    // Dosyayı diske yaz
-    const filePath = path.join(UPLOAD_DIR, storedName);
-    await writeFile(filePath, buffer);
+    // #197: GCS veya yerel diske yaz (backend env'e göre seçilir).
+    await saveStepFile(storedName, buffer, mimeType);
 
     // Veritabanına kaydet
     const stepFile = await prisma.stepFile.create({

--- a/src/lib/storage/step-files.test.ts
+++ b/src/lib/storage/step-files.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// #197: fs mock'lanır — testler gerçek diske dokunmaz.
+const { writeFileMock, readFileMock, unlinkMock, mkdirMock, existsMock } = vi.hoisted(() => ({
+  writeFileMock: vi.fn(),
+  readFileMock: vi.fn(),
+  unlinkMock: vi.fn(),
+  mkdirMock: vi.fn(),
+  existsMock: vi.fn(() => true),
+}));
+vi.mock("fs/promises", () => ({
+  writeFile: (...a: unknown[]) => writeFileMock(...a),
+  readFile: (...a: unknown[]) => readFileMock(...a),
+  unlink: (...a: unknown[]) => unlinkMock(...a),
+  mkdir: (...a: unknown[]) => mkdirMock(...a),
+}));
+vi.mock("fs", () => ({ existsSync: (...a: unknown[]) => existsMock(...a) }));
+
+// GCS_BUCKET tanımsız (test ortamı) → yerel disk branch'i doğrulanır.
+import { saveStepFile, readStepFile, deleteStepFile, usingGcs } from "./step-files";
+
+describe("step-files storage — yerel disk branch (#197)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("GCS_BUCKET yoksa usingGcs() → false", () => {
+    expect(usingGcs()).toBe(false);
+  });
+
+  it("save → writeFile çağrılır", async () => {
+    existsMock.mockReturnValue(true);
+    await saveStepFile("abc.png", Buffer.from("x"), "image/png");
+    expect(writeFileMock).toHaveBeenCalledOnce();
+  });
+
+  it("read → dosya varsa buffer, yoksa null", async () => {
+    existsMock.mockReturnValue(true);
+    readFileMock.mockResolvedValue(Buffer.from("data"));
+    expect(await readStepFile("abc.png")).toEqual(Buffer.from("data"));
+
+    // Dosya yoksa readFile hiç çağrılmaz, null döner.
+    vi.clearAllMocks();
+    existsMock.mockReturnValue(false);
+    expect(await readStepFile("yok.png")).toBeNull();
+    expect(readFileMock).not.toHaveBeenCalled();
+  });
+
+  it("delete → dosya varsa unlink, yoksa sessiz geçer", async () => {
+    existsMock.mockReturnValue(true);
+    await deleteStepFile("abc.png");
+    expect(unlinkMock).toHaveBeenCalledOnce();
+
+    vi.clearAllMocks();
+    existsMock.mockReturnValue(false);
+    await deleteStepFile("yok.png");
+    expect(unlinkMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/storage/step-files.test.ts
+++ b/src/lib/storage/step-files.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
+// Bu birim test yerel-disk branch'ini kapsar (CI'da bağımlılıksız).
+//
+// GCS branch'i manuel bir emülatörle uçtan uca doğrulandı (fake-gcs-server):
+//   docker run -d --name fake-gcs -p 4443:4443 fsouza/fake-gcs-server -scheme http -port 4443
+//   curl -X POST "http://localhost:4443/storage/v1/b?project=test" -d '{"name":"aisigner-test"}'
+//   GCS_BUCKET=aisigner-test GCS_API_ENDPOINT=http://localhost:4443 GOOGLE_CLOUD_PROJECT=test \
+//     tsx -e "<saveStepFile→readStepFile→deleteStepFile round-trip>"
+// Sonuç: save/read/delete + eksik-dosya→null uçtan uca ✓.
+
 // #197: fs mock'lanır — testler gerçek diske dokunmaz.
 const { writeFileMock, readFileMock, unlinkMock, mkdirMock, existsMock } = vi.hoisted(() => ({
   writeFileMock: vi.fn(),

--- a/src/lib/storage/step-files.ts
+++ b/src/lib/storage/step-files.ts
@@ -23,12 +23,17 @@ const GCS_PREFIX = "steps/";
 const UPLOAD_DIR = path.join(process.cwd(), "uploads", "steps");
 
 // GCS istemcisi tembel yüklenir — env yoksa paket hiç import edilmez.
+// GCS_API_ENDPOINT: yalnızca yerel emülatör/test içindir (ör. fake-gcs-server).
+// Prod'da tanımlanmaz → gerçek GCS'e ADC ile bağlanılır.
 let bucketPromise: Promise<Bucket> | null = null;
 async function getBucket(): Promise<Bucket> {
   if (!bucketPromise) {
-    bucketPromise = import("@google-cloud/storage").then(
-      ({ Storage }) => new Storage().bucket(GCS_BUCKET as string),
-    );
+    bucketPromise = import("@google-cloud/storage").then(({ Storage }) => {
+      const opts = process.env.GCS_API_ENDPOINT
+        ? { apiEndpoint: process.env.GCS_API_ENDPOINT, projectId: process.env.GOOGLE_CLOUD_PROJECT || "local" }
+        : {};
+      return new Storage(opts).bucket(GCS_BUCKET as string);
+    });
   }
   return bucketPromise;
 }

--- a/src/lib/storage/step-files.ts
+++ b/src/lib/storage/step-files.ts
@@ -1,0 +1,86 @@
+// #197: Adım dosyaları (StepFile) için depolama katmanı.
+//
+// Amaç: yüklenen dosyalar deploy'da kaybolmasın. `GCS_BUCKET` env tanımlıysa
+// Google Cloud Storage kullanılır; tanımlı DEĞİLSE yerel diske düşer (dev +
+// tek-instance eski davranış). Böylece AI entegrasyonundaki graceful-degradation
+// deseniyle tutarlı kalırız: env yoksa yerel disk, varsa bulut.
+//
+// GCS kimliği ayrı bir şey gerektirmez — mevcut Application Default Credentials
+// (docker-entrypoint.sh'ın yazdığı GOOGLE_APPLICATION_CREDENTIALS) kullanılır.
+//
+// İndirme bilinçli olarak signed URL DEĞİL, proxy (route dosyayı okuyup akıtır):
+// böylece her istekte route'un yetki kontrolü (sahip/atanmış mentör) korunur.
+import { writeFile, readFile, unlink, mkdir } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import type { Bucket } from "@google-cloud/storage";
+
+const GCS_BUCKET = process.env.GCS_BUCKET;
+// Bucket içinde adım dosyaları için klasör öneki.
+const GCS_PREFIX = "steps/";
+
+// Yerel disk yolu (GCS yoksa) — eski davranışla birebir aynı.
+const UPLOAD_DIR = path.join(process.cwd(), "uploads", "steps");
+
+// GCS istemcisi tembel yüklenir — env yoksa paket hiç import edilmez.
+let bucketPromise: Promise<Bucket> | null = null;
+async function getBucket(): Promise<Bucket> {
+  if (!bucketPromise) {
+    bucketPromise = import("@google-cloud/storage").then(
+      ({ Storage }) => new Storage().bucket(GCS_BUCKET as string),
+    );
+  }
+  return bucketPromise;
+}
+
+/** Depolama backend'i GCS mi (true) yoksa yerel disk mi (false)? */
+export function usingGcs(): boolean {
+  return Boolean(GCS_BUCKET);
+}
+
+/** Dosyayı kaydeder (GCS veya yerel disk). */
+export async function saveStepFile(
+  storedName: string,
+  buffer: Buffer,
+  mimeType: string,
+): Promise<void> {
+  if (GCS_BUCKET) {
+    const bucket = await getBucket();
+    await bucket.file(GCS_PREFIX + storedName).save(buffer, {
+      resumable: false,
+      contentType: mimeType,
+    });
+    return;
+  }
+  if (!existsSync(UPLOAD_DIR)) await mkdir(UPLOAD_DIR, { recursive: true });
+  await writeFile(path.join(UPLOAD_DIR, storedName), buffer);
+}
+
+/** Dosyayı okur; yoksa null döner (404'e çevirmek çağıranın işi). */
+export async function readStepFile(storedName: string): Promise<Buffer | null> {
+  if (GCS_BUCKET) {
+    const bucket = await getBucket();
+    try {
+      const [buf] = await bucket.file(GCS_PREFIX + storedName).download();
+      return buf;
+    } catch (err) {
+      // GCS "yok" hatası (404) → null; diğer hatalar yükseltilir.
+      if ((err as { code?: number }).code === 404) return null;
+      throw err;
+    }
+  }
+  const filePath = path.join(UPLOAD_DIR, storedName);
+  if (!existsSync(filePath)) return null;
+  return readFile(filePath);
+}
+
+/** Dosyayı siler (yoksa sessizce geçer). */
+export async function deleteStepFile(storedName: string): Promise<void> {
+  if (GCS_BUCKET) {
+    const bucket = await getBucket();
+    await bucket.file(GCS_PREFIX + storedName).delete({ ignoreNotFound: true });
+    return;
+  }
+  const filePath = path.join(UPLOAD_DIR, storedName);
+  if (existsSync(filePath)) await unlink(filePath);
+}


### PR DESCRIPTION
## Özet
Yüklenen dosyalar artık **deploy'da kaybolmuyor**. `StepFile` depolaması için bir **soyutlama katmanı** (`lib/storage/step-files.ts`): `GCS_BUCKET` env verilirse **Google Cloud Storage**, verilmezse **yerel disk** (graceful degradation — AI entegrasyonundaki desenle tutarlı). Kimlik için ek bir şey gerekmez; mevcut ADC (`GCP_CREDENTIALS_JSON`) kullanılır.

## Neden
Dosyalar `/app/uploads`'a (konteyner diski) yazılıyordu → Volume yoksa her deploy'da sıfırlanıyordu ve çok-instance'ta paylaşılmıyordu. (#197)

## Değişiklikler
- **`lib/storage/step-files.ts`**: `saveStepFile` / `readStepFile` / `deleteStepFile` + `usingGcs()`. GCS istemcisi **tembel** yüklenir (env yoksa paket hiç import edilmez).
- **Upload/download/delete route'ları** bu katmanı kullanır (disk I/O soyutlandı).
- **İndirme signed URL DEĞİL proxy**: route dosyayı okuyup akıtır → **per-request yetki kontrolü** (sahip/mentör) aynen korunur; güvenlik posturası değişmez. Response başlıkları (`nosniff`, `Content-Security-Policy: sandbox`, disposition) korundu.
- **Testler**: fs mock'ları storage katmanına çevrildi + `step-files` yerel-disk **birim testi** (save/read/delete + null sözleşmesi).
- **Docs**: DEPLOYMENT.md (`GCS_BUCKET` env + kalıcılık bölümü), CLAUDE.md.

## Test
- **406 test / 66 dosya geçti**; `tsc --noEmit` (production) temiz; `eslint` temiz.
- `npm run build` başarılı (yeni bağımlılıkla derleniyor).
- **CI lockfile**: `npx npm@10 ci --dry-run` sorunsuz (yeni dep npm@10 uyumlu).

## Kurulum (prod)
GCS bucket oluştur → servis hesabına `Storage Object Admin` ver → `GCS_BUCKET=<bucket-adı>` env'i ekle. Verilmezse yerel disk davranışı (eskisi) korunur.

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)