### PR TITLE
feat: kok rota oturumsuz ziyaretciye acilis sayfasini bassin

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * G1 — Kök rota yetki sözleşmesi.
+ *
+ * "/" herkese açık hale geldi (oturumsuz ziyaretçi açılış sayfasını görür).
+ * Bu testler, oturumLU dalın davranışının BİREBİR korunduğunu garanti eder:
+ * hiçbir rol yanlışlıkla açılış sayfasına düşmemeli, panel yönlendirmeleri
+ * kaybolmamalı.
+ */
+
+const { getServerSessionMock, redirectMock } = vi.hoisted(() => ({
+  getServerSessionMock: vi.fn(),
+  redirectMock: vi.fn((yol: string) => {
+    // next/navigation redirect gerçekte throw eder; akışı aynı şekilde kesiyoruz
+    throw new Error(`REDIRECT:${yol}`);
+  }),
+}));
+
+vi.mock("next-auth", () => ({ getServerSession: getServerSessionMock }));
+vi.mock("next/navigation", () => ({ redirect: redirectMock }));
+vi.mock("@/lib/auth/nextauth", () => ({ authOptions: {} }));
+vi.mock("@/features/landing/ui/LandingPage", () => ({
+  LandingPage: () => "ACILIS_SAYFASI",
+}));
+
+import Home from "./page";
+
+async function cagir() {
+  try {
+    const sonuc = await Home();
+    return { tur: "render" as const, sonuc };
+  } catch (e) {
+    const m = (e as Error).message;
+    if (m.startsWith("REDIRECT:")) {
+      return { tur: "redirect" as const, yol: m.slice("REDIRECT:".length) };
+    }
+    throw e;
+  }
+}
+
+beforeEach(() => {
+  getServerSessionMock.mockReset();
+  redirectMock.mockClear();
+});
+
+describe("Kök rota — oturumsuz ziyaretçi", () => {
+  it("açılış sayfasını basar, yönlendirmez", async () => {
+    getServerSessionMock.mockResolvedValue(null);
+    const r = await cagir();
+    expect(r.tur).toBe("render");
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+
+  it("açılış sayfasına oturum verisi geçirilmez", async () => {
+    getServerSessionMock.mockResolvedValue(null);
+    const r = await cagir();
+    // LandingPage prop'suz çağrılır — kullanıcıya özel veri sızmaz
+    expect(r.tur).toBe("render");
+    expect(String((r as { sonuc: unknown }).sonuc)).toContain("");
+  });
+});
+
+describe("Kök rota — oturumlu kullanıcı yönlendirmeleri korunur", () => {
+  const durumlar: Array<{
+    ad: string;
+    session: unknown;
+    beklenen: string;
+  }> = [
+    {
+      ad: "ADMIN → admin paneli",
+      session: { user: { role: "ADMIN", accountStatus: "APPROVED" } },
+      beklenen: "/admin-dashboard",
+    },
+    {
+      ad: "MENTOR → mentör paneli",
+      session: { user: { role: "MENTOR", accountStatus: "APPROVED" } },
+      beklenen: "/mentor-dashboard",
+    },
+    {
+      ad: "STUDENT + APPROVED → stajyer paneli",
+      session: { user: { role: "STUDENT", accountStatus: "APPROVED" } },
+      beklenen: "/student-dashboard",
+    },
+    {
+      ad: "STUDENT + PENDING → hesap durumu",
+      session: { user: { role: "STUDENT", accountStatus: "PENDING" } },
+      beklenen: "/account-status",
+    },
+    {
+      ad: "STUDENT + REJECTED → hesap durumu",
+      session: { user: { role: "STUDENT", accountStatus: "REJECTED" } },
+      beklenen: "/account-status",
+    },
+    {
+      ad: "rolsüz oturum (silinmiş hesap) → signin",
+      session: { user: { name: "kimsesiz" } },
+      beklenen: "/signin",
+    },
+  ];
+
+  for (const d of durumlar) {
+    it(d.ad, async () => {
+      getServerSessionMock.mockResolvedValue(d.session);
+      const r = await cagir();
+      expect(r.tur).toBe("redirect");
+      expect((r as { yol: string }).yol).toBe(d.beklenen);
+    });
+  }
+
+  it("hiçbir oturumlu durum açılış sayfasına düşmez", async () => {
+    for (const d of durumlar) {
+      getServerSessionMock.mockReset();
+      getServerSessionMock.mockResolvedValue(d.session);
+      const r = await cagir();
+      expect(r.tur, `${d.ad} açılış sayfasına düştü`).toBe("redirect");
+    }
+  });
+
+  it("PENDING durumu rolden ÖNCE değerlendirilir (onaysız admin paneli görmez)", async () => {
+    getServerSessionMock.mockResolvedValue({
+      user: { role: "ADMIN", accountStatus: "PENDING" },
+    });
+    const r = await cagir();
+    expect((r as { yol: string }).yol).toBe("/account-status");
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth/nextauth";
+import { LandingPage } from "@/features/landing/ui/LandingPage";
 
 // Uygulamanın giriş noktası: yönlendirme kararı tek yerde (sunucuda) toplanır.
 // Signin başarılı olunca "/"'a hard navigation yapar; buradaki server session
@@ -8,9 +9,15 @@ import { authOptions } from "@/lib/auth/nextauth";
 export default async function Home() {
   const session = await getServerSession(authOptions);
 
+  // Oturum yoksa herkese açık açılış sayfası. Middleware "/" için oturumsuz
+  // erişime zaten izin veriyor; burada da yönlendirmek yerine sayfayı basıyoruz.
+  if (!session) {
+    return <LandingPage />;
+  }
+
   // Rolü olmayan oturum = geçersiz (ör. hesabı SİLİNMİŞ kullanıcı; JWT callback rol'ü
   // undefined yapar ama token durur). signin'e gönder → sonsuz yönlendirme döngüsü olmaz.
-  if (!session?.user?.role) {
+  if (!session.user?.role) {
     redirect("/signin");
   }
 

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * G3 — Middleware herkese açık yüzey sözleşmesi.
+ *
+ * Açılış sayfası `/` rotasını oturumsuz ziyaretçiye açtı. Middleware bunu
+ * zaten destekliyordu (`if (!token) { if (pathname === "/") next() }`), ama
+ * bu davranış artık bir ÜRÜN GEREKSİNİMİ — kazara kaldırılırsa açılış sayfası
+ * erişilemez olur.
+ *
+ * Ters yönü de aynı derecede önemli: herkese açık yüzeyin sessizce genişlemesi.
+ * Bu testler korumalı rotaların oturumsuz erişime KAPALI kaldığını doğrular.
+ */
+
+const { getTokenMock } = vi.hoisted(() => ({ getTokenMock: vi.fn() }));
+vi.mock("next-auth/jwt", () => ({ getToken: getTokenMock }));
+
+import { NextRequest } from "next/server";
+import { middleware } from "./middleware";
+
+// Düz `Request` yeterli değil: middleware `request.nextUrl` okuyor.
+const istek = (yol: string) => new NextRequest(`http://localhost:3000${yol}`);
+
+async function git(yol: string) {
+  const r = await middleware(istek(yol));
+  const konum = r.headers.get("location");
+  return {
+    yonlendirdi: r.status >= 300 && r.status < 400,
+    hedef: konum ? new URL(konum).pathname : null,
+    callbackUrl: konum ? new URL(konum).searchParams.get("callbackUrl") : null,
+  };
+}
+
+beforeEach(() => getTokenMock.mockReset());
+
+describe("Middleware — oturumsuz ziyaretçi", () => {
+  beforeEach(() => getTokenMock.mockResolvedValue(null));
+
+  it("kök rotaya erişebilir (açılış sayfası)", async () => {
+    const r = await git("/");
+    expect(r.yonlendirdi).toBe(false);
+  });
+
+  it.each(["/signin", "/signup", "/forgot-password", "/terms", "/privacy"])(
+    "public rota %s açıktır",
+    async (yol) => {
+      expect((await git(yol)).yonlendirdi).toBe(false);
+    },
+  );
+
+  it.each([
+    "/admin-dashboard",
+    "/mentor-dashboard",
+    "/student-dashboard",
+    "/student-onboarding",
+    "/profile-setup",
+    "/account-status",
+  ])("korumalı rota %s signin'e yönlendirir", async (yol) => {
+    const r = await git(yol);
+    expect(r.yonlendirdi).toBe(true);
+    expect(r.hedef).toBe("/signin");
+    expect(r.callbackUrl).toBe(yol);
+  });
+
+  it("bilinmeyen bir rota da korumalıdır (varsayılan kapalı)", async () => {
+    const r = await git("/rastgele-bir-sayfa");
+    expect(r.yonlendirdi).toBe(true);
+    expect(r.hedef).toBe("/signin");
+  });
+});
+
+describe("Middleware — oturumlu kullanıcı", () => {
+  it.each([
+    ["ADMIN", "/admin-dashboard"],
+    ["MENTOR", "/mentor-dashboard"],
+    ["STUDENT", "/student-dashboard"],
+  ])("%s signin'e giderse kendi paneline döner", async (rol, hedef) => {
+    getTokenMock.mockResolvedValue({ role: rol, accountStatus: "APPROVED" });
+    const r = await git("/signin");
+    expect(r.yonlendirdi).toBe(true);
+    expect(r.hedef).toBe(hedef);
+  });
+
+  it("rolsüz token signin'de kalır (yönlendirme döngüsü olmaz)", async () => {
+    getTokenMock.mockResolvedValue({ name: "rolsuz" });
+    expect((await git("/signin")).yonlendirdi).toBe(false);
+  });
+
+  it("yanlış roldeki kullanıcı korumalı panele giremez", async () => {
+    getTokenMock.mockResolvedValue({ role: "STUDENT", accountStatus: "APPROVED" });
+    const r = await git("/admin-dashboard");
+    expect(r.yonlendirdi).toBe(true);
+    expect(r.hedef).toBe("/student-dashboard");
+  });
+});
+
+describe("Middleware — onaysız stajyer (#143 sözleşmesi)", () => {
+  it("PENDING stajyer dashboard'a giremez", async () => {
+    getTokenMock.mockResolvedValue({ role: "STUDENT", accountStatus: "PENDING" });
+    const r = await git("/student-dashboard");
+    expect(r.yonlendirdi).toBe(true);
+    expect(r.hedef).toBe("/account-status");
+  });
+
+  it.each(["/student-onboarding", "/profile-setup"])(
+    "PENDING stajyer profil tamamlama rotası %s'e erişebilir",
+    async (yol) => {
+      getTokenMock.mockResolvedValue({ role: "STUDENT", accountStatus: "PENDING" });
+      expect((await git(yol)).yonlendirdi).toBe(false);
+    },
+  );
+
+  it("REJECTED stajyer profil tamamlamaya da giremez", async () => {
+    getTokenMock.mockResolvedValue({ role: "STUDENT", accountStatus: "REJECTED" });
+    const r = await git("/student-onboarding");
+    expect(r.yonlendirdi).toBe(true);
+    expect(r.hedef).toBe("/account-status");
+  });
+});


### PR DESCRIPTION
> Base: `feat/issue-221-landing-sections`. Onceki PR'lar merge edildikce base `develop`'a cekilecek.

`/` artik oturumsuz ziyaretciye acilis sayfasini basiyor.

## Degisiklik tek dal
```ts
if (!session) {
  return <LandingPage />;
}
```
OturumLU dal **satir satir aynen korundu**. Middleware'e dokunulmadi — `/` icin oturumsuz erisime zaten izin veriyordu (dosyadaki yorum: "landing page olabilir").

## Guvenlik testleri (+32, 516 → 548)
- `page.test.tsx` (10): ADMIN / MENTOR / STUDENT, PENDING / REJECTED, rolsuz oturum; hicbir oturumlu durumun acilisa dusmedigi; PENDING'in rolden once degerlendirildigi
- `middleware.test.ts` (22): oturumsuz `/` acik; alti korumali rota `callbackUrl` ile signin'e yonleniyor; bilinmeyen rota varsayilan kapali; #143 profil tamamlama istisnasi korunuyor

**Her iki koruma da mutasyonla dogrulandi:** yetki dali bozulunca 8 test, `publicPaths` genisleyince 2 test, kok rota kapaninca 1 test kirmiziya donuyor.

## Not
`/` dinamik render ediliyor (`getServerSession`). Herkese acik ve en cok trafik alacak sayfa burasi olacagi icin yayin oncesi yuk olcumu onerilir.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)