### PR TITLE
fix: #201 alt kumesi — upload orphan compensation, GCS/migration testleri, logger

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -129,3 +129,26 @@ npm run create:admin
 - **Tek-instance varsayımı**: `rate-limit.ts`, forgot-password token'ları ve `metrics.ts`
   bellek-içi (process-local) tutulur. **Birden çok instance** çalıştıracaksanız bunlar
   instance'lar arasında paylaşılmaz → Redis'e taşıyın. Tek instance ile sorun yok.
+
+---
+
+## 6. 🚀 Canlıya Alma (Cutover) Kontrol Listesi (#201)
+
+Canlı ortama ilk çıkış veya ana sürüm geçişlerinde şu adımlar sırayla tamamlanmalıdır:
+
+1. **GCS Depolama Doğrulaması:**
+   - [ ] GCP Cloud Storage üzerinde bucket oluşturuldu (ör. `aisigner-prod-uploads`).
+   - [ ] Service account'a `roles/storage.objectAdmin` yetkisi verildi.
+   - [ ] Out Plane değişkenlerine `GCS_BUCKET=aisigner-prod-uploads` eklendi.
+   - [ ] Bir dosya yüklenip indirildiği ve DB bağlantı kesintisinde orphan dosya temizliğinin çalıştığı doğrulandı.
+
+2. **Veritabanı ve Şema Geçişi:**
+   - [ ] `DATABASE_URL`'in `sslmode=require` parametresi taşıdığı teyit edildi.
+   - [ ] `npx prisma migrate deploy`'un `docker-entrypoint.sh` üzerinden hatasız tamamlandığı loglandı.
+   - [ ] M:N mentör atama tablosu (`MentorAssignment`) kayıtlarının sağlıklı ilişkilendirildiği doğrulandı.
+
+3. **İlk Yönetici & Sistem Kontrolü:**
+   - [ ] `ADMIN_EMAIL` ve `ADMIN_PASSWORD` ile `npm run create:admin` çalıştırılarak ilk yönetici açıldı.
+   - [ ] `/api/health` uç noktası `200 OK` döndü.
+   - [ ] Admin dashboard ve mentör/öğrenci akışları canlı ortamda duman testinden (smoke test) geçirildi.
+

--- a/scripts/check-migrations.mjs
+++ b/scripts/check-migrations.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 // #198: Yıkıcı migration guard — zero-downtime deploy güvenliği.
 //
 // prisma/migrations/*/migration.sql içindeki geriye-uyumsuz (yıkıcı) ifadeleri
@@ -16,13 +15,14 @@
 // Bağımlılık yok — CI'da `npm ci` öncesinde bile çalışır.
 import { readdirSync, readFileSync, existsSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const MIGRATIONS_DIR = path.join(process.cwd(), "prisma", "migrations");
-const ACK_MARKER = "migration-safety-ack:";
+export const ACK_MARKER = "migration-safety-ack:";
 
 // Geriye-uyumsuz ifadeler. DROP CONSTRAINT bilinçli olarak DIŞARIDA: init pkey
 // churn'ü gibi benign durumlarda yanlış alarm yapmasın.
-const DESTRUCTIVE = [
+export const DESTRUCTIVE = [
   { re: /\bDROP\s+COLUMN\b/i, label: "DROP COLUMN" },
   { re: /\bDROP\s+TABLE\b/i, label: "DROP TABLE" },
   { re: /\bRENAME\s+COLUMN\b/i, label: "RENAME COLUMN" },
@@ -30,27 +30,18 @@ const DESTRUCTIVE = [
   { re: /\bSET\s+NOT\s+NULL\b/i, label: "SET NOT NULL" },
 ];
 
-if (!existsSync(MIGRATIONS_DIR)) {
-  console.log("Migration klasörü yok — atlanıyor.");
-  process.exit(0);
-}
-
-const violations = [];
-for (const entry of readdirSync(MIGRATIONS_DIR, { withFileTypes: true })) {
-  if (!entry.isDirectory()) continue;
-  const sqlPath = path.join(MIGRATIONS_DIR, entry.name, "migration.sql");
-  if (!existsSync(sqlPath)) continue;
-
-  const sql = readFileSync(sqlPath, "utf8");
+/** Tek bir SQL metnini yıkıcı ifadeler için denetler. */
+export function checkMigrationSql(sql, fileName = "migration.sql") {
   const acked = sql.includes(ACK_MARKER);
-  if (acked) continue; // Bilinçli onaylanmış — atla.
+  if (acked) return [];
 
+  const violations = [];
   sql.split(/\r?\n/).forEach((line, i) => {
     if (line.trim().startsWith("--")) return; // yorum satırı
     for (const d of DESTRUCTIVE) {
       if (d.re.test(line)) {
         violations.push({
-          file: `${entry.name}/migration.sql`,
+          file: fileName,
           line: i + 1,
           label: d.label,
           text: line.trim(),
@@ -58,18 +49,48 @@ for (const entry of readdirSync(MIGRATIONS_DIR, { withFileTypes: true })) {
       }
     }
   });
+  return violations;
 }
 
-if (violations.length === 0) {
-  console.log("✓ Migration güvenlik kontrolü: yıkıcı + onaysız ifade yok.");
-  process.exit(0);
+/** Bir migration dizinini baştan sona tarar. */
+export function checkMigrationsDirectory(dirPath = MIGRATIONS_DIR) {
+  if (!existsSync(dirPath)) {
+    return { skipped: true, violations: [] };
+  }
+
+  const violations = [];
+  for (const entry of readdirSync(dirPath, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const sqlPath = path.join(dirPath, entry.name, "migration.sql");
+    if (!existsSync(sqlPath)) continue;
+
+    const sql = readFileSync(sqlPath, "utf8");
+    const fileViolations = checkMigrationSql(sql, `${entry.name}/migration.sql`);
+    violations.push(...fileViolations);
+  }
+
+  return { skipped: false, violations };
 }
 
-console.error("✗ Yıkıcı (geriye-uyumsuz) migration ifadeleri bulundu — onay yorumu yok:\n");
-for (const v of violations) {
-  console.error(`  ${v.file}:${v.line}  [${v.label}]  ${v.text}`);
-}
-console.error(`
+// CLI olarak çalıştırıldığında (node scripts/check-migrations.mjs)
+const isMainModule = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isMainModule) {
+  const result = checkMigrationsDirectory(MIGRATIONS_DIR);
+  if (result.skipped) {
+    console.log("Migration klasörü yok — atlanıyor.");
+    process.exit(0);
+  }
+
+  if (result.violations.length === 0) {
+    console.log("✓ Migration güvenlik kontrolü: yıkıcı + onaysız ifade yok.");
+    process.exit(0);
+  }
+
+  console.error("✗ Yıkıcı (geriye-uyumsuz) migration ifadeleri bulundu — onay yorumu yok:\n");
+  for (const v of result.violations) {
+    console.error(`  ${v.file}:${v.line}  [${v.label}]  ${v.text}`);
+  }
+  console.error(`
 Zero-downtime deploy'da eski sürüm hâlâ koşarken bu ifadeler onu bozabilir.
 Çözüm (bkz. docs/MIGRATIONS.md): expand/contract — önce additive ekle, sonra AYRI
 bir deploy'da drop et. Bilinçli ve güvenli olduğundan eminsen migration dosyasının
@@ -77,4 +98,5 @@ başına şu yorumu ekle:
 
   -- migration-safety-ack: <kısa gerekçe (ör. ilk-deploy: boş DB / expand-contract faz-3)>
 `);
-process.exit(1);
+  process.exit(1);
+}

--- a/scripts/check-migrations.test.ts
+++ b/scripts/check-migrations.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { checkMigrationSql, ACK_MARKER } from "./check-migrations.mjs";
+
+describe("check-migrations — migration güvenlik denetimi (#198 / #201)", () => {
+  it("güvenli ve eklemeli SQL ifadelerinde ihlal bulmaz", () => {
+    const safeSql = `
+      -- Non-destructive migration
+      ALTER TABLE "User" ADD COLUMN "role" TEXT NOT NULL DEFAULT 'STUDENT';
+      ALTER TABLE "Certificate" ALTER COLUMN "completionGrade" DROP DEFAULT;
+      CREATE TABLE "NewTable" ("id" TEXT PRIMARY KEY);
+      CREATE INDEX "idx_user_email" ON "User"("email");
+    `;
+
+    const violations = checkMigrationSql(safeSql, "2026_safe/migration.sql");
+    expect(violations).toHaveLength(0);
+  });
+
+  it("onaysız DROP COLUMN tespit edildiğinde ihlal listeler", () => {
+    const destructiveSql = `
+      -- Dangerous migration
+      ALTER TABLE "User" DROP COLUMN "oldColumn";
+    `;
+
+    const violations = checkMigrationSql(destructiveSql, "2026_bad/migration.sql");
+    expect(violations).toHaveLength(1);
+    expect(violations[0].label).toBe("DROP COLUMN");
+    expect(violations[0].file).toBe("2026_bad/migration.sql");
+    expect(violations[0].line).toBe(3);
+  });
+
+  it("onaysız DROP TABLE, RENAME ve SET NOT NULL ifadelerini tespit eder", () => {
+    const multiDestructiveSql = `
+      DROP TABLE "OldTable";
+      ALTER TABLE "User" RENAME COLUMN "username" TO "handle";
+      ALTER TABLE "User" RENAME TO "LegacyUser";
+      ALTER TABLE "User" ALTER COLUMN "email" SET NOT NULL;
+    `;
+
+    const violations = checkMigrationSql(multiDestructiveSql, "2026_multi/migration.sql");
+    expect(violations).toHaveLength(4);
+    expect(violations.map((v: { label: string }) => v.label)).toEqual([
+      "DROP TABLE",
+      "RENAME COLUMN",
+      "RENAME TO (tablo)",
+      "SET NOT NULL",
+    ]);
+  });
+
+  it("yorum satırındaki anahtar kelimeleri yanlış alarm olarak değerlendirmez", () => {
+    const commentedSql = `
+      -- DROP COLUMN is not executed here
+      -- DROP TABLE was considered but not done
+      SELECT 1;
+    `;
+
+    const violations = checkMigrationSql(commentedSql, "2026_commented/migration.sql");
+    expect(violations).toHaveLength(0);
+  });
+
+  it(`${ACK_MARKER} onay etiketi varsa yıkıcı ifadeleri bilinçli kabul eder`, () => {
+    const ackedSql = `
+      -- ${ACK_MARKER} ilk-deploy: bos DB temizligi
+      ALTER TABLE "User" DROP COLUMN "temporaryCol";
+      DROP TABLE "TemporaryOldTable";
+    `;
+
+    const violations = checkMigrationSql(ackedSql, "2026_acked/migration.sql");
+    expect(violations).toHaveLength(0);
+  });
+});

--- a/src/app/api/steps/[stepId]/files/[fileId]/route.test.ts
+++ b/src/app/api/steps/[stepId]/files/[fileId]/route.test.ts
@@ -5,15 +5,15 @@ const { requireAuthMock, prismaMock, deleteStepFileMock, readStepFileMock } = vi
   requireAuthMock: vi.fn(),
   prismaMock: { stepFile: { findUnique: vi.fn(), delete: vi.fn() } },
   deleteStepFileMock: vi.fn(),
-  readStepFileMock: vi.fn(() => Promise.resolve(null)),
+  readStepFileMock: vi.fn<(...args: unknown[]) => Promise<Buffer | null>>(() => Promise.resolve(null)),
 }));
 vi.mock("@/lib/auth/guard", () => ({
-  requireAuth: (...a: unknown[]) => requireAuthMock(...a),
+  requireAuth: (...a: unknown[]) => requireAuthMock(a[0], a[1]),
 }));
 vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
 vi.mock("@/lib/storage/step-files", () => ({
-  deleteStepFile: (...a: unknown[]) => deleteStepFileMock(...a),
-  readStepFile: (...a: unknown[]) => readStepFileMock(...a),
+  deleteStepFile: (fileName: string) => deleteStepFileMock(fileName),
+  readStepFile: (fileName: string) => readStepFileMock(fileName),
 }));
 
 import { DELETE, GET } from "./route";

--- a/src/app/api/steps/[stepId]/files/[fileId]/route.ts
+++ b/src/app/api/steps/[stepId]/files/[fileId]/route.ts
@@ -150,11 +150,15 @@ export async function DELETE(
       );
     }
 
-    // #197: GCS veya yerel diskten sil (backend env'e göre).
-    await deleteStepFile(stepFile.storedName);
-
-    // Veritabanından sil
+    // #201: Önce veritabanı kaydını sil (tutarlılık garantisi)
     await prisma.stepFile.delete({ where: { id: fileId } });
+
+    // #197: GCS veya yerel diskten sil (backend env'e göre)
+    try {
+      await deleteStepFile(stepFile.storedName);
+    } catch (delErr) {
+      console.error("Storage delete failed for", stepFile.storedName, delErr);
+    }
 
     return NextResponse.json({ message: "Dosya başarıyla silindi." });
   } catch (error) {

--- a/src/app/api/steps/[stepId]/files/[fileId]/route.ts
+++ b/src/app/api/steps/[stepId]/files/[fileId]/route.ts
@@ -3,6 +3,8 @@ import { prisma } from "@/lib/db";
 import { requireAuth } from "@/lib/auth/guard";
 import { isAssignedMentor } from "@/lib/auth/mentor-access";
 import { readStepFile, deleteStepFile } from "@/lib/storage/step-files";
+import { logger } from "@/lib/logger";
+import { incrementCounter } from "@/lib/metrics";
 
 /**
  * GET /api/steps/[stepId]/files/[fileId]
@@ -157,7 +159,14 @@ export async function DELETE(
     try {
       await deleteStepFile(stepFile.storedName);
     } catch (delErr) {
-      console.error("Storage delete failed for", stepFile.storedName, delErr);
+      // DB kaydı zaten silindi; storage silinemezse dosya öksüz kalır → operasyonel
+      // takip için logger + metrik (#201 review: sessiz console.error yerine).
+      incrementCounter("storage.delete.failure");
+      logger.error("Adım dosyası storage'dan silinemedi (DB kaydı silindi)", {
+        storedName: stepFile.storedName,
+        fileId,
+        err: delErr,
+      });
     }
 
     return NextResponse.json({ message: "Dosya başarıyla silindi." });

--- a/src/app/api/steps/[stepId]/files/route.test.ts
+++ b/src/app/api/steps/[stepId]/files/route.test.ts
@@ -2,17 +2,23 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 // --- Bağımlılıkları mock'la ---
 // vi.mock fabrikleri hoist edildiği için mock'ları vi.hoisted ile tanımlıyoruz.
-const { requireAuthMock, prismaMock } = vi.hoisted(() => ({
+const { requireAuthMock, prismaMock, saveStepFileMock, deleteStepFileMock } = vi.hoisted(() => ({
   requireAuthMock: vi.fn(),
   prismaMock: {
     roadmapStep: { findUnique: vi.fn() },
-    stepFile: { count: vi.fn() },
+    stepFile: { count: vi.fn(), create: vi.fn() },
   },
+  saveStepFileMock: vi.fn(),
+  deleteStepFileMock: vi.fn(),
 }));
 vi.mock("@/lib/auth/guard", () => ({
   requireAuth: (...args: unknown[]) => requireAuthMock(...args),
 }));
 vi.mock("@/lib/db", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/storage/step-files", () => ({
+  saveStepFile: (...args: unknown[]) => saveStepFileMock(...args),
+  deleteStepFile: (...args: unknown[]) => deleteStepFileMock(...args),
+}));
 
 import { POST } from "./route";
 
@@ -115,19 +121,42 @@ describe("POST /api/steps/[stepId]/files — içerik imzası (#113)", () => {
   it("metin dosyasında (.txt) içerik kontrolü atlanır — imza hatası dönmez", async () => {
     authAs(MENTOR_USER, "MENTOR");
     prismaMock.roadmapStep.findUnique.mockResolvedValue(buildStep("PUBLISHED"));
+    prismaMock.stepFile.create.mockResolvedValue({ id: "f-1" });
 
     const res = await POST(makeUploadRequest("notlar.txt", "serbest metin icerik"), ctx);
 
-    // İmza kontrolüne takılmadı (400 "uzantısıyla uyuşmuyor" değil);
-    // akış diske yazma/DB aşamasına ilerledi.
-    if (res.status === 400) {
-      const json = await res.json();
-      expect(String(json.error)).not.toContain("uzantısıyla uyuşmuyor");
-    }
+    // İmza kontrolüne takılmadı; başarılı oluşturuldu (201).
+    expect(res.status).toBe(201);
   });
 });
 
-// #113: fs erişimi mock'lanır (vi.mock hoist edilir, tüm dosya için geçerli) —
-// imza testleri gerçek diske yazmasın. Önceki testler fs'e zaten ulaşmıyor.
-// #197: Depolama katmanı mock'lanır — imza testleri gerçek diske/GCS'e yazmasın.
-vi.mock("@/lib/storage/step-files", () => ({ saveStepFile: vi.fn() }));
+describe("POST /api/steps/[stepId]/files — orphan compensation (#201)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.stepFile.count.mockResolvedValue(0);
+  });
+
+  function makeUploadRequest(fileName: string, content: Uint8Array | string) {
+    const form = new FormData();
+    form.set("file", new File([content as BlobPart], fileName));
+    return new Request("http://test/api/steps/step-1/files", {
+      method: "POST",
+      body: form,
+    });
+  }
+
+  it("DB create hata verirse saveStepFile ile kaydedilen dosya deleteStepFile ile temizlenir", async () => {
+    authAs(MENTOR_USER, "MENTOR");
+    prismaMock.roadmapStep.findUnique.mockResolvedValue(buildStep("PUBLISHED"));
+    saveStepFileMock.mockResolvedValue(undefined);
+    deleteStepFileMock.mockResolvedValue(undefined);
+    prismaMock.stepFile.create.mockRejectedValue(new Error("DB connection lost"));
+
+    const res = await POST(makeUploadRequest("test.txt", "dosya icerigi"), ctx);
+
+    expect(res.status).toBe(500);
+    expect(saveStepFileMock).toHaveBeenCalledOnce();
+    expect(deleteStepFileMock).toHaveBeenCalledOnce();
+  });
+});
+

--- a/src/app/api/steps/[stepId]/files/route.ts
+++ b/src/app/api/steps/[stepId]/files/route.ts
@@ -4,7 +4,7 @@ import { requireAuth } from "@/lib/auth/guard";
 import { isAssignedMentor } from "@/lib/auth/mentor-access";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { matchesExtensionSignature } from "@/lib/file-signature";
-import { saveStepFile } from "@/lib/storage/step-files";
+import { saveStepFile, deleteStepFile } from "@/lib/storage/step-files";
 import path from "path";
 import crypto from "crypto";
 
@@ -198,22 +198,33 @@ export async function POST(
     // #197: GCS veya yerel diske yaz (backend env'e göre seçilir).
     await saveStepFile(storedName, buffer, mimeType);
 
-    // Veritabanına kaydet
-    const stepFile = await prisma.stepFile.create({
-      data: {
-        stepId,
-        uploaderId: userId,
-        fileName: file.name.slice(0, 255), // Max 255 karakter
-        storedName,
-        mimeType,
-        fileSize: file.size,
-      },
-      include: {
-        uploader: {
-          select: { id: true, name: true, lastName: true, role: true },
+    let stepFile;
+    try {
+      // Veritabanına kaydet
+      stepFile = await prisma.stepFile.create({
+        data: {
+          stepId,
+          uploaderId: userId,
+          fileName: file.name.slice(0, 255), // Max 255 karakter
+          storedName,
+          mimeType,
+          fileSize: file.size,
         },
-      },
-    });
+        include: {
+          uploader: {
+            select: { id: true, name: true, lastName: true, role: true },
+          },
+        },
+      });
+    } catch (dbError) {
+      // #201: DB insert başarısız olursa storage'daki dosyayı temizle (orphan compensation).
+      try {
+        await deleteStepFile(storedName);
+      } catch (delErr) {
+        console.error("Orphan step file cleanup failed:", storedName, delErr);
+      }
+      throw dbError;
+    }
 
     return NextResponse.json({ file: stepFile }, { status: 201 });
   } catch (error) {

--- a/src/app/api/steps/[stepId]/files/route.ts
+++ b/src/app/api/steps/[stepId]/files/route.ts
@@ -5,6 +5,8 @@ import { isAssignedMentor } from "@/lib/auth/mentor-access";
 import { createRateLimiter } from "@/lib/rate-limit";
 import { matchesExtensionSignature } from "@/lib/file-signature";
 import { saveStepFile, deleteStepFile } from "@/lib/storage/step-files";
+import { logger } from "@/lib/logger";
+import { incrementCounter } from "@/lib/metrics";
 import path from "path";
 import crypto from "crypto";
 
@@ -220,8 +222,16 @@ export async function POST(
       // #201: DB insert başarısız olursa storage'daki dosyayı temizle (orphan compensation).
       try {
         await deleteStepFile(storedName);
+        incrementCounter("storage.orphan_cleanup.success");
       } catch (delErr) {
-        console.error("Orphan step file cleanup failed:", storedName, delErr);
+        // Temizlik de başarısız → dosya storage'da öksüz kalır; operasyonel takip için
+        // logger + metrik (sessiz console.error yerine).
+        incrementCounter("storage.orphan_cleanup.failure");
+        logger.error("Öksüz adım dosyası temizlenemedi (upload rollback)", {
+          storedName,
+          stepId,
+          err: delErr,
+        });
       }
       throw dbError;
     }

--- a/src/lib/storage/step-files.gcs.test.ts
+++ b/src/lib/storage/step-files.gcs.test.ts
@@ -1,7 +1,22 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from "vitest";
 
-// GCS branch'ini test etmek için GCS_BUCKET env ayarlanır.
-process.env.GCS_BUCKET = "aisigner-unit-test-bucket";
+// GCS branch'ini test etmek için GCS_BUCKET gerekir. #201 review: env'i modül
+// seviyesinde set etmek TÜM worker'ı kirletiyordu — `usingGcs()` runtime okuduğu
+// için aynı worker'daki yerel-disk testleri GCS yoluna kayabiliyordu (flaky CI).
+// Bu yüzden env yalnız bu suite süresince set edilir ve sonra eski değerine döner.
+const PREV_GCS_BUCKET = process.env.GCS_BUCKET;
+
+beforeAll(() => {
+  process.env.GCS_BUCKET = "aisigner-unit-test-bucket";
+});
+
+afterAll(() => {
+  if (PREV_GCS_BUCKET === undefined) {
+    delete process.env.GCS_BUCKET;
+  } else {
+    process.env.GCS_BUCKET = PREV_GCS_BUCKET;
+  }
+});
 
 const { saveMock, downloadMock, deleteMock, bucketFileMock } = vi.hoisted(() => {
   const saveMock = vi.fn();

--- a/src/lib/storage/step-files.gcs.test.ts
+++ b/src/lib/storage/step-files.gcs.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// GCS branch'ini test etmek için GCS_BUCKET env ayarlanır.
+process.env.GCS_BUCKET = "aisigner-unit-test-bucket";
+
+const { saveMock, downloadMock, deleteMock, bucketFileMock } = vi.hoisted(() => {
+  const saveMock = vi.fn();
+  const downloadMock = vi.fn();
+  const deleteMock = vi.fn();
+  const bucketFileMock = vi.fn<(...args: unknown[]) => { save: typeof saveMock; download: typeof downloadMock; delete: typeof deleteMock }>(() => ({
+    save: saveMock,
+    download: downloadMock,
+    delete: deleteMock,
+  }));
+  return { saveMock, downloadMock, deleteMock, bucketFileMock };
+});
+
+vi.mock("@google-cloud/storage", () => {
+  return {
+    Storage: class {
+      bucket() {
+        return {
+          file: (name: string) => bucketFileMock(name),
+        };
+      }
+    },
+  };
+});
+
+import { saveStepFile, readStepFile, deleteStepFile, usingGcs } from "./step-files";
+
+describe("step-files storage — GCS branch (#197 / #201)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("GCS_BUCKET tanımlıysa usingGcs() → true döner", () => {
+    expect(usingGcs()).toBe(true);
+  });
+
+  it("saveStepFile → GCS file.save çağrılır", async () => {
+    saveMock.mockResolvedValue(undefined);
+
+    await saveStepFile("test.png", Buffer.from("image-content"), "image/png");
+
+    expect(bucketFileMock).toHaveBeenCalledWith("steps/test.png");
+    expect(saveMock).toHaveBeenCalledWith(Buffer.from("image-content"), {
+      resumable: false,
+      contentType: "image/png",
+    });
+  });
+
+  it("readStepFile → dosya varsa buffer döner", async () => {
+    const fakeBuffer = Buffer.from("downloaded-content");
+    downloadMock.mockResolvedValue([fakeBuffer]);
+
+    const result = await readStepFile("test.png");
+
+    expect(bucketFileMock).toHaveBeenCalledWith("steps/test.png");
+    expect(downloadMock).toHaveBeenCalledOnce();
+    expect(result).toEqual(fakeBuffer);
+  });
+
+  it("readStepFile → GCS 404 hatasında null döner", async () => {
+    const notFoundError = new Error("Not Found") as Error & { code: number };
+    notFoundError.code = 404;
+    downloadMock.mockRejectedValue(notFoundError);
+
+    const result = await readStepFile("missing.png");
+
+    expect(result).toBeNull();
+  });
+
+  it("readStepFile → GCS 500 veya ağ hatasında hatayı fırlatır", async () => {
+    const serverError = new Error("Internal GCS Error") as Error & { code: number };
+    serverError.code = 500;
+    downloadMock.mockRejectedValue(serverError);
+
+    await expect(readStepFile("error.png")).rejects.toThrow("Internal GCS Error");
+  });
+
+  it("deleteStepFile → GCS file.delete({ ignoreNotFound: true }) çağrılır", async () => {
+    deleteMock.mockResolvedValue(undefined);
+
+    await deleteStepFile("delete-me.png");
+
+    expect(bucketFileMock).toHaveBeenCalledWith("steps/delete-me.png");
+    expect(deleteMock).toHaveBeenCalledWith({ ignoreNotFound: true });
+  });
+});

--- a/src/lib/storage/step-files.test.ts
+++ b/src/lib/storage/step-files.test.ts
@@ -15,15 +15,15 @@ const { writeFileMock, readFileMock, unlinkMock, mkdirMock, existsMock } = vi.ho
   readFileMock: vi.fn(),
   unlinkMock: vi.fn(),
   mkdirMock: vi.fn(),
-  existsMock: vi.fn(() => true),
+  existsMock: vi.fn<(...args: unknown[]) => boolean>(() => true),
 }));
 vi.mock("fs/promises", () => ({
-  writeFile: (...a: unknown[]) => writeFileMock(...a),
-  readFile: (...a: unknown[]) => readFileMock(...a),
-  unlink: (...a: unknown[]) => unlinkMock(...a),
-  mkdir: (...a: unknown[]) => mkdirMock(...a),
+  writeFile: (path: string, data: unknown) => writeFileMock(path, data),
+  readFile: (path: string) => readFileMock(path),
+  unlink: (path: string) => unlinkMock(path),
+  mkdir: (path: string, options?: unknown) => mkdirMock(path, options),
 }));
-vi.mock("fs", () => ({ existsSync: (...a: unknown[]) => existsMock(...a) }));
+vi.mock("fs", () => ({ existsSync: (path: string) => existsMock(path) }));
 
 // GCS_BUCKET tanımsız (test ortamı) → yerel disk branch'i doğrulanır.
 import { saveStepFile, readStepFile, deleteStepFile, usingGcs } from "./step-files";

--- a/src/lib/storage/step-files.ts
+++ b/src/lib/storage/step-files.ts
@@ -15,7 +15,10 @@ import { existsSync } from "fs";
 import path from "path";
 import type { Bucket } from "@google-cloud/storage";
 
-const GCS_BUCKET = process.env.GCS_BUCKET;
+function getGcsBucketName(): string | undefined {
+  return process.env.GCS_BUCKET;
+}
+
 // Bucket içinde adım dosyaları için klasör öneki.
 const GCS_PREFIX = "steps/";
 
@@ -27,12 +30,16 @@ const UPLOAD_DIR = path.join(process.cwd(), "uploads", "steps");
 // Prod'da tanımlanmaz → gerçek GCS'e ADC ile bağlanılır.
 let bucketPromise: Promise<Bucket> | null = null;
 async function getBucket(): Promise<Bucket> {
+  const bucketName = getGcsBucketName();
+  if (!bucketName) {
+    throw new Error("GCS_BUCKET is not configured.");
+  }
   if (!bucketPromise) {
     bucketPromise = import("@google-cloud/storage").then(({ Storage }) => {
       const opts = process.env.GCS_API_ENDPOINT
         ? { apiEndpoint: process.env.GCS_API_ENDPOINT, projectId: process.env.GOOGLE_CLOUD_PROJECT || "local" }
         : {};
-      return new Storage(opts).bucket(GCS_BUCKET as string);
+      return new Storage(opts).bucket(bucketName);
     });
   }
   return bucketPromise;
@@ -40,7 +47,7 @@ async function getBucket(): Promise<Bucket> {
 
 /** Depolama backend'i GCS mi (true) yoksa yerel disk mi (false)? */
 export function usingGcs(): boolean {
-  return Boolean(GCS_BUCKET);
+  return Boolean(getGcsBucketName());
 }
 
 /** Dosyayı kaydeder (GCS veya yerel disk). */
@@ -49,7 +56,7 @@ export async function saveStepFile(
   buffer: Buffer,
   mimeType: string,
 ): Promise<void> {
-  if (GCS_BUCKET) {
+  if (usingGcs()) {
     const bucket = await getBucket();
     await bucket.file(GCS_PREFIX + storedName).save(buffer, {
       resumable: false,
@@ -63,7 +70,7 @@ export async function saveStepFile(
 
 /** Dosyayı okur; yoksa null döner (404'e çevirmek çağıranın işi). */
 export async function readStepFile(storedName: string): Promise<Buffer | null> {
-  if (GCS_BUCKET) {
+  if (usingGcs()) {
     const bucket = await getBucket();
     try {
       const [buf] = await bucket.file(GCS_PREFIX + storedName).download();
@@ -81,7 +88,7 @@ export async function readStepFile(storedName: string): Promise<Buffer | null> {
 
 /** Dosyayı siler (yoksa sessizce geçer). */
 export async function deleteStepFile(storedName: string): Promise<void> {
-  if (GCS_BUCKET) {
+  if (usingGcs()) {
     const bucket = await getBucket();
     await bucket.file(GCS_PREFIX + storedName).delete({ ignoreNotFound: true });
     return;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,6 @@ export default defineConfig({
     // başına `// @vitest-environment jsdom` docblock'u ile jsdom kullanır (#123).
     environment: "node",
     globals: true,
-    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    include: ["src/**/*.{test,spec}.{ts,tsx}", "scripts/**/*.{test,spec}.{ts,tsx}"],
   },
 });


### PR DESCRIPTION
## Kapsam (#201'in bir ALT KÜMESİ)

⚠️ **Bu PR #201'i KAPATMAZ.** Kapatma ifadesi, dar kapsamlı alt-issue **#215**'e bağlandı; P0 takip issue'su **#201 açık kalır**.

### Bu PR'da biten işler (= #215)
- **§2 Upload orphan / atomiklik** (best-effort compensate):
  - `saveStepFile` sonrası `prisma.stepFile.create` fail ederse storage'daki dosya temizlenir.
  - **Delete path tutarlılığı**: önce DB kaydı silinir, sonra storage best-effort.
  - **Test**: create throw → storage temizlenir.
- **GCS branch birim testleri** (`step-files.gcs.test.ts`) — save/read/delete mock'lu doğrulanır.
- **Migration guard testleri** (`scripts/check-migrations.test.ts`) + vitest include'a `scripts/**`.
- `GCS_BUCKET` artık **çağrı anında** okunuyor (modül yüklenirken değil) → runtime env doğru çalışır.

### #201'de AÇIK KALAN (bu PR'da YOK)
§1 operasyon (GCS bucket oluşturma, servis hesabı yetkisi, Out Plane `GCS_BUCKET`, prod smoke), §3 expand/contract cutover kararı, §4c mentorId mock temizliği, §5 M:N UX artıkları.

## Review düzeltmeleri (bu push)
- ✅ **Şemsiye issue artık kapatılmıyor** — kapatma ifadesi #215'e yönlendirildi, **`Refs #201`** korunuyor; başlık "alt kümesi" olarak netleştirildi.
- ✅ **GCS test env izolasyonu**: modül seviyesindeki `process.env.GCS_BUCKET` kaldırıldı; `beforeAll`/`afterAll` ile set/restore → aynı worker'daki yerel-disk testlerinin GCS yoluna kayma (flaky CI) riski giderildi.
- ✅ **logger + metrik**: upload orphan cleanup ve delete hata yollarında `console.error` yerine `logger.error` + `incrementCounter` (`storage.orphan_cleanup.success/failure`, `storage.delete.failure`).
- ✅ PR body'de biten/açık kalan #201 satırları net listelendi.

## Test
448 test / 74 dosya geçti · `tsc` (prod) temiz · lint temiz.

Closes #215
Refs #201