### PR TITLE
chore: yikici migration guard + expand/contract playbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
           node-version: 20
           cache: npm
 
+      # #198: Yıkıcı (geriye-uyumsuz) migration guard — bağımlılık gerektirmez.
+      - name: Migration safety check
+        run: node scripts/check-migrations.mjs
+
       - name: Detect package scripts
         shell: bash
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,9 +119,14 @@ Redis gerekir → `DEPLOYMENT.md`.
 npm run dev / build / lint / test
 npm run seed          # idempotent demo verisi (kullanıcılar + şablonlar)
 npm run test:ai       # Vertex AI bağlantı testi (.env gerekli)
+npm run check:migrations   # yıkıcı migration guard (#198, CI'da zorunlu)
 npx prisma migrate dev --name <ad>   # yeni şema değişikliği (db push kullanmayın)
 docker compose up -d  # db (+app) — uploads kalıcı volume'da
 ```
+
+> **Migration güvenliği (#198):** kolon/tablo silme, rename, NOT NULL gibi **yıkıcı**
+> değişiklikleri tek deploy'da yapmayın — **expand/contract** ile bölün. Kural + guard +
+> onay mekanizması: `docs/MIGRATIONS.md`. CI, onaysız yıkıcı migration'ı FAIL eder.
 
 ## Tasarım Sistemi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,8 @@ refactor: prisma client singleton'ı birleştir
 - [ ] Kodunuz lint kontrolünden geçiyor: `npm run lint`
 - [ ] Build başarıyla tamamlanıyor: `npm run build`
 - [ ] Testler geçiyor: `npm test`
-- [ ] İlgili migration varsa eklenmiş
+- [ ] İlgili migration varsa eklenmiş — ve **yıkıcı** (drop/rename/NOT NULL) ise
+      expand/contract'a bölünmüş: `npm run check:migrations` yeşil (bkz. `docs/MIGRATIONS.md`)
 - [ ] Gereksiz dosya değişikliği yok
 - [ ] `.env`, private key veya service account dosyası commit edilmedi
 

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -1,0 +1,88 @@
+# Migration Güvenliği — expand/contract oyun kitabı
+
+Bu belge, şema göçlerini (Prisma migration) **zero-downtime deploy'u bozmadan** yazmak
+içindir. Kısa özet: **yıkıcı değişiklikleri (kolon/tablo silme, rename, NOT NULL) tek bir
+deploy'da yapma — faz faz böl.**
+
+> Deploy mekaniği için `DEPLOYMENT.md`. Guard: `npm run check:migrations` (CI'da zorunlu).
+
+---
+
+## 1. Neden sorun?
+
+Out Plane (ve çoğu PaaS) **downtime'sız** deploy eder: yeni sürüm ayağa kalkarken **eski
+sürüm hâlâ trafik alır**. Konteyner açılışında `docker-entrypoint.sh` → `prisma migrate
+deploy` çalışır. Bu migration bir kolonu **drop** ederse, o kısa çakışma penceresinde hâlâ
+koşan **eski kod** o kolonu sorgular → **hata**.
+
+Yani şema ile kod **iki farklı sürümde** olabildiği an, şema **her iki koda da uyumlu**
+olmalıdır.
+
+---
+
+## 2. Altın kural: expand → migrate → contract
+
+Yıkıcı bir değişikliği **aynı** deploy'da yapma. Üç faza böl (genelde ≥2 ayrı deploy):
+
+| Faz | Ne yapılır | Geriye uyumlu mu? |
+|---|---|---|
+| **1. Expand** | Yeni kolon/tablo **nullable/additive** eklenir. | ✅ Eski kod yeni alanı görmez, bozulmaz. |
+| **2. Migrate** | Veri backfill edilir; kod **hem eskiyi hem yeniyi** yazar/okur (geçiş). | ✅ |
+| **3. Contract** | Eski sürüm tamamen gidince, **AYRI bir deploy'da** eski kolon drop edilir. | ✅ Artık kimse kullanmıyor. |
+
+### Örnekler
+
+- **Kolon ekleme**: her zaman `NULL` veya `DEFAULT` ile ekle. `NOT NULL` gerekiyorsa: (1)
+  nullable ekle, (2) backfill, (3) ayrı deploy'da `SET NOT NULL`.
+- **Kolon silme**: (1) koddan kullanımını kaldır + deploy, (2) sonraki deploy'da `DROP COLUMN`.
+- **Rename**: rename = drop + add. Yeni kolon ekle → çift-yaz → backfill → okumayı yeniye
+  çevir → eskiyi ayrı deploy'da drop et.
+- **Tabloyu M:N'e çevirme (gerçek örnek #195)**: `StudentProfile.mentorId` → `MentorAssignment`
+  join tablosu. Güvenli sıra: (1) join tablosunu ekle + çift-yaz, (2) backfill, (3) ayrı
+  deploy'da `mentorId` kolonunu drop et. *(#195 tek migration'da drop etti; ilk deploy boş
+  DB'ye gittiği için sorun olmadı — aşağıya bak.)*
+
+---
+
+## 3. İstisna: ilk deploy / boş DB
+
+İlk deploy'da **eski sürüm yoktur** — tüm migration'lar temiz/boş bir DB'ye uygulanır,
+çakışma penceresi yoktur. Bu yüzden **ilk deploy öncesi** yazılmış migration'lar drop içerse
+de güvenlidir. Kural asıl **canlıya çıktıktan sonraki** güncellemeler için geçerlidir.
+
+---
+
+## 4. Guard: `npm run check:migrations`
+
+`scripts/check-migrations.mjs`, `prisma/migrations/*/migration.sql` içinde **DROP COLUMN,
+DROP TABLE, RENAME, SET NOT NULL** arar. Böyle bir ifade bulur ve migration **onay yorumu
+taşımıyorsa CI FAIL** eder. (CI adımı: `.github/workflows/ci.yml`.)
+
+Bilinçli ve güvenli olduğundan eminsen (ör. ilk-deploy boş DB, ya da expand/contract'ın 3.
+fazı — kimse artık kullanmıyor), migration dosyasının başına şunu ekle:
+
+```sql
+-- migration-safety-ack: expand/contract faz-3; kolon 2 deploy önce kod tarafında bırakıldı
+```
+
+Onay yorumu **düşünmeyi zorunlu kılar** — drop'un kazara canlıya gitmesini engeller.
+
+---
+
+## 5. Çok-instance notu
+
+`prisma migrate deploy` bir **Postgres advisory lock** alır → aynı anda birden çok konteyner
+`migrate deploy` çalıştırsa bile yalnızca biri uygular, diğerleri bekler/atlar (veri
+bozulmaz). Yani entrypoint'te migration çalıştırmak tek-instance'ta olduğu gibi çok-instance'ta
+da **güvenlidir**. Yine de büyük/uzun migration'larda tercih: migration'ı ayrı bir
+**release/pre-deploy adımına** taşımak (Out Plane böyle bir hook sunuyorsa).
+
+---
+
+## 6. PR checklist (migration içeren PR'lar)
+
+- [ ] Migration **additive** mi? (yeni alan nullable/default ile mi?)
+- [ ] Drop/rename/NOT NULL var mı? Varsa **expand/contract'a** bölündü mü?
+- [ ] `npm run check:migrations` yeşil mi? (yıkıcı + onaysız ifade yok)
+- [ ] Backfill gerekiyorsa migration'a eklendi mi (veri kaybı yok)?
+- [ ] İlk-deploy istisnası geçerliyse `-- migration-safety-ack:` gerekçesi yazıldı mı?

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint",
     "test": "vitest run",
     "test:watch": "vitest",
+    "check:migrations": "node scripts/check-migrations.mjs",
     "seed": "tsx scripts/seed.ts",
     "test:ai": "tsx --env-file=.env scripts/test-ai.ts"
   },

--- a/scripts/check-migrations.mjs
+++ b/scripts/check-migrations.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+// #198: Yıkıcı migration guard — zero-downtime deploy güvenliği.
+//
+// prisma/migrations/*/migration.sql içindeki geriye-uyumsuz (yıkıcı) ifadeleri
+// yakalar: DROP COLUMN, DROP TABLE, RENAME COLUMN/TABLE, SET NOT NULL. Böyle bir
+// ifade içeren bir migration açık onay yorumu taşımıyorsa CI'ı FAIL eder.
+//
+// Neden: Out Plane downtime'sız deploy'da eski + yeni sürüm kısa süre birlikte koşar.
+// Yeni konteynerdeki `migrate deploy` bir kolonu drop ederse, hâlâ trafik alan eski
+// sürüm o kolonu sorgulayınca hata verir. Çözüm expand/contract'tır (docs/MIGRATIONS.md).
+//
+// Bilinçli/güvenli bir drop (ör. ilk deploy — boş DB, ya da expand/contract'ın 3.
+// fazı) için migration dosyasının başına şu yorumu ekleyin:
+//   -- migration-safety-ack: <kısa gerekçe>
+//
+// Bağımlılık yok — CI'da `npm ci` öncesinde bile çalışır.
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+
+const MIGRATIONS_DIR = path.join(process.cwd(), "prisma", "migrations");
+const ACK_MARKER = "migration-safety-ack:";
+
+// Geriye-uyumsuz ifadeler. DROP CONSTRAINT bilinçli olarak DIŞARIDA: init pkey
+// churn'ü gibi benign durumlarda yanlış alarm yapmasın.
+const DESTRUCTIVE = [
+  { re: /\bDROP\s+COLUMN\b/i, label: "DROP COLUMN" },
+  { re: /\bDROP\s+TABLE\b/i, label: "DROP TABLE" },
+  { re: /\bRENAME\s+COLUMN\b/i, label: "RENAME COLUMN" },
+  { re: /\bRENAME\s+TO\b/i, label: "RENAME TO (tablo)" },
+  { re: /\bSET\s+NOT\s+NULL\b/i, label: "SET NOT NULL" },
+];
+
+if (!existsSync(MIGRATIONS_DIR)) {
+  console.log("Migration klasörü yok — atlanıyor.");
+  process.exit(0);
+}
+
+const violations = [];
+for (const entry of readdirSync(MIGRATIONS_DIR, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const sqlPath = path.join(MIGRATIONS_DIR, entry.name, "migration.sql");
+  if (!existsSync(sqlPath)) continue;
+
+  const sql = readFileSync(sqlPath, "utf8");
+  const acked = sql.includes(ACK_MARKER);
+  if (acked) continue; // Bilinçli onaylanmış — atla.
+
+  sql.split(/\r?\n/).forEach((line, i) => {
+    if (line.trim().startsWith("--")) return; // yorum satırı
+    for (const d of DESTRUCTIVE) {
+      if (d.re.test(line)) {
+        violations.push({
+          file: `${entry.name}/migration.sql`,
+          line: i + 1,
+          label: d.label,
+          text: line.trim(),
+        });
+      }
+    }
+  });
+}
+
+if (violations.length === 0) {
+  console.log("✓ Migration güvenlik kontrolü: yıkıcı + onaysız ifade yok.");
+  process.exit(0);
+}
+
+console.error("✗ Yıkıcı (geriye-uyumsuz) migration ifadeleri bulundu — onay yorumu yok:\n");
+for (const v of violations) {
+  console.error(`  ${v.file}:${v.line}  [${v.label}]  ${v.text}`);
+}
+console.error(`
+Zero-downtime deploy'da eski sürüm hâlâ koşarken bu ifadeler onu bozabilir.
+Çözüm (bkz. docs/MIGRATIONS.md): expand/contract — önce additive ekle, sonra AYRI
+bir deploy'da drop et. Bilinçli ve güvenli olduğundan eminsen migration dosyasının
+başına şu yorumu ekle:
+
+  -- migration-safety-ack: <kısa gerekçe (ör. ilk-deploy: boş DB / expand-contract faz-3)>
+`);
+process.exit(1);


### PR DESCRIPTION
## Özet
Zero-downtime deploy'da yıkıcı migration'ların eski sürümü bozmasını önlemek için **guard + oyun kitabı**. Bu bir çalışan-bug değil, **süreç/disiplin** koruması — kolon/tablo silme gibi geriye-uyumsuz değişikliklerin kazara canlıya gitmesini engeller.

## Neden
Out Plane downtime'sız deploy'da eski + yeni sürüm kısa süre birlikte koşar. Yeni konteynerdeki `migrate deploy` bir kolonu drop ederse, hâlâ trafik alan eski sürüm o kolonu sorgulayınca hata verir. Çözüm expand/contract'tır.

## Değişiklikler
- **`scripts/check-migrations.mjs`** (bağımlılıksız): `prisma/migrations/*/migration.sql` içinde **DROP COLUMN / DROP TABLE / RENAME / SET NOT NULL** arar. Böyle bir ifade **onay yorumu** (`-- migration-safety-ack: <gerekçe>`) taşımıyorsa **FAIL** eder. → düşünmeyi zorunlu kılar.
- **`npm run check:migrations`** + **CI adımı** (`ci.yml`, `npm ci` öncesinde erken fail).
- **`docs/MIGRATIONS.md`**: expand → migrate → contract oyun kitabı, örnekler (kolon ekle/sil, rename, **#195 M:N** vakası), **ilk-deploy/boş-DB istisnası**, çok-instance `migrate deploy` advisory-lock notu, PR checklist.
- **CLAUDE.md** + **CONTRIBUTING.md**: kural + link + checklist maddesi.

## Notlar
- `DROP CONSTRAINT` bilinçli olarak kapsam dışı (init pkey churn'ü yanlış alarm yapmasın). Develop'ta guard **temiz** geçer (`✓`).
- Guard iki yönde test edildi: develop temiz → exit 0; `DROP COLUMN` içeren migration → exit 1; `-- migration-safety-ack:` yorumu → tekrar temiz.
- `eslint` temiz.

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)