### PR TITLE
feat: mezuniyet salt-okunur portfolyo, public sertifika dogrulama + completionGrade fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,12 @@ olduğunu hatırlayın; aksi halde onboarding tamamen çöker.
 `rate-limit.ts`, forgot-password `resetTokens`, `metrics.ts` — çok-instance/serverless'ta
 Redis gerekir → `DEPLOYMENT.md`.
 
+### Mezuniyet & Sertifika Doğrulama Sistemi (#208)
+- **Mezuniyet Durumu (`accountStatus: GRADUATED`)**: Portfolyo salt-okunur (Seçenek A). Öğrenci dashboard, yol haritası adımları, dosyaları, yorumları ve sertifikasını görüntüleyebilir; ancak adım durumu değiştirme, dosya yükleme/silme ve yorum ekleme/düzenleme/silme API'leri 403 ile engellenir.
+- **Sertifika Doğrulama**: `/verify-certificate/[certificateNumber]` public doğrulama sayfası (`middleware.ts` `publicPaths` içinde). QR kod veya link üzerinden herkes sertifikanın geçerliliğini teyit edebilir.
+- **Sertifika Notu (`completionGrade`)**: Varsayılan "Üstün Başarı" kaldırıldı (nullable). Admin mezun ederken veya sertifika düzenlerken açıkça seçer (`Üstün Başarı`, `Onur Derecesi`, `Yüksek Başarı`, `Başarılı` veya boş/belirlenmedi).
+- **Stajyer Sertifika Erişimi**: Yalnızca `GRADUATED` durumundaki veya sertifikası düzenlenmiş (`issuedAt !== null`) öğrenciler sertifikalarını görüntüleyebilir (aktif öğrencilere 403).
+
 ## Komutlar
 
 ```bash
@@ -140,4 +146,6 @@ docker compose up -d  # db (+app) — uploads kalıcı volume'da
 
 ---
 
-*Son güncelleme: Temmuz 2026 — kapsamlı tarama + #111–#116 düzeltme oturumu*
+*Son güncelleme: Ağustos 2026 — #208 Mezuniyet sertifikası, doğrulama sayfası ve salt-okunur mezun portfolyo erişimi*
+
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,8 +131,18 @@ Redis gerekir → `DEPLOYMENT.md`.
 - **Mezun yazma yetkisi — bilinçli kararlar (#208)**:
   - **Kapalı**: adım durumu, dosya yükleme/silme, yorum ekleme/düzenleme/silme, **AI chat**
     (her mesaj Gemini maliyeti + aktif staja bağlı araç) → 403.
-  - **Açık (bilinçli)**: **öneri/istek (suggestions)** — mezun geri bildirimi meşru ve düşük riskli.
-    Ürün bunu daraltmak isterse `api/suggestions` POST'una GRADUATED kontrolü eklenmeli.
+  - **Açık (bilinçli)**: **öneri/istek (suggestions)** ve **mesajlaşma (`POST /api/messages`)** —
+    ikisi de *insan iletişimi* kanalıdır; mezunun mentörüne/admin'e yazabilmesi meşru ve düşük
+    riskli. Ürün daraltmak isterse ilgili POST uçlarına GRADUATED kontrolü eklenmeli.
+  - **Ayrım ilkesi**: *sistem durumunu değiştiren* (adım/dosya/yorum) ve *ücretli AI* uçları
+    kapalı; *insan iletişimi* açık.
+- **⚠️ Sertifika yayınlama tek noktadan**: Belgeyi resmileştiren tek yer **mezuniyettir**
+  (`ensureCertificateIssued`). Admin'in not/derece kaydetmesi (`updateCertificateDetails`)
+  `issuedAt` **yazmaz** — aksi halde mezun olmayan öğrencinin belgesi public doğrulamada
+  geçerli görünürdü. `certificateNumber` **@unique**; çakışmada seri no yeniden üretilir.
+- **Public verify PII/enumeration**: rate-limit kontrolü `getVerification` **içinde** —
+  Next.js `generateMetadata`'yı sayfadan önce çalıştırdığı için limit yalnız gövdede olsaydı
+  `<title>` üzerinden ad + seri no sızardı. Tüm metadata `robots: noindex` (PII sayfası).
 
 ## Komutlar
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,18 @@ Redis gerekir → `DEPLOYMENT.md`.
 - **Sertifika Doğrulama**: `/verify-certificate/[certificateNumber]` public doğrulama sayfası (`middleware.ts` `publicPaths` içinde). QR kod veya link üzerinden herkes sertifikanın geçerliliğini teyit edebilir.
 - **Sertifika Notu (`completionGrade`)**: Varsayılan "Üstün Başarı" kaldırıldı (nullable). Admin mezun ederken veya sertifika düzenlerken açıkça seçer (`Üstün Başarı`, `Onur Derecesi`, `Yüksek Başarı`, `Başarılı` veya boş/belirlenmedi).
 - **Stajyer Sertifika Erişimi**: Yalnızca `GRADUATED` durumundaki veya sertifikası düzenlenmiş (`issuedAt !== null`) öğrenciler sertifikalarını görüntüleyebilir (aktif öğrencilere 403).
+- **⚠️ Sertifika persist sözleşmesi (bozmayın)**: Bir belge ancak `certificateNumber` **ve** `issuedAt`
+  DB'de kayıtlıysa **resmidir** (`CertificateData.isIssued`). Mezuniyet (`updateAccountStatus →
+  GRADUATED`) `ensureCertificateIssued()` ile bunları **kalıcı yazar**; öğrenci ucu eski kayıtlar
+  için kendi kendini onarır. Aksi halde öğrenciye/QR'a **kayıtlı olmayan** bir seri no gösterilir
+  ve `/verify-certificate` "bulunamadı" der — doğrulama özelliğinin değeri kaybolur.
+- **Public verify rate-limit**: `/verify-certificate` IP başına 60 sn'de 20 sorgu (seri no
+  enumeration koruması). `generateMetadata` + sayfa React `cache` ile **tek DB sorgusu** paylaşır.
+- **Mezun yazma yetkisi — bilinçli kararlar (#208)**:
+  - **Kapalı**: adım durumu, dosya yükleme/silme, yorum ekleme/düzenleme/silme, **AI chat**
+    (her mesaj Gemini maliyeti + aktif staja bağlı araç) → 403.
+  - **Açık (bilinçli)**: **öneri/istek (suggestions)** — mezun geri bildirimi meşru ve düşük riskli.
+    Ürün bunu daraltmak isterse `api/suggestions` POST'una GRADUATED kontrolü eklenmeli.
 
 ## Komutlar
 

--- a/prisma/migrations/20260810160000_remove_completion_grade_default/migration.sql
+++ b/prisma/migrations/20260810160000_remove_completion_grade_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "StudentProfile" ALTER COLUMN "completionGrade" DROP DEFAULT;

--- a/prisma/migrations/20260815120000_certificate_number_unique/migration.sql
+++ b/prisma/migrations/20260815120000_certificate_number_unique/migration.sql
@@ -1,0 +1,5 @@
+-- #208 review: Sertifika seri numarası belgeyi tekil tanımlar (public doğrulama
+-- `findFirst` ile arar). Çakışma yanlış belgenin "geçerli" sayılmasına yol açabilir.
+-- Additive: yalnız UNIQUE index eklenir; kolon/veri değişmez (NULL'lar etkilenmez —
+-- Postgres'te birden çok NULL unique index'i ihlal etmez).
+CREATE UNIQUE INDEX "StudentProfile_certificateNumber_key" ON "StudentProfile"("certificateNumber");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,7 +51,9 @@ model StudentProfile {
   availability    String?
   birthYear       Int?
   // #204: Staj başarı sertifikası alanları.
-  certificateNumber String?
+  // #208 review: Seri no belgeyi TEKİL tanımlar; public doğrulama `findFirst` ile
+  // arar. Çakışma olursa yanlış belge "geçerli" sayılabilirdi → DB seviyesinde unique.
+  certificateNumber String?  @unique
   mentorNote        String?   @db.VarChar(2000)
   completionGrade   String?
   issuedAt          DateTime?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,7 +53,7 @@ model StudentProfile {
   // #204: Staj başarı sertifikası alanları.
   certificateNumber String?
   mentorNote        String?   @db.VarChar(2000)
-  completionGrade   String?   @default("Üstün Başarı")
+  completionGrade   String?
   issuedAt          DateTime?
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt

--- a/src/app/(student)/student-dashboard/page.tsx
+++ b/src/app/(student)/student-dashboard/page.tsx
@@ -255,7 +255,13 @@ export default async function StudentDashboardPage() {
                         <p className="text-slate-500 dark:text-slate-400 text-sm">İş akışı oluşturuluyor...</p>
                       </div>
                     ) : (
-                      <RoadmapSteps steps={steps} isDraft={isDraft} currentUserId={session.user.id} currentUserRole={session.user.role} />
+                      <RoadmapSteps
+                        steps={steps}
+                        isDraft={isDraft}
+                        isGraduated={isGraduated}
+                        currentUserId={session.user.id}
+                        currentUserRole={session.user.role}
+                      />
                     )}
                   </div>
 

--- a/src/app/api/admin/students/[studentId]/certificate/route.test.ts
+++ b/src/app/api/admin/students/[studentId]/certificate/route.test.ts
@@ -110,4 +110,23 @@ describe("GET & POST /api/admin/students/[studentId]/certificate", () => {
     expect(body.success).toBe(true);
     expect(mockUpdateCertificateDetails).toHaveBeenCalled();
   });
+
+  it("POST: geçersiz completionGrade durumunda 400 döner", async () => {
+    mockRequireAuth.mockResolvedValue({
+      authorized: true,
+      session: { user: { id: "admin-1", role: "ADMIN" } },
+    });
+
+    const req = new Request("http://localhost/api/admin/students/s1/certificate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        completionGrade: "GecersizDeger",
+      }),
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ studentId: "s1" }) });
+    expect(res.status).toBe(400);
+  });
 });
+

--- a/src/app/api/admin/students/[studentId]/certificate/route.ts
+++ b/src/app/api/admin/students/[studentId]/certificate/route.ts
@@ -85,11 +85,12 @@ export async function POST(
       );
     }
 
+    // #208 review (P3): Not/derece kaydetmek belgeyi YAYINLAMAZ. `issuedAt`
+    // gönderilmez → belge yalnız mezuniyette resmileşir (ensureCertificateIssued).
     const updated = await updateCertificateDetails(certificate.id, {
       certificateNumber: parsed.data.certificateNumber,
       mentorNote: parsed.data.mentorNote,
       completionGrade: parsed.data.completionGrade,
-      issuedAt: new Date(),
     });
 
     return NextResponse.json({

--- a/src/app/api/admin/students/[studentId]/certificate/route.ts
+++ b/src/app/api/admin/students/[studentId]/certificate/route.ts
@@ -5,13 +5,7 @@ import {
   getStudentCertificate,
   updateCertificateDetails,
 } from "@/features/certificate/server/certificate";
-import { z } from "zod";
-
-const updateCertificateSchema = z.object({
-  certificateNumber: z.string().optional(),
-  mentorNote: z.string().max(2000, "Referans notu en fazla 2000 karakter olabilir.").optional(),
-  completionGrade: z.string().optional(),
-});
+import { updateCertificateSchema } from "@/lib/validations/api";
 
 export async function GET(
   _request: Request,

--- a/src/app/api/steps/[stepId]/comments/[commentId]/route.test.ts
+++ b/src/app/api/steps/[stepId]/comments/[commentId]/route.test.ts
@@ -14,8 +14,8 @@ vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
 
 import { PUT, DELETE } from "./route";
 
-function authAs(id: string, role: "MENTOR" | "STUDENT" = "STUDENT") {
-  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id, role } } });
+function authAs(id: string, role: "MENTOR" | "STUDENT" = "STUDENT", accountStatus = "APPROVED") {
+  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id, role, accountStatus } } });
 }
 const params = (stepId = "step-1", commentId = "c-1") => Promise.resolve({ stepId, commentId });
 function req(body: unknown) {
@@ -26,10 +26,22 @@ function req(body: unknown) {
   });
 }
 
-describe("yorum düzenle/sil — yetki sınırları (#181)", () => {
+describe("yorum düzenle/sil — yetki sınırları (#181) & GRADUATED (#208)", () => {
   beforeEach(() => vi.clearAllMocks());
 
   // ---- PUT (düzenle) ----
+  it("PUT: GRADUATED öğrenci yorum düzenleyemez → 403 (#208)", async () => {
+    authAs("student-1", "STUDENT", "GRADUATED");
+    prismaMock.stepComment.findUnique.mockResolvedValue({ id: "c-1", stepId: "step-1", authorId: "student-1" });
+
+    const res = await PUT(req({ content: "yeni" }), { params: params() });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("Mezun öğrenciler");
+    expect(prismaMock.stepComment.update).not.toHaveBeenCalled();
+  });
+
   it("PUT: başkasının yorumu → 403, güncelleme yok", async () => {
     authAs("student-1");
     prismaMock.stepComment.findUnique.mockResolvedValue({ id: "c-1", stepId: "step-1", authorId: "baskasi" });
@@ -70,6 +82,16 @@ describe("yorum düzenle/sil — yetki sınırları (#181)", () => {
   });
 
   // ---- DELETE (sil) ----
+  it("DELETE: GRADUATED öğrenci yorum silemez → 403 (#208)", async () => {
+    authAs("student-1", "STUDENT", "GRADUATED");
+    const res = await DELETE(req({}), { params: params() });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("Mezun öğrenciler");
+    expect(prismaMock.stepComment.delete).not.toHaveBeenCalled();
+  });
+
   it("DELETE: yorum sahibi → siler", async () => {
     authAs("student-1");
     prismaMock.stepComment.findUnique.mockResolvedValue({ id: "c-1", stepId: "step-1", authorId: "student-1" });

--- a/src/app/api/steps/[stepId]/comments/[commentId]/route.ts
+++ b/src/app/api/steps/[stepId]/comments/[commentId]/route.ts
@@ -15,6 +15,14 @@ export async function PUT(
   const auth = await requireAuth(["MENTOR", "STUDENT"]);
   if (!auth.authorized) return auth.response;
 
+  // #208: Mezun stajyerler için portfolyo salt-okunurdur (Seçenek A).
+  if (auth.session.user.role === "STUDENT" && auth.session.user.accountStatus === "GRADUATED") {
+    return NextResponse.json(
+      { error: "Mezun öğrenciler staj adımlarındaki yorumları düzenleyemez." },
+      { status: 403 }
+    );
+  }
+
   const { stepId, commentId } = await params;
   const userId = auth.session.user.id!;
 
@@ -79,6 +87,14 @@ export async function DELETE(
 ) {
   const auth = await requireAuth(["MENTOR", "STUDENT"]);
   if (!auth.authorized) return auth.response;
+
+  // #208: Mezun stajyerler için portfolyo salt-okunurdur (Seçenek A).
+  if (auth.session.user.role === "STUDENT" && auth.session.user.accountStatus === "GRADUATED") {
+    return NextResponse.json(
+      { error: "Mezun öğrenciler staj adımlarındaki yorumları silemez." },
+      { status: 403 }
+    );
+  }
 
   const { stepId, commentId } = await params;
   const userId = auth.session.user.id!;

--- a/src/app/api/steps/[stepId]/comments/route.test.ts
+++ b/src/app/api/steps/[stepId]/comments/route.test.ts
@@ -32,10 +32,10 @@ function buildStep(status: "DRAFT" | "PUBLISHED") {
   };
 }
 
-function authAs(userId: string, role: "STUDENT" | "MENTOR") {
+function authAs(userId: string, role: "STUDENT" | "MENTOR", accountStatus = "APPROVED") {
   requireAuthMock.mockResolvedValue({
     authorized: true,
-    session: { user: { id: userId, role } },
+    session: { user: { id: userId, role, accountStatus } },
   });
 }
 
@@ -49,9 +49,21 @@ function makeRequest(body: unknown) {
 
 const ctx = { params: Promise.resolve({ stepId: "step-1" }) };
 
-describe("POST /api/steps/[stepId]/comments — taslak (DRAFT) guard (#52/#69)", () => {
+describe("POST /api/steps/[stepId]/comments — taslak (DRAFT) guard (#52/#69) & GRADUATED (#208)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("GRADUATED öğrenci yorum ekleyemez → 403 (#208)", async () => {
+    authAs(STUDENT_USER, "STUDENT", "GRADUATED");
+    prismaMock.roadmapStep.findUnique.mockResolvedValue(buildStep("PUBLISHED"));
+
+    const res = await POST(makeRequest({ content: "merhaba" }), ctx);
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("Mezun öğrenciler");
+    expect(prismaMock.stepComment.create).not.toHaveBeenCalled();
   });
 
   it("öğrenci + DRAFT roadmap → 403 döner ve yorum oluşturulmaz", async () => {

--- a/src/app/api/steps/[stepId]/comments/route.ts
+++ b/src/app/api/steps/[stepId]/comments/route.ts
@@ -88,6 +88,14 @@ export async function POST(
       );
     }
 
+    // #208: Mezun stajyerler için portfolyo salt-okunurdur (Seçenek A).
+    if (auth.session.user.role === "STUDENT" && auth.session.user.accountStatus === "GRADUATED") {
+      return NextResponse.json(
+        { error: "Mezun öğrenciler staj adımlarına yorum ekleyemez." },
+        { status: 403 }
+      );
+    }
+
     // #52: Öğrenci yalnızca PUBLISHED roadmap adımına yorum ekleyebilir.
     // Mentor, taslağı (DRAFT) düzenleme/inceleme için yorum yapabilir.
     const isStudent = step.roadmap.assignedProject.studentProfile.userId === userId;

--- a/src/app/api/steps/[stepId]/files/[fileId]/route.test.ts
+++ b/src/app/api/steps/[stepId]/files/[fileId]/route.test.ts
@@ -18,8 +18,8 @@ vi.mock("@/lib/storage/step-files", () => ({
 
 import { DELETE, GET } from "./route";
 
-function authAs(id: string, role: "MENTOR" | "STUDENT" = "STUDENT") {
-  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id, role } } });
+function authAs(id: string, role: "MENTOR" | "STUDENT" = "STUDENT", accountStatus = "APPROVED") {
+  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id, role, accountStatus } } });
 }
 const params = (stepId = "step-1", fileId = "f-1") => Promise.resolve({ stepId, fileId });
 
@@ -46,13 +46,23 @@ function stepFile(over: { uploaderId: string; ownerUserId: string; mentorId: str
   };
 }
 
-describe("dosya sil/indir — yetki sınırları (#181)", () => {
+describe("dosya sil/indir — yetki sınırları (#181) & GRADUATED (#208)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     readStepFileMock.mockResolvedValue(null); // varsayılan: dosya yok
   });
 
   // ---- DELETE ----
+  it("DELETE: GRADUATED öğrenci dosya silemez → 403 (#208)", async () => {
+    authAs("student-1", "STUDENT", "GRADUATED");
+    const res = await DELETE(new Request("http://t", { method: "DELETE" }), { params: params() });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("Mezun öğrenciler");
+    expect(prismaMock.stepFile.delete).not.toHaveBeenCalled();
+  });
+
   it("DELETE: yükleyen siler", async () => {
     authAs("student-1");
     prismaMock.stepFile.findUnique.mockResolvedValue(

--- a/src/app/api/steps/[stepId]/files/[fileId]/route.ts
+++ b/src/app/api/steps/[stepId]/files/[fileId]/route.ts
@@ -104,6 +104,14 @@ export async function DELETE(
   const auth = await requireAuth(["MENTOR", "STUDENT"]);
   if (!auth.authorized) return auth.response;
 
+  // #208: Mezun stajyerler için portfolyo salt-okunurdur (Seçenek A).
+  if (auth.session.user.role === "STUDENT" && auth.session.user.accountStatus === "GRADUATED") {
+    return NextResponse.json(
+      { error: "Mezun öğrenciler staj adımlarından dosya silemez." },
+      { status: 403 }
+    );
+  }
+
   const { stepId, fileId } = await params;
   const userId = auth.session.user.id!;
   const userRole = auth.session.user.role;

--- a/src/app/api/steps/[stepId]/files/route.test.ts
+++ b/src/app/api/steps/[stepId]/files/route.test.ts
@@ -31,10 +31,10 @@ function buildStep(status: "DRAFT" | "PUBLISHED") {
   };
 }
 
-function authAs(userId: string, role: "STUDENT" | "MENTOR") {
+function authAs(userId: string, role: "STUDENT" | "MENTOR", accountStatus = "APPROVED") {
   requireAuthMock.mockResolvedValue({
     authorized: true,
-    session: { user: { id: userId, role } },
+    session: { user: { id: userId, role, accountStatus } },
   });
 }
 
@@ -48,10 +48,21 @@ function makeEmptyUploadRequest() {
 
 const ctx = { params: Promise.resolve({ stepId: "step-1" }) };
 
-describe("POST /api/steps/[stepId]/files — taslak (DRAFT) guard (#52/#69)", () => {
+describe("POST /api/steps/[stepId]/files — taslak (DRAFT) guard (#52/#69) & GRADUATED (#208)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     prismaMock.stepFile.count.mockResolvedValue(0);
+  });
+
+  it("GRADUATED öğrenci dosya yükleyemez → 403 (#208)", async () => {
+    authAs(STUDENT_USER, "STUDENT", "GRADUATED");
+    prismaMock.roadmapStep.findUnique.mockResolvedValue(buildStep("PUBLISHED"));
+
+    const res = await POST(makeEmptyUploadRequest(), ctx);
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("Mezun öğrenciler");
   });
 
   it("öğrenci + DRAFT roadmap → 403 (dosya sayımına bile gitmeden reddeder)", async () => {

--- a/src/app/api/steps/[stepId]/files/route.ts
+++ b/src/app/api/steps/[stepId]/files/route.ts
@@ -122,6 +122,14 @@ export async function POST(
       );
     }
 
+    // #208: Mezun stajyerler için portfolyo salt-okunurdur (Seçenek A).
+    if (auth.session.user.role === "STUDENT" && auth.session.user.accountStatus === "GRADUATED") {
+      return NextResponse.json(
+        { error: "Mezun öğrenciler staj adımlarına dosya yükleyemez." },
+        { status: 403 }
+      );
+    }
+
     // #52: Öğrenci yalnızca PUBLISHED roadmap adımına dosya yükleyebilir.
     // Mentor, taslağı (DRAFT) inceleme/düzenleme için yükleyebilir.
     const isStudent = step.roadmap.assignedProject.studentProfile.userId === userId;

--- a/src/app/api/student/ai-chat/route.ts
+++ b/src/app/api/student/ai-chat/route.ts
@@ -39,6 +39,17 @@ export async function POST(req: Request) {
   const auth = await requireAuth("STUDENT");
   if (!auth.authorized) return auth.response;
 
+  // #208 review (bilinçli karar): Mezun portfolyosu SALT-OKUNUR olduğu için AI chat
+  // mezunlara kapalıdır. Gerekçe: her mesaj bir Gemini çağrısı (maliyet) ve chat aktif
+  // staj sürecine bağlı bir öğrenme aracı. Mezun geçmiş sohbetlerini görmeye devam eder.
+  // (Öneri/istek uçları bilinçli olarak AÇIK bırakıldı — bkz. CLAUDE.md #208.)
+  if (auth.session.user.accountStatus === "GRADUATED") {
+    return NextResponse.json(
+      { error: "Staj süreciniz tamamlandığı için AI asistanı kullanıma kapalıdır." },
+      { status: 403 },
+    );
+  }
+
   const userId = auth.session.user.id!;
 
   const rl = limiter.check(userId);

--- a/src/app/api/student/certificate/route.test.ts
+++ b/src/app/api/student/certificate/route.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockRequireAuth, mockGetStudentCertificate } = vi.hoisted(() => ({
+const { mockRequireAuth, mockGetStudentCertificate, mockEnsureCertificateIssued } = vi.hoisted(() => ({
   mockRequireAuth: vi.fn(),
   mockGetStudentCertificate: vi.fn(),
+  mockEnsureCertificateIssued: vi.fn(),
 }));
 
 vi.mock("@/lib/auth/guard", () => ({
@@ -12,6 +13,7 @@ vi.mock("@/lib/auth/guard", () => ({
 
 vi.mock("@/features/certificate/server/certificate", () => ({
   getStudentCertificate: mockGetStudentCertificate,
+  ensureCertificateIssued: mockEnsureCertificateIssued,
 }));
 
 import { GET } from "./route";

--- a/src/app/api/student/certificate/route.test.ts
+++ b/src/app/api/student/certificate/route.test.ts
@@ -31,15 +31,34 @@ describe("GET /api/student/certificate", () => {
     expect(res.status).toBe(401);
   });
 
-  it("sertifika bulunursa 200 ve sertifika verisini döner", async () => {
+  it("APPROVED (henüz mezun olmamış ve issuedAt olmayan) öğrenci sertifika isterse 403 döner (#208)", async () => {
     mockRequireAuth.mockResolvedValue({
       authorized: true,
-      session: { user: { id: "student-1", role: "STUDENT" } },
+      session: { user: { id: "student-1", role: "STUDENT", accountStatus: "APPROVED" } },
+    });
+    mockGetStudentCertificate.mockResolvedValue({
+      studentName: "Ali Yılmaz",
+      certificateNumber: "POS-2026-1111",
+      completionGrade: null,
+      issuedAt: null,
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("mezun durumunda değilsiniz");
+  });
+
+  it("GRADUATED öğrenci sertifika verisini başarıyla alır → 200", async () => {
+    mockRequireAuth.mockResolvedValue({
+      authorized: true,
+      session: { user: { id: "student-1", role: "STUDENT", accountStatus: "GRADUATED" } },
     });
     mockGetStudentCertificate.mockResolvedValue({
       studentName: "Ayşe Yılmaz",
       certificateNumber: "POS-2026-1234",
       completionGrade: "Üstün Başarı",
+      issuedAt: "2026-08-08T12:00:00.000Z",
     });
 
     const res = await GET();
@@ -48,4 +67,39 @@ describe("GET /api/student/certificate", () => {
     expect(body.success).toBe(true);
     expect(body.certificate.studentName).toBe("Ayşe Yılmaz");
   });
+
+  it("resmi issuedAt tarihi atanmış öğrenci (APPROVED olsa bile) 200 alır", async () => {
+    mockRequireAuth.mockResolvedValue({
+      authorized: true,
+      session: { user: { id: "student-1", role: "STUDENT", accountStatus: "APPROVED" } },
+    });
+    mockGetStudentCertificate.mockResolvedValue({
+      studentName: "Can Kaya",
+      certificateNumber: "POS-2026-5555",
+      completionGrade: "Onur Derecesi",
+      issuedAt: "2026-08-01T10:00:00.000Z",
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  it("ADMIN rolündeki kullanıcı sertifikayı sorgulayabilir → 200", async () => {
+    mockRequireAuth.mockResolvedValue({
+      authorized: true,
+      session: { user: { id: "admin-1", role: "ADMIN", accountStatus: "APPROVED" } },
+    });
+    mockGetStudentCertificate.mockResolvedValue({
+      studentName: "Admin Test",
+      certificateNumber: "POS-2026-0001",
+      completionGrade: null,
+      issuedAt: null,
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+  });
 });
+

--- a/src/app/api/student/certificate/route.ts
+++ b/src/app/api/student/certificate/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth/guard";
-import { getStudentCertificate } from "@/features/certificate/server/certificate";
+import {
+  getStudentCertificate,
+  ensureCertificateIssued,
+} from "@/features/certificate/server/certificate";
 
 export async function GET() {
   const auth = await requireAuth(["STUDENT", "ADMIN", "MENTOR"]);
@@ -12,7 +15,7 @@ export async function GET() {
   }
 
   try {
-    const certificate = await getStudentCertificate(studentUserId);
+    let certificate = await getStudentCertificate(studentUserId);
     if (!certificate) {
       return NextResponse.json(
         { error: "Sertifika verisi bulunamadı." },
@@ -30,6 +33,14 @@ export async function GET() {
           { error: "Henüz mezun durumunda değilsiniz veya resmi sertifikanız düzenlenmedi." },
           { status: 403 },
         );
+      }
+
+      // #208 review: Öğrenciye ASLA kayıtlı olmayan (doğrulanamayan) seri no gösterme.
+      // Bu düzeltmeden ÖNCE mezun edilmiş kayıtlarda seri no/issuedAt boş olabilir —
+      // burada kendi kendini onarır, böylece QR/verificationUrl gerçekten çalışır.
+      if (isGraduated && !certificate.isIssued) {
+        await ensureCertificateIssued(studentUserId);
+        certificate = (await getStudentCertificate(studentUserId)) ?? certificate;
       }
     }
 

--- a/src/app/api/student/certificate/route.ts
+++ b/src/app/api/student/certificate/route.ts
@@ -20,6 +20,19 @@ export async function GET() {
       );
     }
 
+    // #208: Öğrenci rolündeyse yalnızca mezun edilmişse veya resmi issuedAt varsa sertifika alabilir.
+    if (auth.session.user.role === "STUDENT") {
+      const isGraduated = auth.session.user.accountStatus === "GRADUATED";
+      const isIssued = certificate.issuedAt !== null;
+
+      if (!isGraduated && !isIssued) {
+        return NextResponse.json(
+          { error: "Henüz mezun durumunda değilsiniz veya resmi sertifikanız düzenlenmedi." },
+          { status: 403 },
+        );
+      }
+    }
+
     return NextResponse.json({ success: true, certificate });
   } catch (error) {
     console.error("Error loading certificate:", error);
@@ -29,3 +42,4 @@ export async function GET() {
     );
   }
 }
+

--- a/src/app/api/student/steps/[stepId]/route.test.ts
+++ b/src/app/api/student/steps/[stepId]/route.test.ts
@@ -14,8 +14,11 @@ vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
 
 import { PATCH } from "./route";
 
-function student(id: string) {
-  requireAuthMock.mockResolvedValue({ authorized: true, session: { user: { id, role: "STUDENT" } } });
+function student(id: string, accountStatus = "APPROVED") {
+  requireAuthMock.mockResolvedValue({
+    authorized: true,
+    session: { user: { id, role: "STUDENT", accountStatus } },
+  });
 }
 const params = (stepId = "s-1") => Promise.resolve({ stepId });
 function req(body: unknown) {
@@ -143,4 +146,14 @@ describe("student steps PATCH — IDOR + kurallar (#184)", () => {
     const res = await PATCH(req({ status: "IN_PROGRESS" }), { params: params() });
     expect(res.status).toBe(400);
   });
+
+  it("GRADUATED öğrenci adım durumunu değiştiremez → 403 (#208)", async () => {
+    student("student-1", "GRADUATED");
+    const res = await PATCH(req({ status: "IN_PROGRESS" }), { params: params() });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain("Mezun öğrenciler");
+    expect(prismaMock.roadmapStep.findUnique).not.toHaveBeenCalled();
+  });
 });
+

--- a/src/app/api/student/steps/[stepId]/route.ts
+++ b/src/app/api/student/steps/[stepId]/route.ts
@@ -16,6 +16,14 @@ export async function PATCH(
   const auth = await requireAuth("STUDENT");
   if (!auth.authorized) return auth.response;
 
+  // #208: Mezun stajyerler için portfolyo salt-okunurdur (Seçenek A).
+  if (auth.session.user.accountStatus === "GRADUATED") {
+    return NextResponse.json(
+      { error: "Mezun öğrenciler tamamlanan staj adımlarının durumunu değiştiremez." },
+      { status: 403 }
+    );
+  }
+
   const { stepId } = await params;
 
   try {

--- a/src/app/verify-certificate/[certificateNumber]/page.test.tsx
+++ b/src/app/verify-certificate/[certificateNumber]/page.test.tsx
@@ -11,6 +11,11 @@ vi.mock("@/features/certificate/server/certificate", () => ({
   verifyCertificate: mockVerifyCertificate,
 }));
 
+// #208 review: sayfa artık rate-limit için istek başlıklarını okuyor.
+vi.mock("next/headers", () => ({
+  headers: async () => new Headers({ "x-forwarded-for": "203.0.113.10" }),
+}));
+
 import VerifyCertificatePage, { generateMetadata } from "./page";
 
 describe("VerifyCertificatePage (#208)", () => {

--- a/src/app/verify-certificate/[certificateNumber]/page.test.tsx
+++ b/src/app/verify-certificate/[certificateNumber]/page.test.tsx
@@ -3,8 +3,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { render, screen } from "@testing-library/react";
 
-const { mockVerifyCertificate } = vi.hoisted(() => ({
+const { mockVerifyCertificate, mockCheck } = vi.hoisted(() => ({
   mockVerifyCertificate: vi.fn(),
+  mockCheck: vi.fn(() => ({ allowed: true, retryAfterSeconds: 0 })),
 }));
 
 vi.mock("@/features/certificate/server/certificate", () => ({
@@ -13,7 +14,12 @@ vi.mock("@/features/certificate/server/certificate", () => ({
 
 // #208 review: sayfa artık rate-limit için istek başlıklarını okuyor.
 vi.mock("next/headers", () => ({
-  headers: async () => new Headers({ "x-forwarded-for": "203.0.113.10" }),
+  headers: async () => new Headers({ "x-real-ip": "203.0.113.10" }),
+}));
+
+// Rate-limit davranışını testte kontrol edebilmek için limiter mock'lanır.
+vi.mock("@/lib/rate-limit", () => ({
+  createRateLimiter: () => ({ check: mockCheck }),
 }));
 
 import VerifyCertificatePage, { generateMetadata } from "./page";
@@ -21,6 +27,7 @@ import VerifyCertificatePage, { generateMetadata } from "./page";
 describe("VerifyCertificatePage (#208)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCheck.mockReturnValue({ allowed: true, retryAfterSeconds: 0 });
   });
 
   it("geçerli sertifika için doğrulanmış belge detaylarını render eder", async () => {
@@ -94,5 +101,59 @@ describe("VerifyCertificatePage (#208)", () => {
       params: Promise.resolve({ certificateNumber: "INVALID" }),
     });
     expect(metaInvalid.title).toContain("Sertifika Doğrulama");
+  });
+
+  // #208 review: Next.js metadata'yı sayfadan ÖNCE üretir. Limit yalnız gövdede
+  // olsaydı, 429 ekranı gösterilse bile <title> öğrenci adını + seri no'yu sızdırırdı.
+  describe("rate-limit — enumeration/PII sızıntısı (#208 review)", () => {
+    const RATE_LIMITED = { allowed: false, retryAfterSeconds: 60 };
+
+    it("limit aşıldığında metadata'da öğrenci adı/seri no BULUNMAZ ve DB'ye gidilmez", async () => {
+      mockCheck.mockReturnValue(RATE_LIMITED);
+      mockVerifyCertificate.mockResolvedValue({
+        isValid: true,
+        certificate: {
+          certificateNumber: "POS-2026-SECRET",
+          studentName: "Ayşe Yılmaz",
+          issuedAt: "2026-08-08T10:00:00.000Z",
+          completionGrade: "Üstün Başarı",
+          mentorName: "Can Demir",
+          completedProjects: [],
+        },
+      });
+
+      const meta = await generateMetadata({
+        params: Promise.resolve({ certificateNumber: "POS-2026-SECRET" }),
+      });
+
+      const serialized = `${meta.title ?? ""} ${meta.description ?? ""}`;
+      expect(serialized).not.toContain("Ayşe Yılmaz");
+      expect(serialized).not.toContain("POS-2026-SECRET");
+      expect(meta.title).toContain("Sertifika Doğrulama"); // generic başlık
+      // Limit aşıldığında doğrulama sorgusu hiç çalıştırılmaz.
+      expect(mockVerifyCertificate).not.toHaveBeenCalled();
+    });
+
+    it("limit aşıldığında sayfa 'çok fazla deneme' ekranı gösterir", async () => {
+      mockCheck.mockReturnValue(RATE_LIMITED);
+
+      const ui = await VerifyCertificatePage({
+        params: Promise.resolve({ certificateNumber: "POS-2026-LIMIT" }),
+      });
+      render(ui);
+
+      expect(screen.getByText(/çok fazla doğrulama denemesi/i)).toBeInTheDocument();
+      expect(mockVerifyCertificate).not.toHaveBeenCalled();
+    });
+
+    it("PII sayfası arama motorlarına indekslenmez (robots noindex)", async () => {
+      mockVerifyCertificate.mockResolvedValue({ isValid: false });
+
+      const meta = await generateMetadata({
+        params: Promise.resolve({ certificateNumber: "POS-2026-NOINDEX" }),
+      });
+
+      expect(meta.robots).toMatchObject({ index: false });
+    });
   });
 });

--- a/src/app/verify-certificate/[certificateNumber]/page.test.tsx
+++ b/src/app/verify-certificate/[certificateNumber]/page.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+
+const { mockVerifyCertificate } = vi.hoisted(() => ({
+  mockVerifyCertificate: vi.fn(),
+}));
+
+vi.mock("@/features/certificate/server/certificate", () => ({
+  verifyCertificate: mockVerifyCertificate,
+}));
+
+import VerifyCertificatePage, { generateMetadata } from "./page";
+
+describe("VerifyCertificatePage (#208)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("geçerli sertifika için doğrulanmış belge detaylarını render eder", async () => {
+    mockVerifyCertificate.mockResolvedValue({
+      isValid: true,
+      certificate: {
+        certificateNumber: "POS-2026-TEST1",
+        studentName: "Mehmet Demir",
+        issuedAt: "2026-08-08T10:00:00.000Z",
+        completionGrade: "Üstün Başarı",
+        mentorName: "Can Demir",
+        completedProjects: [
+          {
+            id: "p-1",
+            title: "Next.js Entegrasyon Projesi",
+            difficulty: "MEDIUM",
+            track: ["Frontend"],
+            completedStepsCount: 3,
+            totalStepsCount: 3,
+          },
+        ],
+      },
+    });
+
+    const jsx = await VerifyCertificatePage({
+      params: Promise.resolve({ certificateNumber: "POS-2026-TEST1" }),
+    });
+    render(jsx);
+
+    expect(screen.getByRole("heading", { level: 1, name: /Staj Başarı Sertifikası Geçerlidir/ })).toBeInTheDocument();
+    expect(screen.getByText("Mehmet Demir")).toBeInTheDocument();
+    expect(screen.getByText("POS-2026-TEST1")).toBeInTheDocument();
+    expect(screen.getByText("Üstün Başarı")).toBeInTheDocument();
+    expect(screen.getByText("Can Demir")).toBeInTheDocument();
+    expect(screen.getByText("Next.js Entegrasyon Projesi")).toBeInTheDocument();
+  });
+
+  it("geçersiz veya bulunamayan sertifikada hata ekranı render eder", async () => {
+    mockVerifyCertificate.mockResolvedValue({
+      isValid: false,
+      message: "Bu seri numarasına ait kayıtlı sertifika bulunamadı.",
+    });
+
+    const jsx = await VerifyCertificatePage({
+      params: Promise.resolve({ certificateNumber: "INVALID-NO" }),
+    });
+    render(jsx);
+
+    expect(screen.getByRole("heading", { level: 1, name: "Sertifika Doğrulanamadı" })).toBeInTheDocument();
+    expect(screen.getByText(/kayıtlı sertifika bulunamadı/)).toBeInTheDocument();
+  });
+
+  it("generateMetadata — geçerli ve geçersiz durumlarda doğru SEO başlığı üretir", async () => {
+    mockVerifyCertificate.mockResolvedValueOnce({
+      isValid: true,
+      certificate: {
+        certificateNumber: "POS-2026-SEO",
+        studentName: "Zeynep Kaya",
+      },
+    });
+
+    const metaValid = await generateMetadata({
+      params: Promise.resolve({ certificateNumber: "POS-2026-SEO" }),
+    });
+    expect(metaValid.title).toContain("Zeynep Kaya");
+
+    mockVerifyCertificate.mockResolvedValueOnce({
+      isValid: false,
+    });
+    const metaInvalid = await generateMetadata({
+      params: Promise.resolve({ certificateNumber: "INVALID" }),
+    });
+    expect(metaInvalid.title).toContain("Sertifika Doğrulama");
+  });
+});

--- a/src/app/verify-certificate/[certificateNumber]/page.tsx
+++ b/src/app/verify-certificate/[certificateNumber]/page.tsx
@@ -26,46 +26,85 @@ const verifyLimiter = createRateLimiter("verify-certificate", {
   windowSeconds: 60,
 });
 
+// Not: `x-real-ip` proxy tarafından set edilir; `x-forwarded-for`'un ilk hop'u
+// proxy arkasında değilsek istemci tarafından uydurulabilir. Bu limit tek başına
+// bir kimlik kontrolü değil, enumeration'ı pahalılaştıran savunma-derinliği katmanıdır.
 function getClientIp(h: Headers): string {
+  const realIp = h.get("x-real-ip")?.trim();
+  if (realIp) return realIp;
   const fwd = h.get("x-forwarded-for");
   if (fwd) return fwd.split(",")[0]!.trim();
-  return h.get("x-real-ip")?.trim() || "anonymous";
+  return "anonymous";
 }
 
 /**
- * #208 review: `generateMetadata` ve sayfa gövdesi aynı isteği iki kez sorguluyordu.
- * React `cache` ile istek başına tek DB sorgusu (aynı argümanda dedupe).
+ * #208 review: Rate-limit kontrolü DOĞRULAMA SORGUSUNUN İÇİNDE.
+ *
+ * Next.js `generateMetadata`'yı sayfa gövdesinden ÖNCE çalıştırır. Limit yalnız
+ * sayfa gövdesinde olsaydı, limiti aşan istek yine de metadata üzerinden DB'ye
+ * gidip `<title>`'a **öğrenci adı + seri no** yazardı (enumeration + PII sızıntısı).
+ * Kontrolü buraya alarak her iki yolu da kapsıyoruz.
+ *
+ * `cache` sayesinde istek başına yalnız BİR kez çalışır → limiter tek sayılır ve
+ * DB'ye tek sorgu gider (metadata + gövde paylaşır).
  */
-const getVerification = cache(async (certificateNumber: string) => {
-  return verifyCertificate(certificateNumber);
-});
+const getVerification = cache(
+  async (
+    certificateNumber: string,
+  ): Promise<
+    | { rateLimited: true }
+    | { rateLimited: false; result: Awaited<ReturnType<typeof verifyCertificate>> }
+  > => {
+    const ip = getClientIp(await headers());
+    if (!verifyLimiter.check(ip).allowed) {
+      return { rateLimited: true };
+    }
+    return { rateLimited: false, result: await verifyCertificate(certificateNumber) };
+  },
+);
+
+// #208 review: Bu sayfa kişisel veri (ad + seri no) gösterir → arama motorlarına
+// ASLA indekslenmemeli. Tüm metadata yanıtlarında geçerli.
+const NOINDEX = { index: false, follow: false } as const;
+
+const GENERIC_METADATA: Metadata = {
+  title: "Sertifika Doğrulama — Posinowa Teknoloji Akademisi",
+  description: "Posinowa staj başarı belgesi ve sertifika doğrulama sistemi.",
+  robots: NOINDEX,
+};
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { certificateNumber } = await params;
   const decodedNumber = decodeURIComponent(certificateNumber);
-  const result = await getVerification(decodedNumber);
+  const verification = await getVerification(decodedNumber);
 
+  // Limit aşıldıysa metadata'da ad/seri no OLMAZ — aksi halde 429 ekranı gösterilse
+  // bile <title> üzerinden belge varlığı + öğrenci adı sızardı.
+  if (verification.rateLimited) {
+    return GENERIC_METADATA;
+  }
+
+  const result = verification.result;
   if (result.isValid && result.certificate) {
     return {
       title: `Sertifika Doğrulandı: ${result.certificate.studentName} (${result.certificate.certificateNumber}) — Posinowa`,
       description: `Posinowa Akademi staj başarı sertifikası doğrulaması: ${result.certificate.studentName}. Seri No: ${result.certificate.certificateNumber}.`,
+      robots: NOINDEX,
     };
   }
 
-  return {
-    title: "Sertifika Doğrulama — Posinowa Teknoloji Akademisi",
-    description: "Posinowa staj başarı belgesi ve sertifika doğrulama sistemi.",
-  };
+  return GENERIC_METADATA;
 }
 
 export default async function VerifyCertificatePage({ params }: Props) {
   const { certificateNumber } = await params;
   const decodedNumber = decodeURIComponent(certificateNumber);
 
-  // #208 review: Enumeration koruması — IP başına dakikada 20 sorgu.
-  const ip = getClientIp(await headers());
-  const rl = verifyLimiter.check(ip);
-  if (!rl.allowed) {
+  // #208 review: Enumeration koruması — IP başına dakikada 20 sorgu. Kontrol
+  // `getVerification` içinde (metadata yolu da kapsansın diye); burada yalnız sonucu
+  // ekrana çeviriyoruz. `cache` sayesinde limiter istek başına bir kez sayılır.
+  const verification = await getVerification(decodedNumber);
+  if (verification.rateLimited) {
     return (
       <main className="min-h-screen flex flex-col items-center justify-center p-6 text-center bg-slate-50 dark:bg-slate-950">
         <div className="max-w-md w-full bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-3xl shadow-lg p-8 space-y-3">
@@ -86,7 +125,7 @@ export default async function VerifyCertificatePage({ params }: Props) {
     );
   }
 
-  const result = await getVerification(decodedNumber);
+  const result = verification.result;
 
   const formattedDate =
     result.isValid && result.certificate?.issuedAt

--- a/src/app/verify-certificate/[certificateNumber]/page.tsx
+++ b/src/app/verify-certificate/[certificateNumber]/page.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
+import { cache } from "react";
+import { headers } from "next/headers";
 import Link from "next/link";
+import { createRateLimiter } from "@/lib/rate-limit";
 import {
   ShieldCheck,
   Award,
@@ -17,10 +20,30 @@ type Props = {
   params: Promise<{ certificateNumber: string }>;
 };
 
+// #208 review: Public uç → seri no enumeration'a karşı IP başına basit rate-limit.
+const verifyLimiter = createRateLimiter("verify-certificate", {
+  maxRequests: 20,
+  windowSeconds: 60,
+});
+
+function getClientIp(h: Headers): string {
+  const fwd = h.get("x-forwarded-for");
+  if (fwd) return fwd.split(",")[0]!.trim();
+  return h.get("x-real-ip")?.trim() || "anonymous";
+}
+
+/**
+ * #208 review: `generateMetadata` ve sayfa gövdesi aynı isteği iki kez sorguluyordu.
+ * React `cache` ile istek başına tek DB sorgusu (aynı argümanda dedupe).
+ */
+const getVerification = cache(async (certificateNumber: string) => {
+  return verifyCertificate(certificateNumber);
+});
+
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { certificateNumber } = await params;
   const decodedNumber = decodeURIComponent(certificateNumber);
-  const result = await verifyCertificate(decodedNumber);
+  const result = await getVerification(decodedNumber);
 
   if (result.isValid && result.certificate) {
     return {
@@ -38,7 +61,32 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 export default async function VerifyCertificatePage({ params }: Props) {
   const { certificateNumber } = await params;
   const decodedNumber = decodeURIComponent(certificateNumber);
-  const result = await verifyCertificate(decodedNumber);
+
+  // #208 review: Enumeration koruması — IP başına dakikada 20 sorgu.
+  const ip = getClientIp(await headers());
+  const rl = verifyLimiter.check(ip);
+  if (!rl.allowed) {
+    return (
+      <main className="min-h-screen flex flex-col items-center justify-center p-6 text-center bg-slate-50 dark:bg-slate-950">
+        <div className="max-w-md w-full bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-3xl shadow-lg p-8 space-y-3">
+          <h1 className="text-xl font-bold text-slate-900 dark:text-slate-100">
+            Çok fazla doğrulama denemesi
+          </h1>
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            Güvenlik nedeniyle sorgu sayısı sınırlandırılmıştır. Lütfen bir dakika sonra tekrar deneyin.
+          </p>
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center h-11 px-6 rounded-xl bg-slate-900 hover:bg-slate-800 text-white text-sm font-medium transition-colors"
+          >
+            Ana Sayfaya Dön
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  const result = await getVerification(decodedNumber);
 
   const formattedDate =
     result.isValid && result.certificate?.issuedAt

--- a/src/app/verify-certificate/[certificateNumber]/page.tsx
+++ b/src/app/verify-certificate/[certificateNumber]/page.tsx
@@ -1,0 +1,201 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ShieldCheck,
+  Award,
+  CheckCircle2,
+  XCircle,
+  Sparkles,
+  Calendar,
+  User,
+  ArrowLeft,
+  Briefcase,
+} from "lucide-react";
+import { verifyCertificate } from "@/features/certificate/server/certificate";
+
+type Props = {
+  params: Promise<{ certificateNumber: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { certificateNumber } = await params;
+  const decodedNumber = decodeURIComponent(certificateNumber);
+  const result = await verifyCertificate(decodedNumber);
+
+  if (result.isValid && result.certificate) {
+    return {
+      title: `Sertifika Doğrulandı: ${result.certificate.studentName} (${result.certificate.certificateNumber}) — Posinowa`,
+      description: `Posinowa Akademi staj başarı sertifikası doğrulaması: ${result.certificate.studentName}. Seri No: ${result.certificate.certificateNumber}.`,
+    };
+  }
+
+  return {
+    title: "Sertifika Doğrulama — Posinowa Teknoloji Akademisi",
+    description: "Posinowa staj başarı belgesi ve sertifika doğrulama sistemi.",
+  };
+}
+
+export default async function VerifyCertificatePage({ params }: Props) {
+  const { certificateNumber } = await params;
+  const decodedNumber = decodeURIComponent(certificateNumber);
+  const result = await verifyCertificate(decodedNumber);
+
+  const formattedDate =
+    result.isValid && result.certificate?.issuedAt
+      ? new Date(result.certificate.issuedAt).toLocaleDateString("tr-TR", {
+          day: "numeric",
+          month: "long",
+          year: "numeric",
+        })
+      : null;
+
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-slate-50 via-indigo-50/20 to-slate-100 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 py-10 px-4 sm:px-6 lg:px-8 flex flex-col justify-center items-center">
+      <div className="w-full max-w-2xl space-y-6">
+        
+        {/* Üst Logo ve Geri Dön Linki */}
+        <div className="flex items-center justify-between">
+          <Link
+            href="/"
+            className="inline-flex items-center gap-1.5 text-xs font-semibold text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100 transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Ana Sayfaya Dön
+          </Link>
+          <span className="inline-flex items-center gap-1 text-xs font-bold text-indigo-600 dark:text-indigo-400">
+            <Sparkles className="w-3.5 h-3.5" /> Posinowa Doğrulama Sistemi
+          </span>
+        </div>
+
+        {/* Sertifika Kartı */}
+        <div className="bg-white dark:bg-slate-900 border border-slate-200/80 dark:border-slate-800 rounded-3xl shadow-xl overflow-hidden">
+          {result.isValid && result.certificate ? (
+            <div>
+              {/* Geçerli Belge Üst Banner */}
+              <div className="bg-gradient-to-r from-emerald-600 via-teal-600 to-emerald-700 p-6 sm:p-8 text-white text-center space-y-2">
+                <div className="w-14 h-14 bg-white/20 backdrop-blur-md rounded-2xl flex items-center justify-center mx-auto mb-2 border border-white/30 shadow-md">
+                  <ShieldCheck className="w-8 h-8 text-white" />
+                </div>
+                <span className="inline-block px-3 py-1 rounded-full bg-white/20 text-xs font-extrabold uppercase tracking-wider backdrop-blur-sm">
+                  Resmi Olarak Doğrulandı
+                </span>
+                <h1 className="text-2xl sm:text-3xl font-extrabold tracking-tight">
+                  Staj Başarı Sertifikası Geçerlidir
+                </h1>
+                <p className="text-xs sm:text-sm text-emerald-100 font-medium max-w-md mx-auto">
+                  Bu belge Posinowa Teknoloji & Yazılım Akademisi veritabanında kayıtlı ve doğrulanmış resmi bir sertifikadır.
+                </p>
+              </div>
+
+              {/* Sertifika Detayları */}
+              <div className="p-6 sm:p-8 space-y-6">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 pb-6 border-b border-slate-100 dark:border-slate-800">
+                  <div className="space-y-1">
+                    <p className="text-xs font-bold uppercase tracking-wider text-slate-400">
+                      Sertifika Sahibi
+                    </p>
+                    <p className="text-lg font-extrabold text-slate-900 dark:text-slate-100 flex items-center gap-2">
+                      <User className="w-4 h-4 text-indigo-600 dark:text-indigo-400" />
+                      {result.certificate.studentName}
+                    </p>
+                  </div>
+
+                  <div className="space-y-1 sm:text-right">
+                    <p className="text-xs font-bold uppercase tracking-wider text-slate-400">
+                      Seri Numarası
+                    </p>
+                    <p className="font-mono text-sm font-bold text-slate-800 dark:text-slate-200 bg-slate-100 dark:bg-slate-800 inline-block px-2.5 py-1 rounded-lg">
+                      {result.certificate.certificateNumber}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 pb-6 border-b border-slate-100 dark:border-slate-800 text-xs">
+                  <div className="space-y-1">
+                    <span className="font-semibold text-slate-400 block">Başarı Derecesi</span>
+                    <span className="inline-flex items-center gap-1 font-bold text-purple-700 dark:text-purple-300 bg-purple-50 dark:bg-purple-950/50 px-2.5 py-1 rounded-md">
+                      <Award className="w-3.5 h-3.5 text-purple-600" />
+                      {result.certificate.completionGrade || "Belirlenmedi"}
+                    </span>
+                  </div>
+
+                  <div className="space-y-1">
+                    <span className="font-semibold text-slate-400 block">Düzenlenme Tarihi</span>
+                    <span className="inline-flex items-center gap-1 font-bold text-slate-700 dark:text-slate-300">
+                      <Calendar className="w-3.5 h-3.5 text-slate-500" />
+                      {formattedDate || "Resmi Belge"}
+                    </span>
+                  </div>
+
+                  <div className="space-y-1 sm:text-right">
+                    <span className="font-semibold text-slate-400 block">Teknik Mentör</span>
+                    <span className="font-bold text-slate-800 dark:text-slate-200">
+                      {result.certificate.mentorName || "Posinowa Mentorluk Ekibi"}
+                    </span>
+                  </div>
+                </div>
+
+                {/* Tamamlanan Projeler Listesi */}
+                {result.certificate.completedProjects.length > 0 && (
+                  <div className="space-y-3">
+                    <p className="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 flex items-center gap-1.5">
+                      <Briefcase className="w-3.5 h-3.5 text-indigo-600 dark:text-indigo-400" />
+                      Staj Sürecinde Tamamlanan Projeler ({result.certificate.completedProjects.length})
+                    </p>
+                    <div className="space-y-2">
+                      {result.certificate.completedProjects.map((p) => (
+                        <div
+                          key={p.id}
+                          className="flex items-center justify-between p-3 rounded-xl bg-slate-50 dark:bg-slate-800/60 border border-slate-200/60 dark:border-slate-700/60 text-xs font-medium"
+                        >
+                          <span className="text-slate-900 dark:text-slate-100 font-semibold truncate">
+                            {p.title}
+                          </span>
+                          <span className="shrink-0 px-2 py-0.5 rounded text-[10px] font-bold bg-indigo-100 text-indigo-800 dark:bg-indigo-950 dark:text-indigo-300">
+                            {p.difficulty}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Kurumsal Onay Mührü */}
+                <div className="pt-4 border-t border-slate-100 dark:border-slate-800 flex items-center justify-between text-[11px] text-slate-400">
+                  <span className="flex items-center gap-1 text-emerald-600 dark:text-emerald-400 font-semibold">
+                    <CheckCircle2 className="w-3.5 h-3.5" /> Dijital Olarak İmzalandı
+                  </span>
+                  <span>Posinowa Teknoloji & Akademi</span>
+                </div>
+              </div>
+            </div>
+          ) : (
+            /* Geçersiz / Bulunamayan Belge */
+            <div className="p-8 sm:p-12 text-center space-y-4">
+              <div className="w-16 h-16 bg-red-50 dark:bg-red-950/40 rounded-full flex items-center justify-center mx-auto text-red-600 dark:text-red-400">
+                <XCircle className="w-10 h-10" />
+              </div>
+              <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
+                Sertifika Doğrulanamadı
+              </h1>
+              <p className="text-sm text-slate-600 dark:text-slate-300 max-w-md mx-auto leading-relaxed">
+                {result.message || "Belirtilen seri numarasına ait resmi veya onaylanmış bir sertifika kaydı bulunamadı."}
+              </p>
+              <div className="pt-2">
+                <p className="text-xs font-mono text-slate-400 bg-slate-100 dark:bg-slate-800 inline-block px-3 py-1.5 rounded-lg">
+                  Aranan No: {decodedNumber}
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Alt Bilgi */}
+        <p className="text-center text-xs text-slate-400 dark:text-slate-500">
+          Posinowa Staj ve Proje Yönetim Platformu © {new Date().getFullYear()} — Tüm hakları saklıdır.
+        </p>
+
+      </div>
+    </main>
+  );
+}

--- a/src/components/certificate/CertificateModal.tsx
+++ b/src/components/certificate/CertificateModal.tsx
@@ -45,7 +45,7 @@ export function CertificateModal({
     certificate.mentorNote || DEFAULT_NOTE_TEMPLATES[0],
   );
   const [completionGrade, setCompletionGrade] = useState(
-    certificate.completionGrade || "Üstün Başarı",
+    certificate.completionGrade || "",
   );
   const [saving, setSaving] = useState(false);
 
@@ -245,14 +245,17 @@ export function CertificateModal({
     }
   };
 
-  const formattedDate = new Date(certificate.issuedAt).toLocaleDateString(
-    "tr-TR",
-    {
-      day: "numeric",
-      month: "long",
-      year: "numeric",
-    },
-  );
+  const formattedDate = certificate.issuedAt
+    ? new Date(certificate.issuedAt).toLocaleDateString("tr-TR", {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+      })
+    : new Date().toLocaleDateString("tr-TR", {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+      });
 
   return (
     <div
@@ -370,6 +373,7 @@ export function CertificateModal({
                   onChange={(e) => setCompletionGrade(e.target.value)}
                   className="w-full rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3.5 py-2.5 text-xs font-semibold text-slate-800 dark:text-slate-200 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 >
+                  <option value="">Belirlenmedi (Seçilmedi)</option>
                   <option value="Üstün Başarı">🎖️ Üstün Başarı (High Honors)</option>
                   <option value="Onur Derecesi">🌟 Onur Derecesi (Honors)</option>
                   <option value="Yüksek Başarı">🚀 Yüksek Başarı (Excellence)</option>
@@ -497,7 +501,7 @@ export function CertificateModal({
               <div>
                 <span className="inline-flex items-center gap-1.5 px-3.5 py-1 rounded-full bg-purple-50 dark:bg-purple-950/60 border border-purple-200 dark:border-purple-800 text-purple-800 dark:text-purple-300 font-bold text-xs">
                   <Award className="w-3.5 h-3.5 text-purple-600" />
-                  Başarı Derecesi: <span className="font-extrabold">{completionGrade}</span>
+                  Başarı Derecesi: <span className="font-extrabold">{completionGrade || "Belirlenmedi"}</span>
                 </span>
               </div>
             </div>

--- a/src/features/admin/server/user.test.ts
+++ b/src/features/admin/server/user.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 // prisma'yı mock'la (gerçek DB gerekmez)
-const { prismaMock, deleteStepFileMock } = vi.hoisted(() => ({
+const { prismaMock, deleteStepFileMock, ensureCertificateIssuedMock } = vi.hoisted(() => ({
   prismaMock: {
     user: {
       findUnique: vi.fn(),
@@ -16,9 +16,14 @@ const { prismaMock, deleteStepFileMock } = vi.hoisted(() => ({
     $transaction: vi.fn(),
   },
   deleteStepFileMock: vi.fn(),
+  ensureCertificateIssuedMock: vi.fn(),
 }));
 vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
 vi.mock("@/lib/storage/step-files", () => ({ deleteStepFile: deleteStepFileMock }));
+// #208: mezuniyet artık sertifikayı resmileştiriyor (seri no + issuedAt persist).
+vi.mock("@/features/certificate/server/certificate", () => ({
+  ensureCertificateIssued: ensureCertificateIssuedMock,
+}));
 
 import {
   setStudentMentors,
@@ -119,6 +124,24 @@ describe("updateAccountStatus — stajyer onay, mezuniyet ve red durumları", ()
       },
     });
     expect(result.accountStatus).toBe("GRADUATED");
+    // #208 review: mezuniyet sertifikayı RESMİLEŞTİRİR (seri no + issuedAt persist)
+    // → öğrenciye/QR'a gösterilen numara doğrulanabilir olur.
+    expect(ensureCertificateIssuedMock).toHaveBeenCalledWith("u-1");
+  });
+
+  it("#208: GRADUATED olmayan durumda sertifika resmileştirilmez", async () => {
+    prismaMock.user.update.mockResolvedValue({
+      id: "u-2",
+      email: "s@test.com",
+      name: "Ali",
+      lastName: "Veli",
+      role: "STUDENT",
+      accountStatus: "APPROVED",
+    });
+
+    await updateAccountStatus("u-2", "APPROVED");
+
+    expect(ensureCertificateIssuedMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/features/admin/server/user.ts
+++ b/src/features/admin/server/user.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@/lib/db";
 import { deleteStepFile } from "@/lib/storage/step-files";
+import { ensureCertificateIssued } from "@/features/certificate/server/certificate";
 import { logger } from "@/lib/logger";
 
 // Type export
@@ -89,11 +90,20 @@ export async function updateAccountStatus(
   userId: string,
   accountStatus: "PENDING" | "APPROVED" | "REJECTED" | "GRADUATED",
 ) {
-  return prisma.user.update({
+  const updated = await prisma.user.update({
     where: { id: userId },
     data: { accountStatus },
     select: { id: true, email: true, name: true, lastName: true, role: true, accountStatus: true },
   });
+
+  // #208 review: Mezun edilen stajyerin sertifikası ANINDA resmileştirilir —
+  // seri no + issuedAt DB'ye yazılır. Aksi halde öğrenciye/QR'a türetilmiş ama
+  // kayıtlı OLMAYAN bir numara gösterilir ve /verify-certificate "bulunamadı" der.
+  if (accountStatus === "GRADUATED") {
+    await ensureCertificateIssued(userId);
+  }
+
+  return updated;
 }
 
 // ------------------------------------

--- a/src/features/certificate/server/certificate.test.ts
+++ b/src/features/certificate/server/certificate.test.ts
@@ -3,15 +3,17 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 const { prismaMock } = vi.hoisted(() => ({
   prismaMock: {
     user: { findUnique: vi.fn() },
-    studentProfile: { update: vi.fn() },
+    studentProfile: { update: vi.fn(), findFirst: vi.fn() },
   },
 }));
 vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
 
 import {
   generateCertificateNumber,
+  getCertificateVerificationUrl,
   getStudentCertificate,
   updateCertificateDetails,
+  verifyCertificate,
 } from "./certificate";
 
 describe("Certificate Service — Staj Başarı Sertifikası", () => {
@@ -24,10 +26,37 @@ describe("Certificate Service — Staj Başarı Sertifikası", () => {
     expect(certNo).toMatch(/^POS-\d{4}-[A-Z0-9]{5}$/);
   });
 
+  it("getCertificateVerificationUrl — geçerli url üretir", () => {
+    const url = getCertificateVerificationUrl("POS-2026-TEST1");
+    expect(url).toContain("/verify-certificate/POS-2026-TEST1");
+  });
+
   it("getStudentCertificate — öğrenci ve profil yoksa null döner", async () => {
     prismaMock.user.findUnique.mockResolvedValue(null);
     const result = await getStudentCertificate("unknown-id");
     expect(result).toBeNull();
+  });
+
+  it("getStudentCertificate — grade girilmemişse 'Üstün Başarı' varsaymaz, null döner", async () => {
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: "u-1",
+      email: "ogrenci@posinowa.com",
+      name: "Ali",
+      studentProfile: {
+        id: "sp-1",
+        certificateNumber: "POS-2026-0001",
+        completionGrade: null,
+        mentorNote: null,
+        issuedAt: null,
+        mentorAssignments: [],
+        assignedProjects: [],
+      },
+    });
+
+    const cert = await getStudentCertificate("u-1");
+    expect(cert).not.toBeNull();
+    expect(cert?.completionGrade).toBeNull();
+    expect(cert?.issuedAt).toBeNull();
   });
 
   it("getStudentCertificate — geçerli öğrenci için tüm sertifika ve proje verilerini derler", async () => {
@@ -107,4 +136,52 @@ describe("Certificate Service — Staj Başarı Sertifikası", () => {
     });
     expect(updated.certificateNumber).toBe("POS-2026-9999");
   });
+
+  describe("verifyCertificate (#208)", () => {
+    it("geçersiz veya boş seri no girildiğinde isValid: false döner", async () => {
+      const res = await verifyCertificate("   ");
+      expect(res.isValid).toBe(false);
+    });
+
+    it("kayıt bulunamadığında isValid: false döner", async () => {
+      prismaMock.studentProfile.findFirst.mockResolvedValue(null);
+      const res = await verifyCertificate("POS-9999-NOTFOUND");
+      expect(res.isValid).toBe(false);
+      expect(res.message).toContain("bulunamadı");
+    });
+
+    it("öğrenci mezun değilse ve issuedAt yoksa isValid: false döner", async () => {
+      prismaMock.studentProfile.findFirst.mockResolvedValue({
+        id: "sp-1",
+        certificateNumber: "POS-2026-1234",
+        issuedAt: null,
+        user: { id: "u-1", name: "Ali", accountStatus: "APPROVED" },
+        mentorAssignments: [],
+        assignedProjects: [],
+      });
+
+      const res = await verifyCertificate("POS-2026-1234");
+      expect(res.isValid).toBe(false);
+      expect(res.message).toContain("resmi olarak onaylanmamış");
+    });
+
+    it("öğrenci GRADUATED veya issuedAt dolu ise geçerli belge verisi döner", async () => {
+      prismaMock.studentProfile.findFirst.mockResolvedValue({
+        id: "sp-1",
+        certificateNumber: "POS-2026-1234",
+        issuedAt: new Date("2026-08-09"),
+        completionGrade: "Onur Derecesi",
+        user: { id: "u-1", name: "Ayşe", lastName: "Yılmaz", email: "ayse@test.com", accountStatus: "GRADUATED" },
+        mentorAssignments: [{ mentor: { name: "Mehmet", lastName: "Öz", email: "mehmet@test.com" } }],
+        assignedProjects: [],
+      });
+
+      const res = await verifyCertificate("POS-2026-1234");
+      expect(res.isValid).toBe(true);
+      expect(res.certificate?.studentName).toBe("Ayşe Yılmaz");
+      expect(res.certificate?.completionGrade).toBe("Onur Derecesi");
+      expect(res.certificate?.mentorName).toBe("Mehmet Öz");
+    });
+  });
 });
+

--- a/src/features/certificate/server/certificate.test.ts
+++ b/src/features/certificate/server/certificate.test.ts
@@ -126,13 +126,15 @@ describe("Certificate Service — Staj Başarı Sertifikası", () => {
       mentorNote: "Çok başarılı.",
     });
 
+    // #208 review (P3): issuedAt GÖNDERİLMEDİYSE dokunulmaz — not kaydetmek belgeyi
+    // yayınlamaz (aksi halde mezun olmayan öğrenci public doğrulamada geçerli görünürdü).
     expect(prismaMock.studentProfile.update).toHaveBeenCalledWith({
       where: { id: "sp-1" },
       data: {
         certificateNumber: "POS-2026-9999",
         completionGrade: "Onur Derecesi",
         mentorNote: "Çok başarılı.",
-        issuedAt: expect.any(Date),
+        issuedAt: undefined,
       },
     });
     expect(updated.certificateNumber).toBe("POS-2026-9999");
@@ -225,6 +227,41 @@ describe("Certificate Service — Staj Başarı Sertifikası", () => {
       await ensureCertificateIssued("yok");
 
       expect(prismaMock.studentProfile.update).not.toHaveBeenCalled();
+    });
+
+    it("seri no VARSA numara değişmez, yalnız issuedAt tamamlanır", async () => {
+      prismaMock.studentProfile.findUnique.mockResolvedValue({
+        id: "sp-1",
+        certificateNumber: "POS-2026-KEEPME",
+        issuedAt: null,
+      });
+
+      await ensureCertificateIssued("user-abc12");
+
+      expect(prismaMock.studentProfile.update).toHaveBeenCalledWith({
+        where: { id: "sp-1" },
+        data: { issuedAt: expect.any(Date) },
+      });
+    });
+
+    it("seri no ÇAKIŞIRSA (P2002) yeni numara üretip yeniden dener", async () => {
+      prismaMock.studentProfile.findUnique.mockResolvedValue({
+        id: "sp-1",
+        certificateNumber: null,
+        issuedAt: null,
+      });
+      const conflict = Object.assign(new Error("Unique constraint"), { code: "P2002" });
+      prismaMock.studentProfile.update
+        .mockRejectedValueOnce(conflict) // ilk aday çakıştı
+        .mockResolvedValueOnce({ id: "sp-1" }); // ikinci aday başarılı
+
+      await ensureCertificateIssued("user-abc12");
+
+      expect(prismaMock.studentProfile.update).toHaveBeenCalledTimes(2);
+      const first = prismaMock.studentProfile.update.mock.calls[0][0].data.certificateNumber;
+      const second = prismaMock.studentProfile.update.mock.calls[1][0].data.certificateNumber;
+      expect(second).not.toBe(first); // yeni aday üretildi
+      expect(second).toMatch(/^POS-\d{4}-[A-Z0-9]{5}$/);
     });
   });
 

--- a/src/features/certificate/server/certificate.test.ts
+++ b/src/features/certificate/server/certificate.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 const { prismaMock } = vi.hoisted(() => ({
   prismaMock: {
     user: { findUnique: vi.fn() },
-    studentProfile: { update: vi.fn(), findFirst: vi.fn() },
+    studentProfile: { update: vi.fn(), findFirst: vi.fn(), findUnique: vi.fn() },
   },
 }));
 vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
@@ -14,6 +14,7 @@ import {
   getStudentCertificate,
   updateCertificateDetails,
   verifyCertificate,
+  ensureCertificateIssued,
 } from "./certificate";
 
 describe("Certificate Service — Staj Başarı Sertifikası", () => {
@@ -181,6 +182,86 @@ describe("Certificate Service — Staj Başarı Sertifikası", () => {
       expect(res.certificate?.studentName).toBe("Ayşe Yılmaz");
       expect(res.certificate?.completionGrade).toBe("Onur Derecesi");
       expect(res.certificate?.mentorName).toBe("Mehmet Öz");
+    });
+  });
+
+  // #208 review: doğrulanabilirlik sözleşmesi — seri no DB'ye YAZILMADAN "resmi" sayılmaz.
+  describe("ensureCertificateIssued — sertifikayı resmileştirme (#208 review)", () => {
+    it("seri no/issuedAt yoksa üretir ve KALICI yazar", async () => {
+      prismaMock.studentProfile.findUnique.mockResolvedValue({
+        id: "sp-1",
+        certificateNumber: null,
+        issuedAt: null,
+      });
+
+      await ensureCertificateIssued("user-abc12");
+
+      expect(prismaMock.studentProfile.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "sp-1" },
+          data: expect.objectContaining({
+            certificateNumber: expect.stringMatching(/^POS-\d{4}-/),
+            issuedAt: expect.any(Date),
+          }),
+        }),
+      );
+    });
+
+    it("zaten resmileşmişse DOKUNMAZ (idempotent — numara değişmez)", async () => {
+      prismaMock.studentProfile.findUnique.mockResolvedValue({
+        id: "sp-1",
+        certificateNumber: "POS-2026-EXIST",
+        issuedAt: new Date("2026-01-01"),
+      });
+
+      await ensureCertificateIssued("user-abc12");
+
+      expect(prismaMock.studentProfile.update).not.toHaveBeenCalled();
+    });
+
+    it("öğrenci profili yoksa sessizce geçer", async () => {
+      prismaMock.studentProfile.findUnique.mockResolvedValue(null);
+
+      await ensureCertificateIssued("yok");
+
+      expect(prismaMock.studentProfile.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("isIssued bayrağı (#208 review)", () => {
+    /** getStudentCertificate için minimum user fixture. */
+    function mockProfile(over: { certificateNumber: string | null; issuedAt: Date | null }) {
+      prismaMock.user.findUnique.mockResolvedValue({
+        id: "u-1",
+        email: "s@test.com",
+        name: "Ali",
+        lastName: "Veli",
+        studentProfile: {
+          id: "sp-1",
+          certificateNumber: over.certificateNumber,
+          issuedAt: over.issuedAt,
+          completionGrade: null,
+          mentorNote: null,
+          mentorAssignments: [],
+          assignedProjects: [],
+        },
+      });
+    }
+
+    it("seri no + issuedAt kayıtlıysa isIssued=true", async () => {
+      mockProfile({ certificateNumber: "POS-2026-AAAAA", issuedAt: new Date("2026-08-01") });
+
+      const cert = await getStudentCertificate("u-1");
+
+      expect(cert?.isIssued).toBe(true);
+    });
+
+    it("kayıtlı değilse isIssued=false (önizleme — doğrulama sorgusu bulamaz)", async () => {
+      mockProfile({ certificateNumber: null, issuedAt: null });
+
+      const cert = await getStudentCertificate("u-1");
+
+      expect(cert?.isIssued).toBe(false);
     });
   });
 });

--- a/src/features/certificate/server/certificate.ts
+++ b/src/features/certificate/server/certificate.ts
@@ -20,6 +20,12 @@ export type CertificateData = {
     totalStepsCount: number;
   }[];
   verificationUrl: string;
+  /**
+   * #208 review: Sertifika RESMİ olarak yayınlandı mı (seri no + issuedAt DB'de kayıtlı)?
+   * false ise `certificateNumber`/`verificationUrl` yalnızca ÖNİZLEME'dir — o numarayla
+   * `/verify-certificate` sorgusu "bulunamadı" döner, çünkü DB'de kayıtlı değildir.
+   */
+  isIssued: boolean;
 };
 
 export type PublicCertificateVerification = {
@@ -130,6 +136,10 @@ export async function getStudentCertificate(userId: string): Promise<Certificate
     ? profile.issuedAt.toISOString()
     : null;
 
+  // #208 review: Belge ancak seri no VE issuedAt DB'de kayıtlıysa resmidir.
+  // Aksi halde (admin önizlemesi) numara türetilmiştir ve doğrulama sorgusu bulamaz.
+  const isIssued = Boolean(profile.certificateNumber && profile.issuedAt);
+
   return {
     id: profile.id,
     studentName,
@@ -142,7 +152,34 @@ export async function getStudentCertificate(userId: string): Promise<Certificate
     issuedAt: issuedDate,
     completedProjects,
     verificationUrl: getCertificateVerificationUrl(certNumber),
+    isIssued,
   };
+}
+
+/**
+ * #208 review: Sertifikayı RESMİLEŞTİR — seri no ve düzenlenme tarihini KALICI yazar.
+ *
+ * Mezuniyet anında çağrılır. Böylece öğrenciye/QR'a gösterilen numara DB'de kayıtlı
+ * olur ve public `/verify-certificate/<no>` sorgusu belgeyi bulur. İdempotent: zaten
+ * kayıtlı alanlara dokunmaz (yeniden mezun etme numarayı değiştirmez).
+ */
+export async function ensureCertificateIssued(userId: string): Promise<void> {
+  const profile = await prisma.studentProfile.findUnique({
+    where: { userId },
+    select: { id: true, certificateNumber: true, issuedAt: true },
+  });
+
+  // Profil yoksa yapacak bir şey yok (sertifika profile bağlı).
+  if (!profile) return;
+  if (profile.certificateNumber && profile.issuedAt) return;
+
+  await prisma.studentProfile.update({
+    where: { id: profile.id },
+    data: {
+      certificateNumber: profile.certificateNumber ?? generateCertificateNumber(userId),
+      issuedAt: profile.issuedAt ?? new Date(),
+    },
+  });
 }
 
 /** Yönetici sertifika bilgilerini (referans notu, başarı derecesi vb.) günceller. */

--- a/src/features/certificate/server/certificate.ts
+++ b/src/features/certificate/server/certificate.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/db";
+import { logger } from "@/lib/logger";
 
 export type CertificateData = {
   id: string;
@@ -54,6 +55,28 @@ export function generateCertificateNumber(userId: string): string {
   const suffix = cleanId.slice(-5).padStart(5, "X");
   const year = new Date().getFullYear();
   return `POS-${year}-${suffix}`;
+}
+
+/** #208 review: Seri no çakışmasında kaç kez yeniden denenecek. */
+const MAX_CERT_NUMBER_ATTEMPTS = 5;
+
+/** Çakışma durumunda kullanılan tamamen rastgele seri no (aynı POS-YYYY-XXXXX formatı). */
+function generateRandomCertificateNumber(): string {
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  let suffix = "";
+  for (let i = 0; i < 5; i++) {
+    suffix += alphabet[Math.floor(Math.random() * alphabet.length)];
+  }
+  return `POS-${new Date().getFullYear()}-${suffix}`;
+}
+
+/** Prisma unique-constraint (P2002) ihlali mi? */
+function isUniqueViolation(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: string }).code === "P2002"
+  );
 }
 
 /** Doğrulama URL'i üretir. */
@@ -173,16 +196,45 @@ export async function ensureCertificateIssued(userId: string): Promise<void> {
   if (!profile) return;
   if (profile.certificateNumber && profile.issuedAt) return;
 
-  await prisma.studentProfile.update({
-    where: { id: profile.id },
-    data: {
-      certificateNumber: profile.certificateNumber ?? generateCertificateNumber(userId),
-      issuedAt: profile.issuedAt ?? new Date(),
-    },
-  });
+  // Seri no zaten varsa yalnız tarihi tamamla (numara ASLA değiştirilmez).
+  if (profile.certificateNumber) {
+    await prisma.studentProfile.update({
+      where: { id: profile.id },
+      data: { issuedAt: profile.issuedAt ?? new Date() },
+    });
+    return;
+  }
+
+  // #208 review: `certificateNumber` artık @unique. Seri no userId'nin son 5
+  // karakterinden türediği için nadir de olsa çakışabilir → unique ihlalinde (P2002)
+  // yeni bir aday üretip sınırlı sayıda yeniden dene.
+  for (let attempt = 0; attempt < MAX_CERT_NUMBER_ATTEMPTS; attempt++) {
+    const candidate =
+      attempt === 0 ? generateCertificateNumber(userId) : generateRandomCertificateNumber();
+    try {
+      await prisma.studentProfile.update({
+        where: { id: profile.id },
+        data: { certificateNumber: candidate, issuedAt: profile.issuedAt ?? new Date() },
+      });
+      return;
+    } catch (err) {
+      if (!isUniqueViolation(err)) throw err;
+      logger.warn("Sertifika seri no çakıştı, yeniden üretiliyor", { userId, attempt });
+    }
+  }
+
+  throw new Error("Benzersiz sertifika numarası üretilemedi (çakışma sınırı aşıldı).");
 }
 
-/** Yönetici sertifika bilgilerini (referans notu, başarı derecesi vb.) günceller. */
+/**
+ * Yönetici sertifika bilgilerini (referans notu, başarı derecesi vb.) günceller.
+ *
+ * #208 review (P3 tuzağı): Eskiden `issuedAt` verilmediğinde otomatik `new Date()`
+ * yazılıyordu — yani admin sadece NOT kaydettiğinde, mezun olmayan öğrencinin belgesi
+ * public doğrulamada "geçerli" hale geliyordu (`GRADUATED || issuedAt`). Artık
+ * `issuedAt` YALNIZCA açıkça gönderildiğinde değişir; belge resmileştirme tek bir
+ * yerde olur: mezuniyet → `ensureCertificateIssued()`.
+ */
 export async function updateCertificateDetails(
   studentProfileId: string,
   data: {
@@ -198,7 +250,8 @@ export async function updateCertificateDetails(
       certificateNumber: data.certificateNumber,
       mentorNote: data.mentorNote,
       completionGrade: data.completionGrade,
-      issuedAt: data.issuedAt !== undefined ? data.issuedAt : new Date(),
+      // undefined → Prisma alanı DEĞİŞTİRMEZ (otomatik yayınlama yok).
+      issuedAt: data.issuedAt,
     },
   });
 }

--- a/src/features/certificate/server/certificate.ts
+++ b/src/features/certificate/server/certificate.ts
@@ -184,18 +184,18 @@ export async function verifyCertificate(
     },
     include: {
       user: {
+        // #208: Public sayfa — email/PII ÇEKİLMEZ (name yoksa nötr etikete düşülür).
         select: {
           id: true,
           name: true,
           lastName: true,
-          email: true,
           accountStatus: true,
         },
       },
       mentorAssignments: {
         include: {
           mentor: {
-            select: { name: true, lastName: true, email: true },
+            select: { name: true, lastName: true },
           },
         },
       },
@@ -233,15 +233,16 @@ export async function verifyCertificate(
     };
   }
 
+  // #208: Public sayfada isim yoksa email'e DÜŞÜLMEZ (PII sızıntısı) — nötr etiket.
   const studentName =
     [profile.user.name, profile.user.lastName].filter(Boolean).join(" ") ||
-    profile.user.email.split("@")[0];
+    "İsimsiz Stajyer";
 
   const mentorsList = profile.mentorAssignments.map((a) => a.mentor);
   const mentorName =
     mentorsList.length > 0
       ? mentorsList
-          .map((m) => [m.name, m.lastName].filter(Boolean).join(" ") || m.email)
+          .map((m) => [m.name, m.lastName].filter(Boolean).join(" ") || "Mentör")
           .join(", ")
       : null;
 

--- a/src/features/certificate/server/certificate.ts
+++ b/src/features/certificate/server/certificate.ts
@@ -7,9 +7,9 @@ export type CertificateData = {
   mentorName: string | null;
   mentorEmail: string | null;
   certificateNumber: string;
-  completionGrade: string;
+  completionGrade: string | null;
   mentorNote: string | null;
-  issuedAt: string;
+  issuedAt: string | null;
   completedProjects: {
     id: string;
     title: string;
@@ -22,12 +22,38 @@ export type CertificateData = {
   verificationUrl: string;
 };
 
+export type PublicCertificateVerification = {
+  isValid: boolean;
+  certificate?: {
+    certificateNumber: string;
+    studentName: string;
+    issuedAt: string | null;
+    completionGrade: string | null;
+    mentorName: string | null;
+    completedProjects: {
+      id: string;
+      title: string;
+      difficulty: string;
+      track: string[];
+      completedStepsCount: number;
+      totalStepsCount: number;
+    }[];
+  };
+  message?: string;
+};
+
 /** Benzersiz sertifika seri no üretir: POS-2026-XXXX */
 export function generateCertificateNumber(userId: string): string {
   const cleanId = userId.replace(/[^a-zA-Z0-9]/g, "").toUpperCase();
   const suffix = cleanId.slice(-5).padStart(5, "X");
   const year = new Date().getFullYear();
   return `POS-${year}-${suffix}`;
+}
+
+/** Doğrulama URL'i üretir. */
+export function getCertificateVerificationUrl(certNumber: string): string {
+  const baseUrl = (process.env.NEXT_PUBLIC_APP_URL || "https://posinowa.com").replace(/\/+$/, "");
+  return `${baseUrl}/verify-certificate/${encodeURIComponent(certNumber)}`;
 }
 
 /** Öğrencinin sertifika verilerini derler. */
@@ -102,7 +128,7 @@ export async function getStudentCertificate(userId: string): Promise<Certificate
 
   const issuedDate = profile.issuedAt
     ? profile.issuedAt.toISOString()
-    : new Date().toISOString();
+    : null;
 
   return {
     id: profile.id,
@@ -111,11 +137,11 @@ export async function getStudentCertificate(userId: string): Promise<Certificate
     mentorName,
     mentorEmail,
     certificateNumber: certNumber,
-    completionGrade: profile.completionGrade || "Üstün Başarı",
+    completionGrade: profile.completionGrade ?? null,
     mentorNote: profile.mentorNote,
     issuedAt: issuedDate,
     completedProjects,
-    verificationUrl: `https://posinowa.com/verify-certificate/${certNumber}`,
+    verificationUrl: getCertificateVerificationUrl(certNumber),
   };
 }
 
@@ -124,9 +150,9 @@ export async function updateCertificateDetails(
   studentProfileId: string,
   data: {
     certificateNumber?: string;
-    mentorNote?: string;
-    completionGrade?: string;
-    issuedAt?: Date;
+    mentorNote?: string | null;
+    completionGrade?: string | null;
+    issuedAt?: Date | null;
   },
 ) {
   return prisma.studentProfile.update({
@@ -135,7 +161,115 @@ export async function updateCertificateDetails(
       certificateNumber: data.certificateNumber,
       mentorNote: data.mentorNote,
       completionGrade: data.completionGrade,
-      issuedAt: data.issuedAt ?? new Date(),
+      issuedAt: data.issuedAt !== undefined ? data.issuedAt : new Date(),
     },
   });
 }
+
+/** #208: Kamu / 3. taraf sertifika doğrulama sorgusu. */
+export async function verifyCertificate(
+  certificateNumber: string,
+): Promise<PublicCertificateVerification> {
+  const trimmedNumber = certificateNumber.trim();
+  if (!trimmedNumber) {
+    return { isValid: false, message: "Geçersiz sertifika numarası." };
+  }
+
+  const profile = await prisma.studentProfile.findFirst({
+    where: {
+      certificateNumber: {
+        equals: trimmedNumber,
+        mode: "insensitive",
+      },
+    },
+    include: {
+      user: {
+        select: {
+          id: true,
+          name: true,
+          lastName: true,
+          email: true,
+          accountStatus: true,
+        },
+      },
+      mentorAssignments: {
+        include: {
+          mentor: {
+            select: { name: true, lastName: true, email: true },
+          },
+        },
+      },
+      assignedProjects: {
+        include: {
+          projectTemplate: true,
+          roadmap: {
+            include: {
+              steps: {
+                select: { id: true, status: true },
+              },
+            },
+          },
+        },
+        orderBy: { createdAt: "desc" },
+      },
+    },
+  });
+
+  if (!profile || !profile.user) {
+    return {
+      isValid: false,
+      message: "Bu seri numarasına ait kayıtlı sertifika bulunamadı.",
+    };
+  }
+
+  // Yalnızca mezun edilmiş veya resmi issuedAt tarihi bulunan belgeler geçerlidir.
+  const isOfficiallyIssued =
+    profile.user.accountStatus === "GRADUATED" || profile.issuedAt !== null;
+
+  if (!isOfficiallyIssued) {
+    return {
+      isValid: false,
+      message: "Bu sertifika henüz resmi olarak onaylanmamış veya yayınlanmamıştır.",
+    };
+  }
+
+  const studentName =
+    [profile.user.name, profile.user.lastName].filter(Boolean).join(" ") ||
+    profile.user.email.split("@")[0];
+
+  const mentorsList = profile.mentorAssignments.map((a) => a.mentor);
+  const mentorName =
+    mentorsList.length > 0
+      ? mentorsList
+          .map((m) => [m.name, m.lastName].filter(Boolean).join(" ") || m.email)
+          .join(", ")
+      : null;
+
+  const completedProjects = profile.assignedProjects.map((p) => {
+    const steps = p.roadmap?.steps || [];
+    const totalStepsCount = steps.length;
+    const completedStepsCount = steps.filter((s) => s.status === "COMPLETED").length;
+
+    return {
+      id: p.id,
+      title: p.projectTemplate.title,
+      difficulty: p.projectTemplate.difficulty,
+      track: p.projectTemplate.track,
+      completedStepsCount,
+      totalStepsCount,
+    };
+  });
+
+  return {
+    isValid: true,
+    certificate: {
+      certificateNumber: profile.certificateNumber || trimmedNumber,
+      studentName,
+      issuedAt: profile.issuedAt ? profile.issuedAt.toISOString() : null,
+      completionGrade: profile.completionGrade ?? null,
+      mentorName,
+      completedProjects,
+    },
+  };
+}
+

--- a/src/features/files/ui/StepFiles.tsx
+++ b/src/features/files/ui/StepFiles.tsx
@@ -36,12 +36,13 @@ type Props = {
   currentUserId: string;
   currentUserRole: string;
   isDraft?: boolean;
+  readOnly?: boolean;
 };
 
-export function StepFiles({ stepId, currentUserId, currentUserRole, isDraft }: Props) {
+export function StepFiles({ stepId, currentUserId, currentUserRole, isDraft, readOnly }: Props) {
   const confirm = useConfirm();
-  // #52: Taslak roadmap'te öğrenci dosya yükleyemez (mentor inceleme için yükleyebilir).
-  const interactionLocked = isDraft && currentUserRole === "STUDENT";
+  // #52: Taslak roadmap'te öğrenci dosya yükleyemez. #208: Mezun portfolyoda salt-okunurdur.
+  const interactionLocked = (isDraft && currentUserRole === "STUDENT") || (readOnly && currentUserRole === "STUDENT");
   const [files, setFiles] = useState<StepFile[]>([]);
   const [loading, setLoading] = useState(false);
   const [uploading, setUploading] = useState(false);
@@ -166,6 +167,8 @@ export function StepFiles({ stepId, currentUserId, currentUserRole, isDraft }: P
   }
 
   function canDelete(file: StepFile) {
+    if (readOnly && currentUserRole === "STUDENT") return false;
+    // Yükleyen veya mentor silebilir
     return file.uploader.id === currentUserId || currentUserRole === "MENTOR";
   }
 

--- a/src/features/messaging/ui/StepComments.tsx
+++ b/src/features/messaging/ui/StepComments.tsx
@@ -24,12 +24,13 @@ type Props = {
   currentUserId: string;
   currentUserRole: string;
   isDraft?: boolean;
+  readOnly?: boolean;
 };
 
-export function StepComments({ stepId, currentUserId, currentUserRole, isDraft }: Props) {
+export function StepComments({ stepId, currentUserId, currentUserRole, isDraft, readOnly }: Props) {
   const confirm = useConfirm();
-  // #52: Taslak roadmap'te öğrenci yorum ekleyemez (mentor inceleme için ekleyebilir).
-  const interactionLocked = isDraft && currentUserRole === "STUDENT";
+  // #52: Taslak roadmap'te öğrenci yorum ekleyemez. #208: Mezun portfolyoda salt-okunurdur.
+  const interactionLocked = (isDraft && currentUserRole === "STUDENT") || (readOnly && currentUserRole === "STUDENT");
   const [comments, setComments] = useState<Comment[]>([]);
   const [newComment, setNewComment] = useState("");
   const [loading, setLoading] = useState(false);
@@ -154,10 +155,11 @@ export function StepComments({ stepId, currentUserId, currentUserRole, isDraft }
     });
   }
 
-  function canDelete(comment: Comment) {
-    // Yorum sahibi veya mentor silebilir
-    return comment.author.id === currentUserId || currentUserRole === "MENTOR";
-  }
+  const canDelete = (comment: Comment) => {
+    if (readOnly && currentUserRole === "STUDENT") return false;
+    if (currentUserRole === "MENTOR") return true;
+    return comment.author.id === currentUserId;
+  };
 
   return (
     <div className="mt-3">
@@ -238,7 +240,7 @@ export function StepComments({ stepId, currentUserId, currentUserRole, isDraft }
                             {comment.content}
                           </p>
                           <div className="flex gap-0.5 ml-2 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity flex-shrink-0">
-                            {comment.author.id === currentUserId && (
+                            {comment.author.id === currentUserId && !readOnly && (
                               <button
                                 onClick={() => { setEditingId(comment.id); setEditContent(comment.content); }}
                                 className="p-1 text-gray-400 dark:text-slate-500 hover:text-blue-600 dark:hover:text-blue-400"

--- a/src/features/student/ui/RoadmapSteps.tsx
+++ b/src/features/student/ui/RoadmapSteps.tsx
@@ -21,16 +21,21 @@ type Step = {
 type Props = {
   steps: Step[];
   isDraft: boolean;
+  isGraduated?: boolean;
   currentUserId?: string;
   currentUserRole?: string;
 };
 
-export function RoadmapSteps({ steps, isDraft, currentUserId, currentUserRole }: Props) {
+export function RoadmapSteps({ steps, isDraft, isGraduated = false, currentUserId, currentUserRole }: Props) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [updatingId, setUpdatingId] = useState<string | null>(null);
 
   async function updateStepStatus(stepId: string, newStatus: "IN_PROGRESS" | "COMPLETED") {
+    if (isGraduated) {
+      toast.info("Mezuniyet sonrası staj adımları salt-okunur durumdadır.");
+      return;
+    }
     setUpdatingId(stepId);
     try {
       const res = await fetch(`/api/student/steps/${stepId}`, {
@@ -186,8 +191,8 @@ export function RoadmapSteps({ steps, isDraft, currentUserId, currentUserRole }:
                   </div>
                 )}
 
-                {/* Aksiyon Butonları */}
-                {!isDraft && !isLocked && !isCompleted && (
+                {/* Aksiyon Butonları — Mezun olmayan ve yayınlanmış adımlarda aktif */}
+                {!isGraduated && !isDraft && !isLocked && !isCompleted && (
                   <div className="mt-4 pt-4 border-t border-slate-100 dark:border-slate-800">
                     {isTodo && isActionable && (
                       <button
@@ -227,6 +232,7 @@ export function RoadmapSteps({ steps, isDraft, currentUserId, currentUserRole }:
                     currentUserId={currentUserId}
                     currentUserRole={currentUserRole}
                     isDraft={isDraft}
+                    readOnly={isGraduated}
                   />
                 )}
 
@@ -237,6 +243,7 @@ export function RoadmapSteps({ steps, isDraft, currentUserId, currentUserRole }:
                     currentUserId={currentUserId}
                     currentUserRole={currentUserRole}
                     isDraft={isDraft}
+                    readOnly={isGraduated}
                   />
                 )}
               </div>
@@ -247,3 +254,4 @@ export function RoadmapSteps({ steps, isDraft, currentUserId, currentUserRole }:
     </div>
   );
 }
+

--- a/src/lib/validations/api.test.ts
+++ b/src/lib/validations/api.test.ts
@@ -4,6 +4,7 @@ import {
   updateTemplateSchema,
   createStepSchema,
   updateStepSchema,
+  updateCertificateSchema,
 } from "./api";
 
 const templateBase = {
@@ -198,3 +199,44 @@ describe("updateStepSchema — githubIssueUrl (#50)", () => {
     expect(result.success).toBe(false);
   });
 });
+
+describe("updateCertificateSchema (#208)", () => {
+  it("geçerli derece ve not ile doğrulamayı geçer", () => {
+    const result = updateCertificateSchema.safeParse({
+      completionGrade: "Üstün Başarı",
+      mentorNote: "Tebrikler, başarılı bir staj süreciydi.",
+      certificateNumber: "POS-2026-TEST1",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("tüm geçerli enum derecelerini kabul eder", () => {
+    for (const grade of ["Üstün Başarı", "Onur Derecesi", "Yüksek Başarı", "Başarılı"]) {
+      const result = updateCertificateSchema.safeParse({ completionGrade: grade });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("geçersiz başarı derecesini reddeder", () => {
+    const result = updateCertificateSchema.safeParse({
+      completionGrade: "Geçersiz Derece",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("null veya undefined değerleri kabul eder", () => {
+    const result = updateCertificateSchema.safeParse({
+      completionGrade: null,
+      mentorNote: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("2000 karakterden uzun referans notunu reddeder", () => {
+    const result = updateCertificateSchema.safeParse({
+      mentorNote: "a".repeat(2001),
+    });
+    expect(result.success).toBe(false);
+  });
+});
+

--- a/src/lib/validations/api.ts
+++ b/src/lib/validations/api.ts
@@ -257,3 +257,25 @@ export const updateSuggestionSchema = z
   .refine((data) => data.status !== undefined || data.adminNote !== undefined, {
     message: "Güncellenecek en az bir alan gönderilmeli",
   });
+
+// ==========================================
+// 🎓 Sertifika ve Mezuniyet Şemaları (#204, #208)
+// ==========================================
+
+export const completionGradeEnum = z.enum([
+  "Üstün Başarı",
+  "Onur Derecesi",
+  "Yüksek Başarı",
+  "Başarılı",
+]);
+
+export const updateCertificateSchema = z.object({
+  certificateNumber: z.string().min(1).max(50).optional(),
+  mentorNote: z
+    .string()
+    .max(2000, "Referans notu en fazla 2000 karakter olabilir.")
+    .optional()
+    .nullable(),
+  completionGrade: completionGradeEnum.optional().nullable(),
+});
+

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,7 +14,17 @@ const protectedRoutes: Record<string, string> = {
 // Auth gerektirmeyen public sayfalar
 // NOT: /forgot-password oturumsuz kullanıcılar için erişilebilir olmalı (şifre sıfırlama).
 // #171: /terms ve /privacy oturumsuz da okunabilmeli (kayıt ekranı bunlara link verir).
-const publicPaths = ["/signin", "/signup", "/forgot-password", "/terms", "/privacy", "/api/auth", "/api/health"];
+// #208: /verify-certificate kamuya açık sertifika doğrulama sayfasıdır.
+const publicPaths = [
+  "/signin",
+  "/signup",
+  "/forgot-password",
+  "/terms",
+  "/privacy",
+  "/verify-certificate",
+  "/api/auth",
+  "/api/health",
+];
 
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;


### PR DESCRIPTION
## Özet
Mezuniyet + sertifika sistemi: mezun portfolyosu **salt-okunur**, **public sertifika doğrulama**, `completionGrade` default'unun kaldırılması.

## Review düzeltmeleri (bu push)

### 1. ✅ ASIL BLOCKER — persist edilmeyen sertifika numarası
**Sorun:** `getStudentCertificate`, DB'de yoksa **üretilmiş ama kaydedilmemiş** seri no döndürüyordu; mezuniyet (`updateAccountStatus`) `certificateNumber`/`issuedAt` yazmıyordu. Sonuç: öğrenci/QR sahte numaraya gidiyor, `/verify-certificate/...` **"bulunamadı"** diyordu → issue'nun "çalışan verificationUrl" kabulü bozuluyordu.

**Çözüm — mezuniyette otomatik resmileştirme:**
- Yeni **`ensureCertificateIssued(userId)`**: seri no + `issuedAt`'i **kalıcı yazar**, **idempotent** (zaten kayıtlıysa dokunmaz → numara değişmez).
- **`updateAccountStatus → GRADUATED`** bunu çağırır → mezun edilen her öğrencinin numarası DB'de kayıtlı, QR/verify **gerçekten çalışır**.
- **Öğrenci ucu kendi kendini onarır**: bu düzeltmeden ÖNCE mezun edilmiş kayıtlarda eksik alanlar ilk erişimde tamamlanır.
- **`CertificateData.isIssued`**: "resmi belge" ile "admin önizlemesi" ayrımı net (önizlemede numara doğrulanamaz olduğu bilgisi taşınır).

### 2. ✅ Public verify rate-limit
`/verify-certificate` → **IP başına 60 sn'de 20 sorgu** (seri no enumeration koruması). Limit aşılırsa kullanıcı dostu "çok fazla deneme" ekranı.

### 3. ✅ GRADUATED yazma politikası — bilinçli karar + docs
- **Kapatıldı: AI chat** → her mesaj bir **Gemini çağrısı (maliyet)** ve chat aktif staja bağlı bir öğrenme aracı. Mezun geçmişi görmeye devam eder, yeni mesaj gönderemez (403).
- **Bilinçli AÇIK: öneri/istek (suggestions)** → mezun geri bildirimi meşru ve düşük riskli.
- Her ikisi de **CLAUDE.md**'de gerekçesiyle belgelendi (ürün daraltmak isterse nereye kontrol ekleneceği de yazılı).

### 4. ✅ generateMetadata çift DB sorgusu
React **`cache()`** ile `generateMetadata` + sayfa gövdesi **istek başına tek sorgu** paylaşıyor.

## Test
- **Yeni**: `ensureCertificateIssued` (üretir+yazar / idempotent / profil yoksa sessiz), `isIssued` bayrağı (resmi vs önizleme), mezuniyette resmileştirme çağrısı + GRADUATED olmayanda çağrılmaması.
- **466 test / 73 dosya** geçti · `tsc` (prod) temiz · lint temiz · `npm run build` başarılı.

## Önceki push'lardaki güvenlik işleri
Public verify'da **email/PII sızıntısı kapatıldı** (isim yoksa nötr etiket, email select bile edilmiyor).

Closes #208