### PR TITLE
fix: sertifika PDF/yazdirma ve indirme ciktisi

### DIFF
--- a/src/components/certificate/CertificateModal.test.tsx
+++ b/src/components/certificate/CertificateModal.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
+import { CertificateModal } from "./CertificateModal";
+import type { CertificateData } from "@/features/certificate/server/certificate";
+
+vi.mock("sonner", () => ({
+  toast: { info: vi.fn(), error: vi.fn(), success: vi.fn() },
+}));
+
+/**
+ * #235 — sertifika yazdırma sözleşmesi.
+ *
+ * Hatanın üç ayrı kaynağı vardı ve her biri tek başına boş/bozuk çıktı
+ * üretebiliyordu. Bu testler üçünü de kilitliyor; biri geri alınırsa kırmızıya
+ * döner.
+ */
+
+const sertifika: CertificateData = {
+  id: "cert-1",
+  studentName: "Test Stajyer",
+  studentEmail: "stajyer@example.com",
+  mentorName: "Test Mentör",
+  mentorEmail: "mentor@example.com",
+  certificateNumber: "AIS-2026-0001",
+  completionGrade: "Üstün Başarı",
+  mentorNote: "Staj boyunca üstün başarı gösterdi.",
+  issuedAt: new Date("2026-01-01").toISOString(),
+  completedProjects: [
+    {
+      id: "p1",
+      title: "Test Projesi",
+      description: "Açıklama",
+      difficulty: "orta",
+      track: ["backend"],
+      completedStepsCount: 5,
+      totalStepsCount: 5,
+    },
+  ],
+  verificationUrl: "https://aisigner.com/verify-certificate/AIS-2026-0001",
+  isIssued: true,
+};
+
+/** Yazdırma akışında oluşturulan iframe (aria-hidden ile işaretli). */
+const yazdirmaCercevesi = () =>
+  document.querySelector<HTMLIFrameElement>('iframe[aria-hidden="true"]');
+
+let printSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  printSpy = vi.fn();
+  // jsdom iframe'lerinde print/fonts yok — kontrollü şekilde sağlıyoruz.
+  Object.defineProperty(HTMLIFrameElement.prototype, "contentWindow", {
+    configurable: true,
+    get() {
+      const doc = this.contentDocument;
+      return {
+        document: doc,
+        focus: vi.fn(),
+        print: printSpy,
+        addEventListener: (t: string, cb: EventListener, o?: AddEventListenerOptions) =>
+          doc?.defaultView?.addEventListener(t, cb, o),
+      };
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  // Yazdırma çerçeveleri React ağacının dışında, doğrudan body'ye ekleniyor;
+  // cleanup() onları sökmez. Kalanları temizlemezsek sonraki testler önceki
+  // testin çerçevesini görür.
+  document
+    .querySelectorAll('iframe[aria-hidden="true"]')
+    .forEach((f) => f.remove());
+  vi.restoreAllMocks();
+});
+
+function ac() {
+  render(
+    <CertificateModal certificate={sertifika} isOpen onClose={() => {}} />,
+  );
+}
+
+const yazdirmayaBas = async () => {
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /pdf \/ yazdır/i }));
+    // yazdir() async — mikrotask kuyrugunu bosalt ki zamanlayicilar kurulsun
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+describe("CertificateModal — yazdırma (#235)", () => {
+  it("yazdırma çerçevesi sıfır boyutlu DEĞİLDİR", async () => {
+    ac();
+    await yazdirmayaBas();
+
+    const f = yazdirmaCercevesi();
+    expect(f, "yazdırma çerçevesi oluşturulmalı").not.toBeNull();
+
+    // 0x0 iframe bazı tarayıcılarda layout almaz → boş sayfa yazdırılır.
+    expect(f!.style.width).not.toBe("0");
+    expect(f!.style.height).not.toBe("0");
+    expect(f!.style.width).toBe("210mm");
+    expect(f!.style.height).toBe("297mm");
+  });
+
+  it("çerçeve ekran dışına konumlanır (kullanıcıya görünmez)", async () => {
+    ac();
+    await yazdirmayaBas();
+
+    const f = yazdirmaCercevesi()!;
+    expect(f.style.position).toBe("fixed");
+    expect(parseInt(f.style.left, 10)).toBeLessThan(-1000);
+  });
+
+  it("sertifika içeriği çerçeveye yazılır", async () => {
+    ac();
+    await yazdirmayaBas();
+
+    const doc = yazdirmaCercevesi()!.contentDocument!;
+    expect(doc.getElementById("certificate-print-area")).not.toBeNull();
+    expect(doc.body.textContent).toContain("Test Stajyer");
+  });
+
+  it("çerçeve hemen kaldırılmaz — yazdırma bitmeden DOM'da kalır", async () => {
+    vi.useFakeTimers();
+    ac();
+    await yazdirmayaBas();
+
+    act(() => void vi.advanceTimersByTime(5_000));
+    // eski davranış 1000ms sonra siliyordu; diyalog açıkken çıktı bozuluyordu
+    expect(yazdirmaCercevesi(), "5sn sonra hâlâ durmalı").not.toBeNull();
+
+    vi.useRealTimers();
+  });
+
+  it("uzun süre sonra güvenlik ağı çerçeveyi temizler", async () => {
+    vi.useFakeTimers();
+    ac();
+    await yazdirmayaBas();
+
+    act(() => void vi.advanceTimersByTime(130_000));
+    expect(yazdirmaCercevesi(), "güvenlik ağı devreye girmeli").toBeNull();
+
+    vi.useRealTimers();
+  });
+  it("yazı tipleri gelmese bile yazdırma engellenmez (sınırlı bekleme)", async () => {
+    vi.useFakeTimers();
+    ac();
+    await yazdirmayaBas();
+
+    // fonts.ready hiç çözülmezse bile üst sınır dolunca print() çağrılmalı
+    await act(async () => {
+      vi.advanceTimersByTime(2_500);
+      await Promise.resolve();
+    });
+
+    expect(printSpy, "print() çağrılmalı").toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});

--- a/src/components/certificate/CertificateModal.test.tsx
+++ b/src/components/certificate/CertificateModal.test.tsx
@@ -162,3 +162,77 @@ describe("CertificateModal — yazdırma (#235)", () => {
     vi.useRealTimers();
   });
 });
+
+describe("CertificateModal — indirme (#235)", () => {
+  /*
+    jsdom'da varsayılan olarak hiç stil sayfası yok; o yüzden test ortamına
+    hem bir <link> hem de kuralı olan bir <style> enjekte ediyoruz. Aksi
+    halde eski (hatalı) kod da boş çıktı üretir ve test YALANCI YEŞİL olur.
+  */
+  const ISARET = "sertifika-stil-isareti";
+
+  beforeEach(() => {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = "/_next/static/css/app/layout.css";
+    document.head.appendChild(link);
+
+    const stil = document.createElement("style");
+    stil.textContent = `.${ISARET} { color: rgb(1, 2, 3); }`;
+    document.head.appendChild(stil);
+  });
+
+  afterEach(() => {
+    document.head.querySelectorAll("link[rel='stylesheet'], style").forEach((n) => n.remove());
+  });
+
+  /*
+    Buton adı TAM eşleşmeyle aranıyor: JS regex'inin `i` bayrağı Türkçe
+    "İ" (U+0130) harfini "i"ye katlamaz, bu yüzden /indir/i eşleşmez.
+  */
+  /** İndirme akışında üretilen HTML'i Blob'dan yakalar. */
+  async function indirilenHtml(): Promise<string> {
+    let yakalanan = "";
+    const gercekBlob = globalThis.Blob;
+    class YakalayanBlob extends gercekBlob {
+      constructor(parcalar: BlobPart[], secenekler?: BlobPropertyBag) {
+        yakalanan = String(parcalar[0] ?? "");
+        super(parcalar, secenekler);
+      }
+    }
+    vi.stubGlobal("Blob", YakalayanBlob);
+    vi.stubGlobal("URL", {
+      ...URL,
+      createObjectURL: () => "blob:test",
+      revokeObjectURL: () => {},
+    });
+
+    ac();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Sertifikayı İndir" }));
+      await Promise.resolve();
+    });
+    return yakalanan;
+  }
+
+  it("stil bağlantısı KOPYALANMAZ — dosya diskte açılınca çözülemez", async () => {
+    const html = await indirilenHtml();
+    // <link rel=stylesheet href="/_next/..."> indirilen dosyada file:/// olarak
+    // çözülür ve sertifika çıplak HTML görünür — hatanın kök nedeni buydu.
+    expect(html).not.toMatch(/<link[^>]*stylesheet/i);
+    expect(html).not.toContain("/_next/static/css");
+  });
+
+  it("stil KURALLARI dosyanın içine gömülür", async () => {
+    const html = await indirilenHtml();
+    expect(html).toMatch(/<style>/);
+    // sadece <style> etiketi değil, gerçek kural metni de içeride olmalı
+    expect(html).toContain(ISARET);
+  });
+
+  it("sertifika içeriği ve doğrulama numarası dosyada yer alır", async () => {
+    const html = await indirilenHtml();
+    expect(html).toContain("Test Stajyer");
+    expect(html).toContain("AIS-2026-0001");
+  });
+});

--- a/src/components/certificate/CertificateModal.tsx
+++ b/src/components/certificate/CertificateModal.tsx
@@ -27,6 +27,31 @@ type CertificateModalProps = {
   onSave?: (data: { mentorNote: string; completionGrade: string }) => Promise<void>;
 };
 
+/**
+ * #235: Sayfadaki tum stil kurallarini METIN olarak toplar.
+ *
+ * Neden `<link rel="stylesheet">` etiketini kopyalamiyoruz: indirilen dosya
+ * diske kaydedilip acildiginda `/_next/static/css/...` yolu `file:///_next/...`
+ * olarak cozulur, hicbir stil yuklenmez ve sertifika ciplak HTML olarak gorunur.
+ * Ayni sekilde yazdirma cercevesinde de ag beklemesi gerekmez.
+ *
+ * Ayni kaynakli stil sayfalarinin `cssRules` erisimi acik; farkli kaynakli
+ * olanlar (varsa) sessizce atlanir.
+ */
+function stilKurallariniTopla(): string {
+  let css = "";
+  for (const sayfa of Array.from(document.styleSheets)) {
+    try {
+      for (const kural of Array.from(sayfa.cssRules)) {
+        css += kural.cssText + "\n";
+      }
+    } catch {
+      // farkli kaynakli stil sayfasi — okunamaz, atla
+    }
+  }
+  return css;
+}
+
 const DEFAULT_NOTE_TEMPLATES = [
   "Staj programı boyunca gösterdiği üstün problem çözme yeteneği, disiplin ve teknik yetkinlik ile projelerini başarıyla tamamlamıştır. Kendisini tebrik eder, profesyonel kariyerinde başarılar dileriz.",
   "Modern yazılım mimarisi, yapay zeka entegrasyonu ve takım çalışmasında sergilediği teknik vizyon ile staj dönemini üstün başarıyla tamamlamıştır.",
@@ -81,10 +106,7 @@ export function CertificateModal({
       }
 
       // Ana sayfadaki tüm Tailwind ve font stillerini iframe'e kopyala
-      let stylesHtml = "";
-      document.querySelectorAll("style, link[rel='stylesheet']").forEach((node) => {
-        stylesHtml += node.outerHTML;
-      });
+      const stylesHtml = `<style>${stilKurallariniTopla()}</style>`;
 
       doc.open();
       doc.write(`
@@ -182,10 +204,7 @@ export function CertificateModal({
     }
 
     try {
-      let stylesHtml = "";
-      document.querySelectorAll("style, link[rel='stylesheet']").forEach((node) => {
-        stylesHtml += node.outerHTML;
-      });
+      const stylesHtml = `<style>${stilKurallariniTopla()}</style>`;
 
       const fullHtml = `<!DOCTYPE html>
 <html lang="tr">

--- a/src/components/certificate/CertificateModal.tsx
+++ b/src/components/certificate/CertificateModal.tsx
@@ -66,12 +66,11 @@ export function CertificateModal({
 
     try {
       const iframe = document.createElement("iframe");
-      iframe.style.position = "fixed";
-      iframe.style.right = "0";
-      iframe.style.bottom = "0";
-      iframe.style.width = "0";
-      iframe.style.height = "0";
-      iframe.style.border = "none";
+      // #235: 0x0 iframe kullanma. Tarayicilarin bir kismi sifir boyutlu
+      // iframe'in icerigine layout uygulamaz ve print() bos sayfa uretir.
+      // Gercek A4 olcusu verip cerceveyi ekranin disina aliyoruz.
+      iframe.style.cssText =
+        "position:fixed;left:-10000px;top:0;width:210mm;height:297mm;border:0;";
       iframe.setAttribute("aria-hidden", "true");
       document.body.appendChild(iframe);
 
@@ -129,13 +128,46 @@ export function CertificateModal({
       `);
       doc.close();
 
-      iframe.contentWindow?.focus();
-      setTimeout(() => {
-        iframe.contentWindow?.print();
-        setTimeout(() => {
-          document.body.removeChild(iframe);
-        }, 1000);
-      }, 250);
+      const win = iframe.contentWindow;
+      if (!win) {
+        iframe.remove();
+        window.print();
+        return;
+      }
+
+      const temizle = () => iframe.remove();
+
+      const yazdir = async () => {
+        // #235: Temizligi EN BASTA kaydet. Asagidaki bekleme ne olursa olsun
+        // (fonts API takilsa, hata atsa) cerceve DOM'da unutulmaz.
+        // iframe 1sn sonra degil, yazdirma bitince kaldirilir — diyalog
+        // acikken DOM'dan cikarilirsa cikti bozulur.
+        win.addEventListener("afterprint", temizle, { once: true });
+        // afterprint her tarayicida tetiklenmiyor → guvenlik agi
+        setTimeout(temizle, 120_000);
+
+        // #235: Sabit 250ms gecikme yerine gercek hazir olma sinyali.
+        // Kopyalanan <link rel=stylesheet> ve yazi tipleri inmeden print()
+        // cagrilirsa cikti bicimsiz ya da bos olur. Bekleme SINIRLI: yazi
+        // tipleri hic gelmezse yazdirmayi sonsuza kadar engellemesin.
+        try {
+          await Promise.race([
+            doc.fonts?.ready ?? Promise.resolve(),
+            new Promise((r) => setTimeout(r, 2_000)),
+          ]);
+        } catch {
+          // fonts API yoksa/basarisizsa yazdirmaya yine de devam et
+        }
+
+        win.focus();
+        win.print();
+      };
+
+      if (doc.readyState === "complete") {
+        void yazdir();
+      } else {
+        win.addEventListener("load", () => void yazdir(), { once: true });
+      }
     } catch (e) {
       console.error("Print error:", e);
       window.print();


### PR DESCRIPTION
Mezuniyet sertifikasinda **PDF / Yazdir** dugmesi cikti uretmiyordu.

## Uc kusur, uc ayri sebep

`handlePrint` izole bir iframe kurup `document.write` ile sertifikayi basiyor. Her biri tek basina bos/bozuk cikti uretebilecek uc sorun vardi:

| # | Sorun | Duzeltme |
|---|---|---|
| 1 | **0x0 iframe** — bazi tarayicilar sifir boyutlu cerceveye layout uygulamaz, `print()` bos sayfa uretir | Gercek A4 olcusu (210mm x 297mm), ekran disina konumlandi |
| 2 | **Sabit 250ms bekleme** — kopyalanan `<link rel=stylesheet>` ve yazi tipleri inmeden yazdirilabiliyordu | `load` + `fonts.ready` bekleniyor, **ust sinir 2sn** |
| 3 | **1sn sonra iframe siliniyordu** — diyalog acikken DOM'dan cikarsa cikti bozulur | `afterprint` olayinda kaldiriliyor, 120sn guvenlik agi |

Bekleme sinirini bilerek koydum: `fonts.ready` hic cozulmezse yazdirma sonsuza kadar engellenmemeli. Ayrica temizlik kaydi beklemeden **once** yapiliyor — bekleme takilsa bile cerceve DOM'da unutulmuyor.

## Testler
Bu bilesenin ilk test dosyasi; 6 test. **Ucu de mutasyonla dogrulandi:**

| Geri alinan kusur | Kirmiziya donen |
|---|---|
| 0x0 iframe | 2 test |
| 1sn'de silme | 1 test |
| Sinirsiz fonts beklemesi | 1 test |

Ayrica testler arasi temizlik eklendi: yazdirma cerceveleri React agacinin disinda `body`'ye eklendigi icin `cleanup()` onlari sokmuyor, kalintilar sonraki testi kirletiyordu.

## Dogrulanmasi gereken
Hatayi **uctan uca yeniden uretemedim**: Docker Desktop kapali, veritabaninda mezun hesabi/sertifika verisi yok. Duzeltmeler kod incelemesine dayaniyor. Mezun bir hesapla gercek tarayicida denenmeli — ozellikle ciktinin stilleriyle geldigi.

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)