### PR TITLE
chore: create:admin ve seed komutlari .env yuklesin

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "check:migrations": "node scripts/check-migrations.mjs",
-    "seed": "tsx scripts/seed.ts",
-    "create:admin": "tsx scripts/create-admin.ts",
+    "seed": "tsx --env-file-if-exists=.env scripts/seed.ts",
+    "create:admin": "tsx --env-file-if-exists=.env scripts/create-admin.ts",
     "test:ai": "tsx --env-file=.env scripts/test-ai.ts"
   },
   "dependencies": {

--- a/scripts/create-admin.ts
+++ b/scripts/create-admin.ts
@@ -5,11 +5,17 @@
  * Gerçek yönetici hesabını bu script ile oluştur. Kimlik bilgileri ORTAM
  * DEĞİŞKENİNDEN okunur — repoya hardcode EDİLMEZ, parola loglanmaz.
  *
- * Kullanım (dev makineden prod DB'ye, SSL ile):
+ * Kullanım — LOKAL (.env'deki DATABASE_URL kullanılır):
+ *   ADMIN_EMAIL="admin@posinowa.com" ADMIN_PASSWORD="<parola>" npm run create:admin
+ *
+ * Kullanım — dev makineden PROD DB'ye (SSL ile), .env'e dokunmadan:
  *   DATABASE_URL="postgresql://user:pass@host:5432/db?sslmode=require" \
  *   ADMIN_EMAIL="admin@posinowa.com" \
  *   ADMIN_PASSWORD="<güçlü-parola>" \
  *   npx tsx scripts/create-admin.ts
+ *
+ * Not: npm script'i `--env-file-if-exists=.env` kullanır; .env yoksa çökmez,
+ * ortamda tanımlı değişkenlerle devam eder.
  *
  * Idempotent: aynı e-posta ile tekrar çalıştırılırsa parolayı günceller
  * (ADMIN rolüne + APPROVED durumuna çeker). Şifre sıfırlama için de kullanılabilir.


### PR DESCRIPTION
`npm run create:admin` ve `npm run seed` `.env` dosyasini yuklemiyordu; `DATABASE_URL` tanimsiz kaldigi icin Prisma veritabanina ulasamiyordu. Dokumandaki haliyle calistiran herkes ayni duvara tosluyor.

`test:ai` komutu zaten `--env-file=.env` kullaniyordu — tutarsizlik.

## Neden duz `--env-file` degil
`node --env-file=.env` dosya **yoksa hata firlatip cikiyor**. Prod'da degiskenler dogrudan ortamdan gelebilir; o durumda komut kirilirdi. `--env-file-if-exists` her iki durumda da calisir.

## Guvenlik kontrolu
Degisiklik otomatik bir yolu etkilemiyor:
- `docker-entrypoint.sh` bu komutlari **calistirmiyor** ("db push/seed DEGIL" notu var)
- CI de calistirmiyor (lint / typecheck / build)

Yalnizca elle kullanilan komutlar.

## Elle test edildi
| Durum | Sonuc |
|---|---|
| `.env` varken | degiskenler yukleniyor |
| `.env` gecici olarak kaldirilinca | komut **cokmuyor**, kendi dogrulama mesajini veriyor |

## Ek
`create-admin.ts` icindeki kullanim aciklamasinda yalnizca prod ornegi vardi; lokal kullanim ornegi eklendi.

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)