### PR TITLE
chore: guvenli ilk-admin olusturma script'i (create-admin)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -75,12 +75,26 @@ Out Plane konsolunda servisin **Variables** bölümüne girilir.
    `→ Prisma migrate deploy çalışıyor...` ve `→ Uygulama başlatılıyor...`.
 5. **Doğrula**: `https://<url>/api/health` 200 dönmeli; ardından `/signin`.
 
-### İlk admin'i güvenli oluştur
+### İlk admin'i güvenli oluştur (#206)
 
-`npm run seed` **prod'da ÇALIŞTIRILMAZ** (aşağıdaki güvenlik listesine bakın). İlk yönetici için:
-tek seferlik güvenli bir script ile veya DB'ye elle, **güçlü ve benzersiz** bir parolayla
-(argon2 hash — `@node-rs/argon2`'nin `hash()` fonksiyonu; `scripts/seed.ts` örnek alınabilir)
-bir ADMIN kullanıcı ekleyin.
+`npm run seed` **prod'da ÇALIŞTIRILMAZ** — zayıf demo admin (`admin@example.com`) açar.
+Gerçek yöneticiyi **`scripts/create-admin.ts`** ile oluştur: kimlik bilgileri **ortam
+değişkeninden** okunur (repoya hardcode edilmez, parola loglanmaz), argon2 ile hash'lenir,
+ADMIN + APPROVED olarak **idempotent** upsert edilir (aynı komut parola sıfırlamak için de
+kullanılabilir).
+
+Bir **dev makineden**, prod DB'ye SSL ile bağlanarak tek sefer çalıştır:
+
+```bash
+DATABASE_URL="postgresql://user:pass@host:5432/db?sslmode=require" \
+ADMIN_EMAIL="admin@posinowa.com" \
+ADMIN_PASSWORD="<güçlü-parola>" \
+npm run create:admin
+```
+
+> **Not:** `tsx` bir dev bağımlılığıdır; prod imajında (`--omit=dev`) yoktur. Bu yüzden script,
+> imaj içinde değil, `tsx`'in bulunduğu bir dev makineden prod `DATABASE_URL`'ine karşı çalıştırılır.
+> `ADMIN_PASSWORD`'ü terminal geçmişine yazmamak için tek satırda inline env olarak ver.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:watch": "vitest",
     "check:migrations": "node scripts/check-migrations.mjs",
     "seed": "tsx scripts/seed.ts",
+    "create:admin": "tsx scripts/create-admin.ts",
     "test:ai": "tsx --env-file=.env scripts/test-ai.ts"
   },
   "dependencies": {

--- a/scripts/create-admin.ts
+++ b/scripts/create-admin.ts
@@ -1,0 +1,68 @@
+/**
+ * #206: Güvenli ilk-admin oluşturma (prod deploy).
+ *
+ * Prod'da `npm run seed` ÇALIŞTIRILMAZ (zayıf demo admin: admin@example.com).
+ * Gerçek yönetici hesabını bu script ile oluştur. Kimlik bilgileri ORTAM
+ * DEĞİŞKENİNDEN okunur — repoya hardcode EDİLMEZ, parola loglanmaz.
+ *
+ * Kullanım (dev makineden prod DB'ye, SSL ile):
+ *   DATABASE_URL="postgresql://user:pass@host:5432/db?sslmode=require" \
+ *   ADMIN_EMAIL="admin@posinowa.com" \
+ *   ADMIN_PASSWORD="<güçlü-parola>" \
+ *   npx tsx scripts/create-admin.ts
+ *
+ * Idempotent: aynı e-posta ile tekrar çalıştırılırsa parolayı günceller
+ * (ADMIN rolüne + APPROVED durumuna çeker). Şifre sıfırlama için de kullanılabilir.
+ */
+import { PrismaClient } from "@prisma/client";
+import { hash } from "@node-rs/argon2";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const email = process.env.ADMIN_EMAIL?.toLowerCase().trim();
+  const password = process.env.ADMIN_PASSWORD;
+
+  if (!email || !password) {
+    console.error(
+      "✗ ADMIN_EMAIL ve ADMIN_PASSWORD ortam değişkenleri zorunludur.\n" +
+        '  Örn: ADMIN_EMAIL="admin@posinowa.com" ADMIN_PASSWORD="<parola>" npx tsx scripts/create-admin.ts',
+    );
+    process.exit(1);
+  }
+
+  // Basit e-posta + parola sağlamlık kontrolü (prod admin zayıf olmasın).
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    console.error("✗ Geçersiz e-posta biçimi.");
+    process.exit(1);
+  }
+  if (password.length < 10) {
+    console.error("✗ Parola en az 10 karakter olmalı (prod için daha güçlüsü önerilir).");
+    process.exit(1);
+  }
+
+  const hashed = await hash(password);
+
+  const user = await prisma.user.upsert({
+    where: { email },
+    update: { password: hashed, role: "ADMIN", accountStatus: "APPROVED" },
+    create: {
+      email,
+      password: hashed,
+      role: "ADMIN",
+      accountStatus: "APPROVED",
+      name: "Yönetici",
+    },
+    select: { id: true, email: true, role: true },
+  });
+
+  // Parola ASLA loglanmaz.
+  console.log(`✓ Admin hazır: ${user.email} (rol: ${user.role}). Artık bu hesapla giriş yapabilirsin.`);
+}
+
+main()
+  .catch((e) => {
+    console.error("✗ Admin oluşturma hatası:", e instanceof Error ? e.message : e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Özet
Prod'da `npm run seed` çalıştırılamaz (zayıf demo admin `admin@example.com` = arka kapı). Gerçek yöneticiyi güvenli, env-tabanlı bir script ile oluşturmak için `scripts/create-admin.ts` + `npm run create:admin`.

## Neden
Deploy öncesi eksikti: `admin@example.com` yerine gerçek bir admin (ör. `admin@posinowa.com`) **güçlü parolayla** ve **repoya sızmadan** oluşturulmalı.

## Değişiklikler
- **`scripts/create-admin.ts`**: `ADMIN_EMAIL` + `ADMIN_PASSWORD` **env'inden** okur → argon2 hash → **ADMIN + APPROVED** idempotent upsert. Parola **asla loglanmaz/hardcode edilmez**. E-posta biçimi + min parola uzunluğu kontrolü.
- **`npm run create:admin`**.
- **DEPLOYMENT.md**: "İlk admin" bölümü bu script'e + güvenli çalıştırma komutuna yönlendirildi (dev makineden prod DB'ye SSL ile; `tsx` prod imajında olmadığı için).

## Güvenlik
- Parola repoya/commit'e/log'a girmez; yalnız çalıştırma anında inline env olarak verilir.
- İdempotent → parola sıfırlama için de kullanılabilir.

## Test (yerel)
- Script çalıştırıldı → `admin@posinowa.com` ADMIN/APPROVED oluştu.
- `@node-rs/argon2` `verify`: doğru parola → `true`, yanlış → `false` (login akışının kullandığı doğrulama).
- `tsc` + `eslint` temiz.

Closes #206