### PR TITLE
feat: acilis sayfasi Turkiye haritasi ve animasyonu

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -130,6 +130,102 @@ body {
   color-scheme: light;
 }
 
+/*
+  Açılış sayfası — harita ve hareket.
+  Proje CSS module kullanmadığı için (glass-panel, premium-card gibi) özel
+  sınıflar burada yaşıyor. Tokenlar yukarıdaki .landing bloğundan geliyor.
+*/
+
+/* --- iller --- */
+.landing-prov {
+  fill: var(--landing-map-off);
+  stroke: var(--landing-map-seam);
+  stroke-width: 0.7;
+  stroke-linejoin: round;
+  opacity: 0;
+  transition:
+    fill 0.55s var(--landing-ease-out),
+    opacity 0.5s ease;
+}
+.landing-prov[data-in="true"] { opacity: 1; }
+.landing-prov[data-lit="true"] { fill: var(--landing-wave); }
+.landing-prov[data-seed="true"] { fill: var(--landing-navy); }
+.landing-prov[data-hover="true"] { fill: var(--landing-teal); }
+
+/* --- şehir işaretleri --- */
+.landing-pin {
+  position: absolute;
+  width: 0;
+  height: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+.landing-pin[data-on="true"] {
+  animation: landing-pin-in 0.45s cubic-bezier(0.2, 0.9, 0.25, 1) forwards;
+}
+@keyframes landing-pin-in {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: none; }
+}
+.landing-pin-core {
+  position: absolute;
+  left: -3.5px;
+  top: -3.5px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 0 0 2px var(--landing-navy);
+}
+.landing-pin[data-on="true"] .landing-pin-core::after {
+  content: "";
+  position: absolute;
+  inset: -3px;
+  border-radius: 50%;
+  border: 1.5px solid var(--landing-teal);
+  animation: landing-ring 1.4s cubic-bezier(0.16, 0.8, 0.3, 1) 1 forwards;
+}
+@keyframes landing-ring {
+  from { transform: scale(0.5); opacity: 0.85; }
+  to { transform: scale(4); opacity: 0; }
+}
+
+/* --- açılış sırası --- */
+@keyframes landing-rise {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: none; }
+}
+@keyframes landing-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.landing-rise {
+  opacity: 0;
+  animation: landing-rise 0.5s var(--landing-ease-out) forwards;
+}
+
+/* --- kaydırınca beliren bölümler --- */
+.landing-reveal {
+  opacity: 0;
+  transform: translateY(12px);
+  transition:
+    opacity 0.5s var(--landing-ease-out),
+    transform 0.5s var(--landing-ease-out);
+}
+.landing-reveal[data-shown="true"] {
+  opacity: 1;
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  /* daha az ve daha yumuşak — sıfır değil */
+  .landing-rise { animation: landing-fade 0.3s ease forwards; }
+  .landing-reveal { transform: none; transition: opacity 0.3s ease; }
+  .landing-prov { transition-duration: 0.001ms; }
+  .landing-pin[data-on="true"] { animation-duration: 0.001ms; }
+  .landing-pin[data-on="true"] .landing-pin-core::after { animation: none; }
+}
+
 /* Custom premium subtle card and glow utilities */
 .glass-panel {
   background: rgba(255, 255, 255, 0.85);

--- a/src/features/landing/ui/TurkeyMap.test.tsx
+++ b/src/features/landing/ui/TurkeyMap.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, act, cleanup } from "@testing-library/react";
+import { TurkeyMap } from "./TurkeyMap";
+import { PROVINCES, SEED_PROVINCES } from "../data/tr-provinces";
+
+/**
+ * IntersectionObserver ve matchMedia jsdom'da yok; ikisini de kontrol
+ * edilebilir şekilde sahteliyoruz. IO gözlemlenen öğeyi ANINDA kesişiyor
+ * sayıyor — böylece animasyon render sonrası başlıyor.
+ */
+let azHareket = false;
+
+function ioKur(anindaKesis = true) {
+  class SahteIO {
+    constructor(private cb: IntersectionObserverCallback) {}
+    observe(el: Element) {
+      if (anindaKesis) {
+        this.cb(
+          [{ isIntersecting: true, target: el } as IntersectionObserverEntry],
+          this as unknown as IntersectionObserver,
+        );
+      }
+    }
+    disconnect() {}
+    unobserve() {}
+    takeRecords() {
+      return [];
+    }
+    root = null;
+    rootMargin = "";
+    thresholds = [];
+  }
+  vi.stubGlobal("IntersectionObserver", SahteIO);
+}
+
+beforeEach(() => {
+  azHareket = false;
+  vi.useFakeTimers();
+  ioKur();
+  vi.stubGlobal(
+    "matchMedia",
+    (q: string) =>
+      ({
+        matches: q.includes("reduced-motion") ? azHareket : false,
+        media: q,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        onchange: null,
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList,
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+const ilerle = (ms: number) => act(() => void vi.advanceTimersByTime(ms));
+const yanan = () =>
+  document.querySelectorAll('[data-lit="true"]').length;
+const belirenPin = () =>
+  document.querySelectorAll('.landing-pin[data-on="true"]').length;
+
+describe("TurkeyMap — render", () => {
+  it("81 ilin tamamını çizer", () => {
+    render(<TurkeyMap />);
+    expect(document.querySelectorAll(".landing-prov")).toHaveLength(81);
+  });
+
+  it("her il erişilebilir bir başlık taşır", () => {
+    render(<TurkeyMap />);
+    const basliklar = [...document.querySelectorAll(".landing-prov title")].map(
+      (t) => t.textContent,
+    );
+    expect(basliklar).toHaveLength(81);
+    expect(basliklar).toContain("Ankara");
+    expect(basliklar).toContain("Diyarbakır");
+  });
+
+  it("haritanın kendisi ekran okuyucuya tanımlıdır", () => {
+    render(<TurkeyMap />);
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("Türkiye haritası"),
+    );
+  });
+
+  it("seed illeri için pin oluşturur", () => {
+    render(<TurkeyMap />);
+    expect(document.querySelectorAll(".landing-pin")).toHaveLength(
+      SEED_PROVINCES.length,
+    );
+  });
+});
+
+describe("TurkeyMap — animasyon akışı", () => {
+  it("başlangıçta hiçbir il boyanmamıştır", () => {
+    render(<TurkeyMap />);
+    expect(yanan()).toBe(0);
+    expect(screen.getByText("00")).toBeInTheDocument();
+  });
+
+  it("ilk yanan il Ankara'dır", () => {
+    render(<TurkeyMap />);
+    ilerle(1600); // T_SEED0 = 1500
+    const ilk = document.querySelector('[data-lit="true"]');
+    expect(ilk?.getAttribute("data-il")).toBe("Ankara");
+  });
+
+  it("seed iller sırayla yanar, dalgadan önce biter", () => {
+    render(<TurkeyMap />);
+    ilerle(1500 + 360 * SEED_PROVINCES.length);
+    expect(yanan()).toBe(SEED_PROVINCES.length);
+    expect(belirenPin()).toBe(SEED_PROVINCES.length);
+  });
+
+  it("dalga tamamlanınca 81 ilin hepsi boyanır", () => {
+    render(<TurkeyMap />);
+    ilerle(30_000);
+    expect(yanan()).toBe(81);
+    expect(screen.getByText("81")).toBeInTheDocument();
+  });
+
+  it("sayaç gerçekten boyanan il sayısını gösterir", () => {
+    render(<TurkeyMap />);
+    ilerle(1500 + 360 * 4);
+    const dom = Number(
+      screen.getByText(/^\d{2}$/).textContent,
+    );
+    expect(dom).toBe(yanan());
+  });
+});
+
+describe("TurkeyMap — tekrar oynat", () => {
+  it("sayacı ve boyalı illeri sıfırlar", async () => {
+    render(<TurkeyMap />);
+    ilerle(30_000);
+    expect(yanan()).toBe(81);
+
+    act(() => {
+      screen.getByRole("button", { name: /tekrar oynat/i }).click();
+    });
+    expect(yanan()).toBe(0);
+    expect(screen.getByText("00")).toBeInTheDocument();
+  });
+
+  it("üst üste basmak zamanlayıcıları çakıştırmaz", () => {
+    render(<TurkeyMap />);
+    const btn = screen.getByRole("button", { name: /tekrar oynat/i });
+
+    ilerle(3000);
+    act(() => btn.click());
+    ilerle(500);
+    act(() => btn.click());
+    ilerle(500);
+    act(() => btn.click());
+
+    // eski turlardan artakalan zamanlayıcı olsaydı sayaç DOM ile tutmazdı
+    ilerle(30_000);
+    expect(yanan()).toBe(81);
+    expect(screen.getByText("81")).toBeInTheDocument();
+  });
+});
+
+describe("TurkeyMap — hareket azaltma", () => {
+  it("bitmiş haritayı gözlemciyi beklemeden gösterir", () => {
+    azHareket = true;
+    ioKur(false); // IO hiç tetiklenmesin
+    render(<TurkeyMap />);
+
+    // hiç zaman ilerletmeden bitmiş olmalı
+    expect(yanan()).toBe(81);
+    expect(belirenPin()).toBe(SEED_PROVINCES.length);
+    expect(screen.getByText("81")).toBeInTheDocument();
+  });
+});
+
+describe("TurkeyMap — veri tutarlılığı", () => {
+  it("çizilen il adları veri kaynağıyla birebir aynıdır", () => {
+    render(<TurkeyMap />);
+    const cizilen = [...document.querySelectorAll(".landing-prov")]
+      .map((p) => p.getAttribute("data-il"))
+      .sort();
+    const beklenen = PROVINCES.map((p) => p.name).sort();
+    expect(cizilen).toEqual(beklenen);
+  });
+});

--- a/src/features/landing/ui/TurkeyMap.tsx
+++ b/src/features/landing/ui/TurkeyMap.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  PROVINCES,
+  SEED_PROVINCES,
+  FLIPPED_LABELS,
+  MAP_VIEWBOX,
+} from "../data/tr-provinces";
+
+/*
+  Animasyon akışı:
+    1) iller Ankara'dan dışa doğru belirir
+    2) 10 seed il tek tek yanar (pin + halka)
+    3) kalan iller dalga halinde maviye döner
+    4) sayaç gerçekten boyanan il sayısını gösterir — 81'de biter
+
+  Zamanlayıcılar setTimeout ile kuruluyor; hepsi tek bir ref'te toplanıp
+  temizleniyor, aksi halde "tekrar oynat"a üst üste basınca eski
+  zamanlayıcılar yeni turu bozardı.
+*/
+
+const T_IN = 200; // iller belirmeye başlar
+const IN_STEP = 11; // il başına gecikme
+const T_SEED0 = 1500; // Ankara yanar
+const SEED_GAP = 360;
+const WAVE_STEP = 34; // dalgadaki iller arası gecikme
+
+type Durum = {
+  belirdi: Set<string>;
+  yandi: Set<string>;
+  pin: Set<string>;
+};
+
+const BOS: Durum = { belirdi: new Set(), yandi: new Set(), pin: new Set() };
+
+export function TurkeyMap() {
+  const [durum, setDurum] = useState<Durum>(BOS);
+  const [uzerinde, setUzerinde] = useState<string | null>(null);
+  const zamanlayicilar = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const kutu = useRef<HTMLDivElement>(null);
+  const calisiyor = useRef(false);
+
+  const ankara = useMemo(
+    () => PROVINCES.find((p) => p.name === "Ankara"),
+    [],
+  );
+
+  /** Ankara'ya uzaklığa göre sıralı il adları */
+  const uzakliktanSirali = useMemo(() => {
+    if (!ankara) return PROVINCES.map((p) => p.name);
+    return [...PROVINCES]
+      .sort((a, b) => {
+        const da = Math.hypot(a.cx - ankara.cx, a.cy - ankara.cy);
+        const db = Math.hypot(b.cx - ankara.cx, b.cy - ankara.cy);
+        return da - db;
+      })
+      .map((p) => p.name);
+  }, [ankara]);
+
+  /** Seed olmayan iller — dalga bunları sırayla boyar */
+  const dalgaSirasi = useMemo(
+    () =>
+      uzakliktanSirali.filter(
+        (ad) => !(SEED_PROVINCES as readonly string[]).includes(ad),
+      ),
+    [uzakliktanSirali],
+  );
+
+  const temizle = useCallback(() => {
+    zamanlayicilar.current.forEach(clearTimeout);
+    zamanlayicilar.current = [];
+  }, []);
+
+  const sonDurum = useCallback(() => {
+    setDurum({
+      belirdi: new Set(PROVINCES.map((p) => p.name)),
+      yandi: new Set(PROVINCES.map((p) => p.name)),
+      pin: new Set(SEED_PROVINCES),
+    });
+  }, []);
+
+  const oynat = useCallback(() => {
+    temizle();
+    setDurum(BOS);
+
+    const azHareket =
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    if (azHareket) {
+      // hareket istemeyen kullanıcı bitmiş haritayı hemen görür
+      sonDurum();
+      return;
+    }
+
+    calisiyor.current = true;
+    const ekle = (ms: number, fn: () => void) => {
+      zamanlayicilar.current.push(setTimeout(fn, ms));
+    };
+
+    // 1) beliriş
+    uzakliktanSirali.forEach((ad, i) => {
+      ekle(T_IN + i * IN_STEP, () =>
+        setDurum((d) => ({ ...d, belirdi: new Set(d.belirdi).add(ad) })),
+      );
+    });
+
+    // 2) seed iller
+    SEED_PROVINCES.forEach((ad, i) => {
+      ekle(T_SEED0 + i * SEED_GAP, () =>
+        setDurum((d) => ({
+          ...d,
+          yandi: new Set(d.yandi).add(ad),
+          pin: new Set(d.pin).add(ad),
+        })),
+      );
+    });
+
+    // 3) dalga
+    const dalgaBasi = T_SEED0 + SEED_GAP * SEED_PROVINCES.length + 320;
+    dalgaSirasi.forEach((ad, i) => {
+      ekle(dalgaBasi + i * WAVE_STEP, () =>
+        setDurum((d) => ({ ...d, yandi: new Set(d.yandi).add(ad) })),
+      );
+    });
+
+    ekle(dalgaBasi + dalgaSirasi.length * WAVE_STEP + 400, () => {
+      calisiyor.current = false;
+    });
+  }, [temizle, sonDurum, uzakliktanSirali, dalgaSirasi]);
+
+  // haritayı ekrana girince başlat
+  useEffect(() => {
+    const el = kutu.current;
+    if (!el) return;
+
+    const azHareket = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    if (azHareket) {
+      // gözlemciyi beklemeden bitmiş hali göster
+      sonDurum();
+      return;
+    }
+
+    const io = new IntersectionObserver(
+      (girisler) => {
+        for (const g of girisler) {
+          if (g.isIntersecting && !calisiyor.current) {
+            oynat();
+            io.disconnect();
+          }
+        }
+      },
+      { threshold: 0.25 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [oynat, sonDurum]);
+
+  // ayrılırken zamanlayıcıları bırakma
+  useEffect(() => temizle, [temizle]);
+
+  // dar ekranda harita yatay kayar — ülkenin ortasından başlat
+  useEffect(() => {
+    const el = kutu.current;
+    if (!el) return;
+    const ortala = () => {
+      const tasan = el.scrollWidth - el.clientWidth;
+      if (tasan > 0) el.scrollLeft = tasan / 2;
+    };
+    ortala();
+    window.addEventListener("resize", ortala);
+    return () => window.removeEventListener("resize", ortala);
+  }, []);
+
+  const sayac = durum.yandi.size;
+
+  return (
+    <div className="relative overflow-hidden rounded-[10px] border border-[var(--landing-line-soft)] bg-[var(--landing-stage)] p-[clamp(10px,1.5vw,16px)]">
+      <div
+        ref={kutu}
+        className="w-full overflow-x-auto [scrollbar-width:thin]"
+        data-testid="harita-kutusu"
+      >
+        <div className="relative mx-auto w-full max-[680px]:min-w-[620px] min-[681px]:max-w-[max(560px,calc((100vh-486px)*2.976))]">
+          <svg
+            viewBox={`0 0 ${MAP_VIEWBOX.width} ${MAP_VIEWBOX.height}`}
+            preserveAspectRatio="xMidYMid meet"
+            className="block h-auto w-full overflow-visible"
+            role="img"
+            aria-label="Türkiye haritası: iller tek tek maviye boyanarak 81 ilin tamamı kaplanıyor."
+          >
+            <g>
+              {PROVINCES.map((il) => (
+                <path
+                  key={il.name}
+                  d={il.d}
+                  className="landing-prov"
+                  data-in={durum.belirdi.has(il.name)}
+                  data-lit={durum.yandi.has(il.name)}
+                  data-seed={durum.pin.has(il.name)}
+                  data-hover={uzerinde === il.name}
+                  data-il={il.name}
+                  onPointerEnter={() => setUzerinde(il.name)}
+                  onPointerLeave={() => setUzerinde(null)}
+                >
+                  <title>{il.name}</title>
+                </path>
+              ))}
+            </g>
+          </svg>
+
+          {SEED_PROVINCES.map((ad) => {
+            const il = PROVINCES.find((p) => p.name === ad);
+            if (!il) return null;
+            const sola = FLIPPED_LABELS.has(ad);
+            return (
+              <div
+                key={ad}
+                className="landing-pin"
+                data-on={durum.pin.has(ad)}
+                style={{
+                  left: `${(il.cx / MAP_VIEWBOX.width) * 100}%`,
+                  top: `${(il.cy / MAP_VIEWBOX.height) * 100}%`,
+                }}
+              >
+                <span className="landing-pin-core" />
+                <span
+                  className={`absolute top-1/2 -translate-y-1/2 whitespace-nowrap rounded-[4px] bg-[color-mix(in_srgb,var(--landing-stage)_80%,transparent)] px-1 py-px font-mono text-[clamp(8.5px,0.95vw,10.5px)] uppercase tracking-[0.05em] text-[var(--landing-ink)] max-[680px]:hidden ${
+                    sola ? "right-[10px]" : "left-[10px]"
+                  }`}
+                >
+                  {ad}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div
+        className="absolute bottom-[clamp(12px,2.2vw,22px)] left-[clamp(12px,2.2vw,22px)] flex items-baseline gap-2 rounded-lg bg-[color-mix(in_srgb,var(--landing-stage)_84%,transparent)] px-3 pb-2.5 pt-2 font-mono tabular-nums backdrop-blur-[3px]"
+        aria-hidden="true"
+      >
+        <span className="text-[clamp(28px,4.6vw,44px)] font-bold leading-none tracking-[-0.04em] text-[var(--landing-navy)]">
+          {String(sayac).padStart(2, "0")}
+        </span>
+        <span className="text-xs uppercase tracking-[0.14em] text-[var(--landing-muted)]">
+          / 81 il
+        </span>
+      </div>
+
+      <button
+        type="button"
+        onClick={oynat}
+        className="absolute bottom-[clamp(12px,2.2vw,22px)] right-[clamp(12px,2.2vw,22px)] cursor-pointer rounded-md border border-[var(--landing-line)] bg-[color-mix(in_srgb,var(--landing-paper)_82%,transparent)] px-[11px] py-[7px] font-mono text-[11px] uppercase tracking-[0.1em] text-[var(--landing-muted)] transition-colors hover:border-[var(--landing-muted)] hover:text-[var(--landing-ink)]"
+      >
+        Tekrar oynat
+      </button>
+
+      <p className="sr-only" aria-live="polite">
+        {sayac} il boyandı
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
> Base: `feat/issue-219-landing-foundation`. #219 merge edilince base `develop`'a cekilecek.

81 il tek tek beliriyor, 10 sehir sirayla yaniyor, kalan iller Ankara'dan disa dogru dalga halinde maviye donuyor.

## Kararlar
- **Yeni bagimlilik yok.** Saf CSS + IntersectionObserver. Tek sayfa icin framer-motion ~30KB ve kalici bakim yuku demekti.
- Durum `data-*` nitelikleriyle tasiniyor; CSS sinif kurgusu yerine React state dogrudan niteliklere yaziliyor.
- Zamanlayicilar tek ref'te toplanip temizleniyor.
- `prefers-reduced-motion` acikken bitmis harita **gozlemci beklenmeden** gosteriliyor.

## Testler
+13 test (503 → 516): render, animasyon sirasi, sayac-DOM tutarliligi, tekrar oynat, cift tiklama, hareket azaltma dali, veri kaynagi ile ad esitligi.

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)